### PR TITLE
Fix build error on Ubuntu 13.04.

### DIFF
--- a/src/gddccontrol/Makefile.am
+++ b/src/gddccontrol/Makefile.am
@@ -7,7 +7,7 @@ LDADD = ../lib/libddccontrol.la
 
 bin_PROGRAMS = gddccontrol
 gddccontrol_SOURCES = main.c notebook.c notebook.h gprofile.c fspatterns.c
-gddccontrol_LDFLAGS = $(GNOME_LDFLAGS)
+gddccontrol_LDFLAGS = $(GNOME_LDFLAGS) -lm
 AM_CFLAGS = $(GNOME_CFLAGS)
 
 


### PR DESCRIPTION
When application build on Ubuntu 13.04 in usual way:
./autogen
./confugure
make
appears error:
/usr/bin/ld: notebook.o: undefined reference to symbol 'round@@GLIBC_2.2.5' .

Error was reproduced on three different machines.

This pull request try to fix this error (may be not the best way).

P.S.
There are no problems on openSUSE 12.3.
