### PR TITLE
fix: add missing return statement to dbus_monitor_close

### DIFF
--- a/src/daemon/dbus_client.c
+++ b/src/daemon/dbus_client.c
@@ -49,6 +49,7 @@ static int dbus_monitor_writectrl(struct monitor *mon, unsigned char ctrl, unsig
 static int dbus_monitor_close(struct monitor *mon)
 {
 	// TODO: think about architecture, maybe notify D-Bus daemon?
+	return 0;
 }
 
 static const struct monitor_vtable dbus_monitor_vtable = {


### PR DESCRIPTION
This avoids the following error during build:
```
dbus_client.c: In function 'dbus_monitor_close':
dbus_client.c:52:1: error: no return statement in function returning non-void [-Werror=return-type]
   52 | }
      | ^
```
