### PR TITLE
Added src folder to include reference paths

### DIFF
--- a/src/ddccontrol/Makefile.am
+++ b/src/ddccontrol/Makefile.am
@@ -1,5 +1,5 @@
 localedir = $(datadir)/locale
-AM_CPPFLAGS = -I$(top_srcdir)/src/lib -DLOCALEDIR=\"$(localedir)\"
+AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/src/lib -DLOCALEDIR=\"$(localedir)\"
 
 LDADD = ../lib/libddccontrol.la ../daemon/libddccontrol_dbus_client.la
 


### PR DESCRIPTION
Fixes building in separate build folder, daemon/dbus_client.h was referenced in main.c directly.