### PR TITLE
do not blink warning message, closes #24

### DIFF
--- a/src/ddccontrol/main.c
+++ b/src/ddccontrol/main.c
@@ -352,7 +352,7 @@ int main(int argc, char **argv)
 		
 		if (mon.fallback) {
 			/* Put a big warning (in red if we are writing to a terminal). */
-			printf("%s%s\n", isatty(1) ? "\x1B[5;31m" : "", _("=============================== WARNING ==============================="));
+			printf("%s%s\n", isatty(1) ? "\x1B[0;31m" : "", _("=============================== WARNING ==============================="));
 			if (mon.fallback == 1) {
 				printf(_(
 					"There is no support for your monitor in the database, but ddccontrol is\n"


### PR DESCRIPTION
The WARNING message about lack of support in the database had extra
flags on top of "red": it would blink on certain terminals (like
rxvt-unicode). This would make the message really hard to read, which
is probably not the intention.

This simply removes the blinking setting from the terminal escape codes.