### PR TITLE
Port ddccontrol to FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,13 @@ AC_ARG_ENABLE(i2cdev,
 
 if test "x$support_i2c_dev" = "xyes" ; then
 	AC_DEFINE_UNQUOTED(HAVE_I2C_DEV, 1, [Define if ddccontrol is built with /dev/i2c-* support.])
-	AC_CHECK_HEADERS([linux/types.h], [], [AC_MSG_ERROR([Linux kernel header files not found, please install them.], [1])], [])
+
+	AC_CANONICAL_HOST
+	case $host_os in
+		linux*)
+		AC_CHECK_HEADERS([linux/types.h], [], [AC_MSG_ERROR([Linux kernel header files not found, please install them.], [1])], [])
+		;;
+	esac
 
 	support_i2c_dev_works=no
 	AC_MSG_CHECKING([if linux/i2c-dev.h works with non-kernel linux/types.h])

--- a/src/ddccontrol/Makefile.am
+++ b/src/ddccontrol/Makefile.am
@@ -5,5 +5,5 @@ LDADD = ../lib/libddccontrol.la
 
 bin_PROGRAMS = ddccontrol
 ddccontrol_SOURCES = main.c
-ddccontrol_LDFLAGS = $(LIBXML2_LDFLAGS)
+ddccontrol_LDFLAGS = $(LIBXML2_LDFLAGS) $(LIBINTL)
 AM_CFLAGS = $(LIBXML2_CFLAGS)

--- a/src/lib/ddcci.c
+++ b/src/lib/ddcci.c
@@ -297,7 +297,7 @@ static int i2c_write(struct monitor* mon, unsigned int addr, unsigned char *buf,
 		}
 
 #ifdef __FreeBSD__
-		i = 1; // FreeBSD ioctl() returns 0
+		i = len; // FreeBSD ioctl() returns 0
 #endif
 
 		return i;
@@ -386,7 +386,7 @@ static int i2c_read(struct monitor* mon, unsigned int addr, unsigned char *buf, 
 		}
 
 #ifdef __FreeBSD__
-		i = 1; // FreeBSD ioctl() returns 0
+		i = len; // FreeBSD ioctl() returns 0
 #endif
 
 		return i;

--- a/src/lib/ddcci.c
+++ b/src/lib/ddcci.c
@@ -274,7 +274,11 @@ static int i2c_write(struct monitor* mon, unsigned int addr, unsigned char *buf,
 		msg_rdwr.msgs = &i2cmsg;
 		msg_rdwr.nmsgs = 1;
 	
+#ifdef __FreeBSD__
+		i2cmsg.slave = addr << 1;
+#else
 		i2cmsg.addr  = addr;
+#endif
 		i2cmsg.flags = 0;
 		i2cmsg.len   = len;
 		i2cmsg.buf   = buf;
@@ -291,6 +295,10 @@ static int i2c_write(struct monitor* mon, unsigned int addr, unsigned char *buf,
 		if (verbosity > 1) {
 			dumphex(stderr, "Send", buf, len);
 		}
+
+#ifdef __FreeBSD__
+		i = 1; // FreeBSD ioctl() returns 0
+#endif
 
 		return i;
 	}
@@ -355,7 +363,11 @@ static int i2c_read(struct monitor* mon, unsigned int addr, unsigned char *buf, 
 		msg_rdwr.msgs = &i2cmsg;
 		msg_rdwr.nmsgs = 1;
 	
+#ifdef __FreeBSD__
+		i2cmsg.slave = addr << 1;
+#else
 		i2cmsg.addr  = addr;
+#endif
 		i2cmsg.flags = I2C_M_RD;
 		i2cmsg.len   = len;
 		i2cmsg.buf   = buf;
@@ -372,6 +384,10 @@ static int i2c_read(struct monitor* mon, unsigned int addr, unsigned char *buf, 
 		if (verbosity > 1) {
 			dumphex(stderr, "Recv", buf, i);
 		}
+
+#ifdef __FreeBSD__
+		i = 1; // FreeBSD ioctl() returns 0
+#endif
 
 		return i;
 	}

--- a/src/lib/ddcci.c
+++ b/src/lib/ddcci.c
@@ -1201,9 +1201,15 @@ struct monitorlist* ddcci_probe() {
 	
 	dirp = opendir("/dev/");
 	
+#ifdef __FreeBSD__
+	const char *prefix = "iic";
+#else
+	const char *prefix = "i2c-";
+#endif
+	int prefix_len = strlen(prefix);
 	while ((direntp = readdir(dirp)) != NULL)
 	{
-		if (!strncmp(direntp->d_name, "i2c-", 4))
+		if (!strncmp(direntp->d_name, prefix, prefix_len))
 		{
 			filename = malloc(strlen(direntp->d_name)+12);
 			

--- a/src/lib/i2c-dev.h
+++ b/src/lib/i2c-dev.h
@@ -24,6 +24,18 @@
 /* If linux/i2c-dev.h is usable, use it, otherwise, define
  * the required constants and structures. */
 
+#ifdef __FreeBSD__
+
+#include <sys/types.h>
+#include <dev/iicbus/iic.h>
+
+#define I2C_M_RD   IIC_M_RD
+#define I2C_RDWR   I2CRDWR
+
+#define i2c_msg iic_msg
+#define i2c_rdwr_ioctl_data iic_rdwr_data
+
+#else
 #if HAVE_BUGGY_I2C_DEV
 #include <linux/types.h>
 
@@ -57,5 +69,6 @@ struct i2c_rdwr_ioctl_data {
 #include <linux/i2c-dev.h>
 
 #endif
+#endif // __FreeBSD__
 
 #endif //DDCCONTROL_I2C_DEV_H


### PR DESCRIPTION
This patch allows building and using ddccontrol / gddccontrol on FreeBSD.
ddcpci is not ported yet. It should be disabled during configure for FreeBSD.
Tested on FreeBSD 12-CURRENT with a Dell monitor using an Intel integrated graphics card with i915kms kernel driver. I2C device with this monitor appears as /dev/iic2.

The I2CRDWR ioctl() on FreeBSD was designed to be Linux compatible. However, there are some small differences, including the slave address and the return value.