### PR TITLE
patches: module load, missing link, ditch xml2-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,17 +88,7 @@ CFLAGS="$CFLAGS -Wall  -DDATADIR=\"\\\"${datadir}/ddccontrol-db\\\"\" -DBINDIR=\
 AC_SEARCH_LIBS([round],[m])
 
 # libxml2 check
-
-AC_PATH_PROG(XML2_CONFIG, xml2-config, no)
-if test "x$XML2_CONFIG" = "xno" ; then
-   AC_MSG_ERROR([xml2-config not found, please install libxml2, available at http://www.xmlsoft.org/.], [1])
-fi
-
-LIBXML2_LDFLAGS="`xml2-config --libs`"
-LIBXML2_CFLAGS="`xml2-config --cflags`"
-
-AC_SUBST([LIBXML2_LDFLAGS])
-AC_SUBST([LIBXML2_CFLAGS])
+PKG_CHECK_MODULES([LIBXML2], [libxml-2.0])
 
 # Direct PCI memory access check
 support_ddcpci=yes
@@ -174,7 +164,7 @@ if test x$support_gnome = xyes; then
 
    echo -n "checking for gtk+>=2.4 and gthread>=2.4... "
    if $PKG_CONFIG --atleast-version=2.4 gtk+-2.0 gthread-2.0 ; then
-      GNOME_LDFLAGS="$LIBXML2_LDFLAGS `$PKG_CONFIG --libs gtk+-2.0 gthread-2.0`"
+      GNOME_LDFLAGS="$LIBXML2_LIBS `$PKG_CONFIG --libs gtk+-2.0 gthread-2.0`"
       GNOME_CFLAGS="$LIBXML2_CFLAGS `$PKG_CONFIG --cflags gtk+-2.0 gthread-2.0`"
       GDDCCONTROL=gddccontrol
       echo "yes"
@@ -200,7 +190,7 @@ GNOME_APPLET=
 if test x$support_gnome_applet = xyes; then
 	if $PKG_CONFIG --atleast-version=2.10 libpanelapplet-2.0 ; then
 		GNOME_APPLET="gnome-ddcc-applet"
-	    GNOME_LDFLAGS="$LIBXML2_LDFLAGS `$PKG_CONFIG --libs gtk+-2.0 gthread-2.0 libpanelapplet-2.0`"
+	    GNOME_LDFLAGS="$LIBXML2_LIBS `$PKG_CONFIG --libs gtk+-2.0 gthread-2.0 libpanelapplet-2.0`"
 	    GNOME_CFLAGS="$LIBXML2_CFLAGS `$PKG_CONFIG --cflags gtk+-2.0 gthread-2.0 libpanelapplet-2.0`"
 	fi
 fi

--- a/src/daemon/Makefile.am
+++ b/src/daemon/Makefile.am
@@ -19,7 +19,7 @@ lib_LTLIBRARIES = libddccontrol_dbus_client.la
 
 libddccontrol_dbus_client_la_SOURCES = dbus_client.c
 libddccontrol_dbus_client_la_LDFLAGS = $(LIBXML2_LDFLAGS)
-libddccontrol_dbus_client_la_LIBADD   = libdbusinterface.la
+libddccontrol_dbus_client_la_LIBADD   = libdbusinterface.la ../lib/libddccontrol.la
 
 # interface library
 noinst_LTLIBRARIES = libdbusinterface.la

--- a/src/daemon/Makefile.am
+++ b/src/daemon/Makefile.am
@@ -11,14 +11,14 @@ dist_dbusinterfaces_DATA = ddccontrol.DDCControl.xml
 pkglibexec_PROGRAMS = ddccontrol_service
 
 ddccontrol_service_SOURCES = service.c
-ddccontrol_service_LDFLAGS = $(LIBXML2_LDFLAGS) $(LIBINTL)
+ddccontrol_service_LDFLAGS = $(LIBXML2_LIBS) $(LIBINTL)
 ddccontrol_service_LDADD   = libdbusinterface.la ../lib/libddccontrol.la
 
 # D-Bus client library
 lib_LTLIBRARIES = libddccontrol_dbus_client.la
 
 libddccontrol_dbus_client_la_SOURCES = dbus_client.c
-libddccontrol_dbus_client_la_LDFLAGS = $(LIBXML2_LDFLAGS)
+libddccontrol_dbus_client_la_LDFLAGS = $(LIBXML2_LIBS)
 libddccontrol_dbus_client_la_LIBADD   = libdbusinterface.la ../lib/libddccontrol.la
 
 # interface library

--- a/src/ddccontrol/Makefile.am
+++ b/src/ddccontrol/Makefile.am
@@ -5,6 +5,6 @@ LDADD = ../lib/libddccontrol.la ../daemon/libddccontrol_dbus_client.la
 
 bin_PROGRAMS = ddccontrol
 ddccontrol_SOURCES = main.c printing.c
-ddccontrol_LDFLAGS = $(LIBXML2_LDFLAGS) $(LIBINTL)
+ddccontrol_LDFLAGS = $(LIBXML2_LIBS) $(LIBINTL)
 AM_CFLAGS = $(LIBXML2_CFLAGS)
 

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -9,6 +9,9 @@ pkgconfig_DATA = ddccontrol.pc
 
 $(pkgconfig_DATA): $(srcdir)/ddccontrol.pc.in $(top_builddir)/config.status
 
+modulesdir = /etc/modules-load.d/
+modules_DATA = ddccontrol-i2c-dev.conf
+
 lib_LTLIBRARIES = libddccontrol.la
 
 libddccontrol_la_SOURCES = ddcci.c ddcci.h monitor_db.c monitor_db.h \

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -17,4 +17,4 @@ lib_LTLIBRARIES = libddccontrol.la
 libddccontrol_la_SOURCES = ddcci.c ddcci.h monitor_db.c monitor_db.h \
    ddcpci-ipc.h i2c-dev.h conf.c conf.h amd_adl.c amd_adl.h internal.h
 
-libddccontrol_la_LIBADD = $(LIBXML2_LDFLAGS)
+libddccontrol_la_LIBADD = $(LIBXML2_LIBS)

--- a/src/lib/ddccontrol-i2c-dev.conf
+++ b/src/lib/ddccontrol-i2c-dev.conf
@@ -1,0 +1,2 @@
+# Load i2c-dev at boot to probe DDC/CI devices (displays)
+i2c-dev


### PR DESCRIPTION
This pull request has three minor patches, to fix three minor issues.

* load the appropriate i2c module at boot
* link one dynamic library into another to avoid missing symbol warnings
* use pkg-config instead of the soon-to-disappear-maybe xml2-config