### PR TITLE
README: Suggest local installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Clone, build and install built version:
 git clone https://github.com/ddccontrol/ddccontrol.git
 cd ddccontrol
 ./autogen.sh
-./configure --prefix=/usr/ --sysconfdir=/etc --libexecdir=/usr/lib
+./configure --prefix=/usr/local/ --sysconfdir=/etc --libexecdir=/usr/local/lib
 make
 sudo make install
 ```


### PR DESCRIPTION
On most linux distributions, `/usr` is reserved for files managed by a package manager (deb, rpm, …). Local (manual) installations should be put into `/usr/local` instead.

See also: https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s09.html