### PR TITLE
Added CLI arg. `-W` to relatively change ctrl value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - D-Bus client execution mode to ddccontrol (default mode, if available)
 - systemd service to launch daemon
 - ddccontrol CLI argument `-l` to load profiles created in GUI
+- ddccontrol CLI arg. `-W` to relatively change ctrl value
 
 ### Changed
 - ddccontrol shows warning message without blinking


### PR DESCRIPTION
New option to increase/decrease a value without having to parse the cluttered output of ddccontrol. Simply bind it to a keyboard shortcut for notebook-like experience.

I was contemplating on just making a flag for the already existing `-w` command, but this looks better IMO.

**Lower value:**
`ddccontrol -r 0x10 -W -5 dev:/dev/i2c-1`
**Increase value:**
`ddccontrol -r 0x10 -W 5 dev:/dev/i2c-1`