### PR TITLE
Use D-Bus daemon in `gddccontrol`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - systemd service to launch daemon
 
 ### Changed
-- show warning message without blinking
+- ddccontrol shows warning message without blinking
+- gddccontrol uses D-Bus daemon to access HW devices
 - install binary ddcpci to pkglibexec directory (it's not run by users)
 - fixed build with custom CFLAGS
 - fixed configure.ac to use `$PKGCONFIG` set by `PKG_PROG_PKG_CONFIG` macro

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = lib ddccontrol daemon $(GNOME_APPLET) $(GDDCCONTROL) $(DDCPCI)
+SUBDIRS = lib daemon ddccontrol $(GNOME_APPLET) $(GDDCCONTROL) $(DDCPCI)

--- a/src/daemon/Makefile.am
+++ b/src/daemon/Makefile.am
@@ -2,7 +2,6 @@ SUBDIRS = data
 
 AM_CFLAGS = $(LIBXML2_CFLAGS)
 AM_CPPFLAGS = -I$(top_srcdir)/src/lib
-LDADD = ../lib/libddccontrol.la
 
 # install D-Bus API specification for ddccontrol.DDCControl.xml interface
 dbusinterfacesdir = $(datadir)/dbus-1/interfaces
@@ -11,8 +10,20 @@ dist_dbusinterfaces_DATA = ddccontrol.DDCControl.xml
 # install to pkglibexec, because it's not intended to be run by user
 pkglibexec_PROGRAMS = ddccontrol_service
 
-ddccontrol_service_SOURCES = interface.h interface.c service.c
+ddccontrol_service_SOURCES = service.c
 ddccontrol_service_LDFLAGS = $(LIBXML2_LDFLAGS) $(LIBINTL)
+ddccontrol_service_LDADD   = libdbusinterface.la ../lib/libddccontrol.la
+
+# D-Bus client library
+lib_LTLIBRARIES = libddccontrol_dbus_client.la
+
+libddccontrol_dbus_client_la_SOURCES = dbus_client.c
+libddccontrol_dbus_client_la_LDFLAGS = $(LIBXML2_LDFLAGS)
+libddccontrol_dbus_client_la_LIBADD   = libdbusinterface.la
+
+# interface library
+noinst_LTLIBRARIES = libdbusinterface.la
+libdbusinterface_la_SOURCES = interface.c interface.h
 
 BUILT_SOURCES = interface.h interface.c
 noinst_HEADERS = $(BUILT_SOURCES)

--- a/src/daemon/dbus_client.c
+++ b/src/daemon/dbus_client.c
@@ -1,0 +1,171 @@
+/*
+    ddc/ci D-Bus client library implementation
+
+    Copyright(c) 2018 Miroslav Kravec (kravec.miroslav@gmail.com)
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#include "dbus_client.h"
+
+#include "internal.h"
+#include "interface.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int ddcci_dbus_open(DDCControl *proxy, struct monitor* mon, const char* filename) {
+    char *pnpid = NULL;
+    GError *error = NULL;
+
+    memset(mon, 0, sizeof(struct monitor));
+
+    gboolean result = ddccontrol_call_open_monitor_sync(proxy, filename, &pnpid, &mon->caps.raw_caps, NULL, &error);
+    if(result == FALSE) {
+        fprintf(stderr, _("Open monitor failed: %s\n."), error->message);
+        return -1;
+    }
+
+    strncpy(&mon->pnpid, pnpid, 7);
+    mon->pnpid[7] = 0;
+
+    ddcci_parse_caps(mon->caps.raw_caps, &mon->caps, 1);
+
+    // TODO: duplicated from ddcci.c
+    // DUPLICATED CODE START
+    mon->db = ddcci_create_db(mon->pnpid, &mon->caps, 1);
+    mon->fallback = 0; /* No fallback */
+
+    if (!mon->db) {
+        /* Fallback on manufacturer generic profile */
+        char buffer[7];
+        buffer[0] = 0;
+        strncat(buffer, mon->pnpid, 3); /* copy manufacturer id */
+        switch(mon->caps.type) {
+        case lcd:
+            strcat(buffer, "lcd");
+            mon->db = ddcci_create_db(buffer, &mon->caps, 1);
+            mon->fallback = 1;
+            break;
+        case crt:
+            strcat(buffer, "crt");
+            mon->db = ddcci_create_db(buffer, &mon->caps, 1);
+            mon->fallback = 1;
+            break;
+        case unk:
+            break;
+        }
+
+        if (!mon->db) {
+            /* Fallback on VESA generic profile */
+            mon->db = ddcci_create_db("VESA", &mon->caps, 1);
+            mon->fallback = 2;
+        }
+    }
+    // DUPLICATED CODE END
+    return 0;
+}
+
+int ddcci_dbus_readctrl(DDCControl *proxy, char *fn,
+        unsigned char ctrl, unsigned short *value, unsigned short *maximum)
+{
+    int result;
+    GError *error = NULL;
+
+    gboolean call_result = ddccontrol_call_get_control_sync(proxy, fn, ctrl, &result, value, maximum, NULL, &error);
+
+    if(call_result == TRUE) {
+        return result;
+    } else {
+        fprintf(stderr, _("Control 0x%02x D-Bus read failed: %s\n."), ctrl, error->message);
+        return -10;
+    }
+}
+
+int ddcci_dbus_writectrl(DDCControl *proxy, char *fn,
+        unsigned char ctrl, unsigned short value)
+{
+    GError *error = NULL;
+
+    gboolean call_result = ddccontrol_call_set_control_sync(proxy, fn, ctrl, value, NULL, &error);
+
+    if(call_result == TRUE) {
+        // original write result
+        return 0;
+    } else {
+        fprintf(stderr, _("Control 0x%02x D-Bus write failed: %s\n."), ctrl, error->message);
+        return -10;
+    }
+}
+
+struct monitorlist * ddcci_dbus_rescan_monitors(DDCControl *proxy) {
+    int i;
+    struct monitorlist *monlist = NULL, *current = NULL;
+    
+    char **devices = NULL, **names = NULL;
+    char *supported = NULL, *digital = NULL;
+
+    GError *error = NULL;
+    GVariant *v_supported, *v_digital;
+    size_t supported_n, digital_n;
+
+    gboolean result = ddccontrol_call_rescan_monitors_sync(proxy, &devices, &v_supported, &names, &v_digital, NULL, &error);
+
+    if(result == FALSE) {
+        // TODO: better error output
+        fprintf(stderr, _("Probe failed: %s\n."), error->message);
+        return NULL;
+    }
+
+    supported = g_variant_get_fixed_array(v_supported, &supported_n, sizeof(char));
+    digital = g_variant_get_fixed_array(v_digital, &digital_n, sizeof(char));
+
+    for(i = 0; devices[i] != NULL && i < supported_n; i++) {
+        if(current == NULL) {
+            monlist = current = malloc(sizeof(struct monitorlist));
+        } else {
+            current->next = malloc(sizeof(struct monitorlist));
+            current = current->next;
+        }
+        current->filename = devices[i];
+        current->supported = supported[i];
+        current->name = names[i];
+        current->digital = digital[i];
+    }
+    if(current != NULL)
+        current->next = NULL;
+    return monlist;
+}
+
+DDCControl* ddcci_dbus_open_proxy() {
+    GError *error = NULL;
+ 
+    DDCControl *proxy = ddccontrol_proxy_new_for_bus_sync(
+            G_BUS_TYPE_SYSTEM,
+            G_DBUS_PROXY_FLAGS_NONE,
+            "ddccontrol.DDCControl",
+            "/ddccontrol/DDCControl",
+            NULL,
+            &error
+    );
+
+    if( error != NULL ) {
+        fprintf(stderr, _("D-Bus connection failed with error: %s.\n"), error->message);
+        return NULL;
+    }
+
+    return proxy;
+}

--- a/src/daemon/dbus_client.h
+++ b/src/daemon/dbus_client.h
@@ -29,7 +29,7 @@ DDCControl* ddcci_dbus_open_proxy();
 
 struct monitorlist* ddcci_dbus_rescan_monitors(DDCControl *proxy);
 
-int ddcci_dbus_open(DDCControl *proxy, struct monitor* mon, const char* filename);
+int ddcci_dbus_open(DDCControl *proxy, struct monitor **mon, const char* filename);
 int ddcci_dbus_readctrl(DDCControl *proxy, char *fn,
         unsigned char ctrl, unsigned short *value, unsigned short *maximum);
 int ddcci_dbus_writectrl(DDCControl *proxy, char *fn,

--- a/src/daemon/dbus_client.h
+++ b/src/daemon/dbus_client.h
@@ -1,0 +1,39 @@
+/*
+    ddc/ci D-Bus client library headers
+
+    Copyright(c) 2018 Miroslav Kravec (kravec.miroslav@gmail.com)
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+*/
+
+#ifndef DDCCONTROL_DBUS_CLIENT_H
+#define DDCCONTROL_DBUS_CLIENT_H
+
+#include "ddcci.h"
+
+typedef struct _DDCControl DDCControl;
+
+DDCControl* ddcci_dbus_open_proxy();
+
+struct monitorlist* ddcci_dbus_rescan_monitors(DDCControl *proxy);
+
+int ddcci_dbus_open(DDCControl *proxy, struct monitor* mon, const char* filename);
+int ddcci_dbus_readctrl(DDCControl *proxy, char *fn,
+        unsigned char ctrl, unsigned short *value, unsigned short *maximum);
+int ddcci_dbus_writectrl(DDCControl *proxy, char *fn,
+        unsigned char ctrl, unsigned short value);
+
+
+#endif // DDCCONTROL_DBUS_CLIENT_H

--- a/src/ddccontrol/Makefile.am
+++ b/src/ddccontrol/Makefile.am
@@ -1,18 +1,10 @@
 localedir = $(datadir)/locale
 AM_CPPFLAGS = -I$(top_srcdir)/src/lib -DLOCALEDIR=\"$(localedir)\"
 
-LDADD = ../lib/libddccontrol.la
+LDADD = ../lib/libddccontrol.la ../daemon/libddccontrol_dbus_client.la
 
 bin_PROGRAMS = ddccontrol
-ddccontrol_SOURCES = main.c dbus_client.c printing.c dbus_interface.h dbus_interface.c
+ddccontrol_SOURCES = main.c dbus_client.c printing.c
 ddccontrol_LDFLAGS = $(LIBXML2_LDFLAGS) $(LIBINTL)
 AM_CFLAGS = $(LIBXML2_CFLAGS)
 
-BUILT_SOURCES = dbus_interface.h dbus_interface.c
-noinst_HEADERS = $(BUILT_SOURCES)
-CLEANFILES = $(BUILT_SOURCES)
-
-main.c: dbus_interface.h dbus_interface.c
-
-dbus_interface.h dbus_interface.c: ../daemon/ddccontrol.DDCControl.xml
-	gdbus-codegen --interface-prefix ddccontrol --generate-c-code dbus_interface $<

--- a/src/ddccontrol/dbus_client.c
+++ b/src/ddccontrol/dbus_client.c
@@ -33,7 +33,7 @@
 static void dumpctrl(DDCControl *proxy, char *fn, struct monitor* mon, unsigned char ctrl, int force)
 {
 	unsigned short value, maximum;
-	int result = ddcci_dbus_readctrl(proxy, fn, ctrl, &value, &maximum);
+	int result = ddcci_readctrl(mon, ctrl, &value, &maximum);
 
 	if ((result > 0) || force) {
 		print_control_value(mon, ctrl, value, maximum, result);
@@ -87,26 +87,26 @@ int perform_using_dbus(char *fn, int dump, int caps, int probe, int ctrl, int va
 		}
 	}
 
-	struct monitor mon;
+	struct monitor *mon;
 	ddcci_dbus_open(proxy, &mon, fn);
 
 	if( ctrl >= 0 ) {
 		if( value == -1 ) {
 			fprintf(stdout, _("Reading 0x%02x...\n"), ctrl);
 		} else {
-			int result = ddcci_dbus_writectrl(proxy, fn, ctrl, value);
+			int result = ddcci_writectrl(mon, ctrl, value, 0 /* TODO */);
 			if(result < 0) {
 				printf(_("Write failed\n."));
 			}
 		}
-		dumpctrl(proxy, fn, &mon, ctrl, 1);
+		dumpctrl(proxy, fn, mon, ctrl, 1);
 	}
 
 	if (dump) {
 		fprintf(stdout, _("\nControls (valid/current/max) [Description - Value name]:\n"));
 
 		for (i = 0; i < 256; i++) {
-			dumpctrl(proxy, fn, &mon, i, force);
+			dumpctrl(proxy, fn, mon, i, force);
 		}
 	}
 	return 0;

--- a/src/ddccontrol/dbus_client.c
+++ b/src/ddccontrol/dbus_client.c
@@ -21,8 +21,10 @@
 
 #include "ddccontrol.h"
 
+#include "daemon/dbus_client.h"
+
+#include "ddcci.h"
 #include "internal.h"
-#include "dbus_interface.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -31,23 +33,15 @@
 static void dumpctrl(DDCControl *proxy, char *fn, struct monitor* mon, unsigned char ctrl, int force)
 {
 	unsigned short value, maximum;
-	int result;
-	GError *error = NULL;
+	int result = ddcci_dbus_readctrl(proxy, fn, ctrl, &value, &maximum);
 
-	gboolean call_result = ddccontrol_call_get_control_sync(proxy, fn, ctrl, &result, &value, &maximum, NULL, &error);
-
-	if(call_result == TRUE) {
-		if ((result > 0) || force) {
-			print_control_value(mon, ctrl, value, maximum, result);
-		}
-	} else {
-		fprintf(stderr, _("Control 0x%02x read failed: %s\n."), ctrl, error->message);
+	if ((result > 0) || force) {
+		print_control_value(mon, ctrl, value, maximum, result);
 	}
 }
 
 int perform_using_dbus(char *fn, int dump, int caps, int probe, int ctrl, int value, int force) {
 	int i;
-	gboolean result;
 
 	// TODO: custom datadir
 	if (!ddcci_init_db(NULL)) {
@@ -55,54 +49,32 @@ int perform_using_dbus(char *fn, int dump, int caps, int probe, int ctrl, int va
 		exit(1);
 	}
 
-	GError *error = NULL;
-	DDCControl *proxy = ddccontrol_proxy_new_for_bus_sync(
-			G_BUS_TYPE_SYSTEM,
-			G_DBUS_PROXY_FLAGS_NONE,
-			"ddccontrol.DDCControl",
-			"/ddccontrol/DDCControl",
-			NULL,
-			&error
-	);
-
-	if( error != NULL ) {
-		fprintf(stderr, _("D-Bus connection failed with error: %s.\n"), error->message);
+	DDCControl *proxy = ddcci_dbus_open_proxy();
+	if(proxy == NULL)
 		return -1;
-	}
 
 	if (probe) {
 		fn = NULL;
 
-		char **devices = NULL, **names = NULL;
-		char *supported = NULL, *digital = NULL;
-
-		GVariant *v_supported, *v_digital;
-		size_t supported_n, digital_n;
-
-		result = ddccontrol_call_rescan_monitors_sync(proxy, &devices, &v_supported, &names, &v_digital, NULL, &error);
-
-		printf(_("Detected monitors :\n"));
-		if(result == FALSE) {
-			fprintf(stderr, _("Probe failed: %s\n."), error->message);
-			return -1;
-		}
-
-		supported = g_variant_get_fixed_array(v_supported, &supported_n, sizeof(char));
-		digital = g_variant_get_fixed_array(v_digital, &digital_n, sizeof(char));
-
-
-		for(i = 0; devices[i] != NULL && i < supported_n; i++) {
-			printf(_(" - Device: %s\n"), devices[i]);
-			printf(_("   DDC/CI supported: %s\n"), supported[i] ? _("Yes") : _("No"));
-			printf(_("   Monitor Name: %s\n"), names[i]);
-			printf(_("   Input type: %s\n"), digital[i] ? _("Digital") : _("Analog"));
-
-			if ((!fn) && (supported[i]))
+		struct monitorlist *monlist, *current;
+		
+		monlist = ddcci_dbus_rescan_monitors(proxy);
+		current = monlist;
+		while (current != NULL)
+		{
+			printf(_(" - Device: %s\n"), current->filename);
+			printf(_("   DDC/CI supported: %s\n"), current->supported ? _("Yes") : _("No"));
+			printf(_("   Monitor Name: %s\n"), current->name);
+			printf(_("   Input type: %s\n"), current->digital ? _("Digital") : _("Analog"));
+			
+			if ((!fn) && (current->supported))
 			{
 				printf(_("   (Automatically selected)\n"));
-				fn = malloc(strlen(devices[i])+1);
-				strcpy(fn, devices[i]);
+				fn = malloc(strlen(current->filename)+1);
+				strcpy(fn, current->filename);
 			}
+			
+			current = current->next;
 		}
 
 		if (fn == NULL) {
@@ -110,64 +82,20 @@ int perform_using_dbus(char *fn, int dump, int caps, int probe, int ctrl, int va
 				"No monitor supporting DDC/CI available.\n"
 				"If your graphics card need it, please check all the required kernel modules are loaded (i2c-dev, and your framebuffer driver).\n"
 				));
+			ddcci_release();
 			exit(0);
 		}
 	}
 
 	struct monitor mon;
-	char *pnpid = NULL;
-
-	result = ddccontrol_call_open_monitor_sync(proxy, fn, &pnpid, &mon.caps.raw_caps, NULL, &error);
-	if(result == FALSE) {
-		fprintf(stderr, _("Open monitor failed: %s\n."), error->message);
-		return -1;
-	}
-
-	strncpy(&mon.pnpid, pnpid, 7);
-	mon.pnpid[8] = 0;
-
-	ddcci_parse_caps(mon.caps.raw_caps, &mon.caps, 1);
-
-	// TODO: duplicated from ddcci.c
-	// DUPLICATED CODE START
-	mon.db = ddcci_create_db(mon.pnpid, &mon.caps, 1);
-	mon.fallback = 0; /* No fallback */
-
-	if (!mon.db) {
-		/* Fallback on manufacturer generic profile */
-		char buffer[7];
-		buffer[0] = 0;
-		strncat(buffer, mon.pnpid, 3); /* copy manufacturer id */
-		switch(mon.caps.type) {
-		case lcd:
-			strcat(buffer, "lcd");
-			mon.db = ddcci_create_db(buffer, &mon.caps, 1);
-			mon.fallback = 1;
-			break;
-		case crt:
-			strcat(buffer, "crt");
-			mon.db = ddcci_create_db(buffer, &mon.caps, 1);
-			mon.fallback = 1;
-			break;
-		case unk:
-			break;
-		}
-
-		if (!mon.db) {
-			/* Fallback on VESA generic profile */
-			mon.db = ddcci_create_db("VESA", &mon.caps, 1);
-			mon.fallback = 2;
-		}
-	}
-	// DUPLICATED CODE END
-
+	ddcci_dbus_open(proxy, &mon, fn);
 
 	if( ctrl >= 0 ) {
 		if( value == -1 ) {
 			fprintf(stdout, _("Reading 0x%02x...\n"), ctrl);
 		} else {
-			result = ddccontrol_call_set_control_sync(proxy, fn, ctrl, value, NULL, &error);
-			if(result == FALSE) {
+			int result = ddcci_dbus_writectrl(proxy, fn, ctrl, value);
+			if(result < 0) {
 				printf(_("Write failed\n."));
 			}
 		}

--- a/src/gddccontrol/Makefile.am
+++ b/src/gddccontrol/Makefile.am
@@ -3,11 +3,10 @@ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_srcdir)/src -DLOCALEDIR=\"$(locale
 
 EXTRA_DIST = gddccontrol.desktop.in gddccontrol.png gddccontrol-bluecurve.png
 
-LDADD = ../lib/libddccontrol.la
-
 bin_PROGRAMS = gddccontrol
 gddccontrol_SOURCES = main.c notebook.c notebook.h gprofile.c fspatterns.c
 gddccontrol_LDFLAGS = $(GNOME_LDFLAGS) -lm
+gddccontrol_LDADD = ../daemon/libddccontrol_dbus_client.la ../lib/libddccontrol.la
 AM_CFLAGS = $(GNOME_CFLAGS)
 
 

--- a/src/lib/ddcci.c
+++ b/src/lib/ddcci.c
@@ -558,6 +558,10 @@ static int ddcci_read(struct monitor* mon, unsigned char *buf, unsigned char len
 /* write value to register ctrl of ddc/ci at address addr */
 int ddcci_writectrl(struct monitor* mon, unsigned char ctrl, unsigned short value, int delay)
 {
+	if(mon->__vtable) {
+		return mon->__vtable->writectrl(mon, ctrl, value, delay);
+	}
+
 	unsigned char buf[4];
 
 	buf[0] = DDCCI_COMMAND_WRITE;
@@ -599,6 +603,10 @@ static int ddcci_raw_readctrl(struct monitor* mon,
 int ddcci_readctrl(struct monitor* mon, unsigned char ctrl, 
 	unsigned short *value, unsigned short *maximum)
 {
+	if(mon->__vtable) {
+		return mon->__vtable->readctrl(mon, ctrl, value, maximum);
+	}
+
 	unsigned char buf[8];
 
 	int len = ddcci_raw_readctrl(mon, ctrl, buf, sizeof(buf));
@@ -1059,6 +1067,12 @@ int ddcci_save(struct monitor* mon)
 */
 int ddcci_close(struct monitor* mon)
 {
+	// TODO: closing and freeing are different operations, split the function!
+
+	if(mon->__vtable) {
+		return mon->__vtable->close(mon);
+	}
+
 	if (mon->db)
 	{
 		if (mon->db->init == samsung) {

--- a/src/lib/ddcci.h
+++ b/src/lib/ddcci.h
@@ -48,6 +48,8 @@ struct caps {
 #include "monitor_db.h"
 
 struct monitor {
+	const struct monitor_vtable *__vtable;
+
 	int fd;
 	unsigned int addr;
 	int adl_adapter, adl_display;

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -32,4 +32,10 @@
 #define N_(String) String
 #endif
 
+struct monitor_vtable {
+	int (*readctrl)(struct monitor* mon, unsigned char ctrl, unsigned short *value, unsigned short *maximum);
+	int (*writectrl)(struct monitor* mon, unsigned char ctrl, unsigned short value, int delay);
+	int (*close)(struct monitor* mon);
+};
+
 #endif //DDCCI_INTERNAL_H


### PR DESCRIPTION
Changes made to implement feature:

* created shared internal `dbus_client` library, and modified `libddccontrol` library to support polymorphism on `struct monitor` (`read/write ctrl`, and `close`)
* refactored `ddccontrol` and `gddccontrol` to use `dbus_client` library