### PR TITLE
src/lib/Makefile.am: Fix modulesdir

### DIFF
--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -9,7 +9,7 @@ pkgconfig_DATA = ddccontrol.pc
 
 $(pkgconfig_DATA): $(srcdir)/ddccontrol.pc.in $(top_builddir)/config.status
 
-modulesdir = /etc/modules-load.d/
+modulesdir = $(libdir)/modules-load.d/
 modules_DATA = ddccontrol-i2c-dev.conf
 
 lib_LTLIBRARIES = libddccontrol.la


### PR DESCRIPTION
Hardcoding `/etc` doesn't work if the user running `make install` is using a custom prefix and can't write to system directories.

I [am told](https://github.com/NixOS/nixpkgs/pull/148095#discussion_r762344236) that the standard install path for these files is `/usr/lib/modules-load.d/*.conf`. At least it is for [systemd (man 5 modules-load.d)](https://www.systutorials.com/docs/linux/man/5-modules-load.d/).

Cheers