### PR TITLE
dbus: Set signal arg directions to "out"

### DIFF
--- a/src/daemon/ddccontrol.DDCControl.xml
+++ b/src/daemon/ddccontrol.DDCControl.xml
@@ -31,9 +31,9 @@
       <arg name="value"   type="u" direction="in"  />
     </method>
     <signal name="ControlChanged">
-      <arg name="device"  type="s" direction="in"  />
-      <arg name="control" type="u" direction="in"  />
-      <arg name="value"   type="u" direction="in"  />
+      <arg name="device"  type="s" direction="out"  />
+      <arg name="control" type="u" direction="out"  />
+      <arg name="value"   type="u" direction="out"  />
     </signal>
   </interface>
 </node>


### PR DESCRIPTION
If I call `Gio.DBusProxy.makeProxyWrapper` in gjs I get an `GLib.MarkupError`:
`Only direction 'out' is allowed for <arg> elements embedded in <signal>`