### PR TITLE
gddccontrol: prepare migration to Gtk3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -165,7 +165,7 @@ if test x$support_gnome = xyes; then
    echo -n "checking for gtk+>=2.4 and gthread>=2.4... "
    if $PKG_CONFIG --atleast-version=2.4 gtk+-2.0 gthread-2.0 ; then
       GNOME_LDFLAGS="$LIBXML2_LIBS `$PKG_CONFIG --libs gtk+-2.0 gthread-2.0`"
-      GNOME_CFLAGS="$LIBXML2_CFLAGS `$PKG_CONFIG --cflags gtk+-2.0 gthread-2.0` -DGTK_DISABLE_SINGLE_INCLUDES"
+      GNOME_CFLAGS="$LIBXML2_CFLAGS `$PKG_CONFIG --cflags gtk+-2.0 gthread-2.0` -DGTK_DISABLE_SINGLE_INCLUDES -DGDK_DISABLE_DEPRECATED -DGTK_DISABLE_DEPRECATED"
       GDDCCONTROL=gddccontrol
       echo "yes"
 

--- a/configure.ac
+++ b/configure.ac
@@ -165,7 +165,7 @@ if test x$support_gnome = xyes; then
    echo -n "checking for gtk+>=2.4 and gthread>=2.4... "
    if $PKG_CONFIG --atleast-version=2.4 gtk+-2.0 gthread-2.0 ; then
       GNOME_LDFLAGS="$LIBXML2_LIBS `$PKG_CONFIG --libs gtk+-2.0 gthread-2.0`"
-      GNOME_CFLAGS="$LIBXML2_CFLAGS `$PKG_CONFIG --cflags gtk+-2.0 gthread-2.0`"
+      GNOME_CFLAGS="$LIBXML2_CFLAGS `$PKG_CONFIG --cflags gtk+-2.0 gthread-2.0` -DGTK_DISABLE_SINGLE_INCLUDES"
       GDDCCONTROL=gddccontrol
       echo "yes"
 

--- a/configure.ac
+++ b/configure.ac
@@ -165,7 +165,7 @@ if test x$support_gnome = xyes; then
    echo -n "checking for gtk+>=2.4 and gthread>=2.4... "
    if $PKG_CONFIG --atleast-version=2.4 gtk+-2.0 gthread-2.0 ; then
       GNOME_LDFLAGS="$LIBXML2_LIBS `$PKG_CONFIG --libs gtk+-2.0 gthread-2.0`"
-      GNOME_CFLAGS="$LIBXML2_CFLAGS `$PKG_CONFIG --cflags gtk+-2.0 gthread-2.0` -DGTK_DISABLE_SINGLE_INCLUDES -DGDK_DISABLE_DEPRECATED -DGTK_DISABLE_DEPRECATED"
+      GNOME_CFLAGS="$LIBXML2_CFLAGS `$PKG_CONFIG --cflags gtk+-2.0 gthread-2.0` -DGTK_DISABLE_SINGLE_INCLUDES -DGDK_DISABLE_DEPRECATED -DGTK_DISABLE_DEPRECATED -DGSEAL_ENABLE"
       GDDCCONTROL=gddccontrol
       echo "yes"
 

--- a/src/gddccontrol/fspatterns.c
+++ b/src/gddccontrol/fspatterns.c
@@ -175,6 +175,55 @@ static void drawchecker(GdkDrawable* pixmap, int width, int height, gchar* text)
 	cairo_destroy(gc);
 }
 
+static void draw_color_crosses(GdkDrawable* pixmap, int width, int height) {
+	const int cross_size = 51;
+	const int arm_length = 25;
+
+	cairo_t* gc = gdk_cairo_create(pixmap);
+	cairo_set_line_cap(gc, CAIRO_LINE_CAP_SQUARE);
+	cairo_set_line_width(gc, 1);
+	
+	GdkColor color;
+	
+	int x, y, color_index = 0, color_column = 0;
+	for (x = 0; x < width; x += cross_size) {
+		color_index = color_column;
+		for (y = 0; y < height; y += cross_size) {
+			color.red = 0x0000;
+			color.green = 0x0000;
+			color.blue = 0x0000;
+			switch (color_index % 4) {
+			case 0:
+				color.red = 0xFFFF;
+				break;
+			case 1:
+				color.green = 0xFFFF;
+				break;
+			case 2:
+				color.blue = 0xFFFF;
+				break;
+			default:
+				color.red = 0xFFFF;
+				color.green = 0xFFFF;
+				color.blue = 0xFFFF;
+			}
+			gdk_cairo_set_source_color(gc, &color);
+			
+			cairo_move_to(gc, 0.5f+x+arm_length, 0.5f+y);
+			cairo_line_to(gc, 0.5f+x+arm_length, 0.5f+y+cross_size);
+			cairo_stroke(gc);
+			
+			cairo_move_to(gc, 0.5f+x, 0.5f+y+arm_length);
+			cairo_line_to(gc, 0.5f+x+cross_size, 0.5f+y+arm_length);
+			cairo_stroke(gc);
+			
+			color_index++;
+		}
+		color_column++;
+	}
+	cairo_destroy(gc);
+}
+
 static void show_pattern(gchar* patternname)
 {
 	// TODO create and draw fullscreen window instead which we can close with [ESC] key
@@ -241,44 +290,7 @@ static void show_pattern(gchar* patternname)
 			  "Adjust Image Lock Fine to minimize movement on the screen."));
 	}
 	else if (g_str_equal(patternname, "misconvergence")) {
-		const int csize = 51;
-		const int dsize = 25;
-		int x, y, c = 0, d = 0;
-		for (x = 0; x < drect.width; x += csize) {
-			c = d;
-			for (y = 0; y < drect.height; y += csize) {
-				color.red = 0x0000;
-				color.green = 0x0000;
-				color.blue = 0x0000;
-				switch (c % 4) {
-				case 0:
-					color.red = 0xFFFF;
-					break;
-				case 1:
-					color.green = 0xFFFF;
-					break;
-				case 2:
-					color.blue = 0xFFFF;
-					break;
-				default:
-					color.red = 0xFFFF;
-					color.green = 0xFFFF;
-					color.blue = 0xFFFF;
-				}
-				gdk_cairo_set_source_color(gc, &color);
-				// TODO maybe +0.5f pixel
-				cairo_move_to(gc, x+dsize, y);
-				cairo_line_to(gc, x+dsize, y+csize);
-				cairo_stroke(gc);
-				
-				// TODO maybe +0.5f pixel
-				cairo_move_to(gc, x, y+dsize);
-				cairo_line_to(gc, x+csize, y+dsize);
-				cairo_stroke(gc);
-				c++;
-			}
-			d++;
-		}
+		draw_color_crosses(pixmap, drect.width, drect.height);
 	}
 	else {
 		color.red = color.green = color.blue = 0xFFFF;

--- a/src/gddccontrol/fspatterns.c
+++ b/src/gddccontrol/fspatterns.c
@@ -41,11 +41,10 @@ static GtkWidget* images[4] = {NULL, NULL, NULL, NULL}; /* top-bottom-left-right
 
 static void destroy(GtkWidget *widget, gpointer data)
 {
-	
-	gtk_widget_ref(vbox);
+	g_object_ref(vbox);
 	gtk_container_remove(GTK_CONTAINER(centervbox), vbox);
 	gtk_box_pack_start(GTK_BOX(monmainvbox), vbox, 0, 5, 5);
-	gtk_widget_unref(vbox);
+	g_object_unref(vbox);
 	
 	gtk_widget_hide(fs_patterns_window);
 }
@@ -145,11 +144,15 @@ static void drawchecker(GdkDrawable* pixmap, int width, int height, gchar* text)
 	GdkColor color;
 	color.red = color.green = color.blue = 0xFFFF;
 	gdk_cairo_set_source_color(gc, &color);
-	
+
+	// TODO
 	int x, y;
 	for (x = 0; x < width; x += 1) {
 		for (y = x%2; y < height; y += 2) {
-			gdk_draw_point(pixmap, gc, x, y);
+			// gdk_draw_point(pixmap, gc, x, y);
+			cairo_move_to(gc, x, y);
+			cairo_line_to(gc, x, y);
+			cairo_stroke(gc);
 		}
 	}
 	
@@ -167,7 +170,7 @@ static void drawchecker(GdkDrawable* pixmap, int width, int height, gchar* text)
 	cairo_move_to(gc, (width-label_width)/2, 3*height/8);
 	pango_cairo_show_layout(gc, layout);
 	
-	g_object_unref(gc);
+	//g_object_unref(gc);
 }
 
 static void show_pattern(gchar* patternname)
@@ -196,9 +199,10 @@ static void show_pattern(gchar* patternname)
 	gdk_cairo_set_source_color(gc, &color);
 	cairo_rectangle(gc, 0, 0, drect.width, drect.height);
 	cairo_fill(gc);
+	// TODO turn this string matching into an Enum or similar
 	if (g_str_equal(patternname, "brightnesscontrast")) {
 		drawShade(pixmap, drect.height/8, drect.height/8, 21);
-		
+
 		color.red = color.green = color.blue = 0xFFFF;
 		gdk_cairo_set_source_color(gc, &color);
 		PangoLayout* layout = pango_layout_new(gtk_widget_get_pango_context(fs_patterns_window));
@@ -217,11 +221,12 @@ static void show_pattern(gchar* patternname)
 		color.red = color.green = color.blue = 0xFFFF;
 		gdk_cairo_set_source_color(gc, &color);
 		cairo_set_line_cap(gc, CAIRO_LINE_CAP_SQUARE);
-		cairo_move_to(gc, 0, (drect.height)/24);
-		cairo_line_to(gc, drect.width, (drect.height)/24);
+		// TODO this line is off by .5 pixels and I don't understand why
+		cairo_move_to(gc, 0, 0.5f+((float)((drect.height)/24)));
+		cairo_line_to(gc, drect.width, 0.5f+((float)((drect.height)/24)));
 		cairo_stroke(gc);
-		cairo_move_to(gc, 0, (23*drect.height)/24);
-		cairo_line_to(gc, drect.width, (23*drect.height)/24);
+		cairo_move_to(gc, 0, (23*drect.height)/24+0.5f);
+		cairo_line_to(gc, drect.width, (23*drect.height)/24+0.5f);
 		cairo_stroke(gc);
 	}
 	else if (g_str_equal(patternname, "moire")) {
@@ -284,8 +289,6 @@ static void show_pattern(gchar* patternname)
 		pango_cairo_show_layout(gc, layout);
 	}
 	
-	g_object_unref(gc);
-	
 	GdkPixbuf* pixbufs[4];
 	
 	pixbufs[0] = gdk_pixbuf_get_from_drawable(NULL, pixmap, NULL, 0, 0, 0, 0, drect.width, top);
@@ -337,10 +340,10 @@ void fullscreen_callback(GtkWidget *widget, gpointer data) {
 	if (!fs_patterns_window)
 		create_fullscreen_patterns_window();
 	
-	gtk_widget_ref(vbox);
+	g_object_ref(vbox);
 	gtk_container_remove(GTK_CONTAINER(monmainvbox), vbox);
 	gtk_box_pack_start(GTK_BOX(centervbox), vbox, 0, 5, 5);
-	gtk_widget_unref(vbox);
+	g_object_unref(vbox);
 	
 	show_pattern(g_object_get_data(G_OBJECT(widget),"pattern"));
 }

--- a/src/gddccontrol/fspatterns.c
+++ b/src/gddccontrol/fspatterns.c
@@ -248,7 +248,7 @@ static void show_pattern(gchar* patternname)
 	GdkRectangle drect;
 	
 	GdkScreen* screen = gdk_screen_get_default();
-	int i = gdk_screen_get_monitor_at_window(gdk_screen_get_default(), main_app_window->window);
+	int i = gdk_screen_get_monitor_at_window(gdk_screen_get_default(), gtk_widget_get_window(main_app_window));
 	gdk_screen_get_monitor_geometry(screen, i, &drect);
 		
 	int top = 7*drect.height/12, bottom = 11*drect.height/12, left = drect.width/3, right = 2*drect.width/3;
@@ -256,8 +256,9 @@ static void show_pattern(gchar* patternname)
 	gtk_widget_set_size_request(fs_patterns_window, drect.width, drect.height);
 	
 	gtk_window_move(GTK_WINDOW(fs_patterns_window), drect.x, drect.y);
-	
-	GdkDrawable* pixmap = gdk_pixmap_new(0, drect.width, drect.height, gdk_colormap_get_visual(gdk_colormap_get_system())->depth);
+
+	gint depth = gdk_visual_get_depth(gdk_visual_get_system());
+	GdkDrawable* pixmap = gdk_pixmap_new(0, drect.width, drect.height, depth);
 	gdk_drawable_set_colormap(pixmap, gdk_colormap_get_system());
 
 	// draw black background

--- a/src/gddccontrol/fspatterns.c
+++ b/src/gddccontrol/fspatterns.c
@@ -159,13 +159,11 @@ static void drawchecker(GdkDrawable* pixmap, int width, int height, gchar* text)
 	
 	color.red = color.green = color.blue = 0x8000;
 	gdk_cairo_set_source_color(gc, &color);
-	// gdk_draw_rectangle(pixmap, gc, TRUE, (width-label_width)/2-5, 3*height/8-5, label_width+10, label_height+10);
 	cairo_rectangle(gc, (width-label_width)/2-5, 3*height/8-5, label_width+10, label_height+10);
 	cairo_fill(gc);
 	
 	color.red = color.green = color.blue = 0x0000;
 	gdk_cairo_set_source_color(gc, &color);
-	//gdk_draw_layout(pixmap, gc, (width-label_width)/2, 3*height/8, layout);
 	cairo_move_to(gc, (width-label_width)/2, 3*height/8);
 	pango_cairo_show_layout(gc, layout);
 	
@@ -195,7 +193,6 @@ static void show_pattern(gchar* patternname)
 	cairo_t* gc = gdk_cairo_create(pixmap);
 	color.red = color.green = color.blue = 0x0000;
 	gdk_cairo_set_source_color(gc, &color);
-	// gdk_draw_rectangle(pixmap, gc, TRUE, 0, 0, drect.width, drect.height);
 	cairo_rectangle(gc, 0, 0, drect.width, drect.height);
 	cairo_fill(gc);
 	if (g_str_equal(patternname, "brightnesscontrast")) {
@@ -217,15 +214,11 @@ static void show_pattern(gchar* patternname)
 		
 		/* Fujitsu-Siemens blank lines for auto level (0xfe). */
 		color.red = color.green = color.blue = 0xFFFF;
-
 		gdk_cairo_set_source_color(gc, &color);
 		cairo_set_line_cap(gc, CAIRO_LINE_CAP_SQUARE);
-		// gdk_draw_line(pixmap, gc, 0, (drect.height)/24, drect.width, (drect.height)/24);
 		cairo_move_to(gc, 0, (drect.height)/24);
 		cairo_line_to(gc, drect.width, (drect.height)/24);
 		cairo_stroke(gc);
-
-		// gdk_draw_line(pixmap, gc, 0, (23*drect.height)/24, drect.width, (23*drect.height)/24);
 		cairo_move_to(gc, 0, (23*drect.height)/24);
 		cairo_line_to(gc, drect.width, (23*drect.height)/24);
 		cairo_stroke(gc);
@@ -264,12 +257,12 @@ static void show_pattern(gchar* patternname)
 					color.blue = 0xFFFF;
 				}
 				gdk_cairo_set_source_color(gc, &color);
-				// gdk_draw_line(pixmap, gc, x+dsize, y, x+dsize, y+csize);
+				// TODO maybe +0.5f pixel
 				cairo_move_to(gc, x+dsize, y);
 				cairo_line_to(gc, x+dsize, y+csize);
 				cairo_stroke(gc);
 				
-				// gdk_draw_line(pixmap, gc, x, y+dsize, x+csize, y+dsize);
+				// TODO maybe +0.5f pixel
 				cairo_move_to(gc, x, y+dsize);
 				cairo_line_to(gc, x+csize, y+dsize);
 				cairo_stroke(gc);

--- a/src/gddccontrol/fspatterns.c
+++ b/src/gddccontrol/fspatterns.c
@@ -162,17 +162,17 @@ static void draw_shade(GdkDrawable* pixmap, int y_position, int shade_height, in
 
 static void draw_checker(GdkDrawable* pixmap, int width, int height, gchar* text) {
 	int label_width, label_height;
-	cairo_t* gc = gdk_cairo_create(pixmap);
+	cairo_t* cairo = gdk_cairo_create(pixmap);
 	GdkColor color;
 	color.red = color.green = color.blue = 0xFFFF;
-	gdk_cairo_set_source_color(gc, &color);
+	gdk_cairo_set_source_color(cairo, &color);
 
 	// draw checker pattern (alternating white pixels)
 	int x, y;
 	for (x = 0; x < width; x += 1) {
 		for (y = x%2; y < height; y += 2) {
-			cairo_rectangle(gc, x, y, 1, 1);
-			cairo_fill(gc);
+			cairo_rectangle(cairo, x, y, 1, 1);
+			cairo_fill(cairo);
 		}
 	}
 
@@ -181,25 +181,25 @@ static void draw_checker(GdkDrawable* pixmap, int width, int height, gchar* text
 	pango_layout_set_markup(layout, text, -1);
 	pango_layout_get_pixel_size(layout, &label_width, &label_height);
 	color.red = color.green = color.blue = 0x8000;
-	gdk_cairo_set_source_color(gc, &color);
-	cairo_rectangle(gc, (width-label_width)/2-5, 3*height/8-5, label_width+10, label_height+10);
-	cairo_fill(gc);
+	gdk_cairo_set_source_color(cairo, &color);
+	cairo_rectangle(cairo, (width-label_width)/2-5, 3*height/8-5, label_width+10, label_height+10);
+	cairo_fill(cairo);
 	color.red = color.green = color.blue = 0x0000;
-	gdk_cairo_set_source_color(gc, &color);
-	cairo_move_to(gc, (width-label_width)/2, 3*height/8);
-	pango_cairo_show_layout(gc, layout);
+	gdk_cairo_set_source_color(cairo, &color);
+	cairo_move_to(cairo, (width-label_width)/2, 3*height/8);
+	pango_cairo_show_layout(cairo, layout);
 	g_object_unref(layout);
 	
-	cairo_destroy(gc);
+	cairo_destroy(cairo);
 }
 
 static void draw_color_crosses(GdkDrawable* pixmap, int width, int height) {
 	const int cross_size = 51;
 	const int arm_length = 25;
 
-	cairo_t* gc = gdk_cairo_create(pixmap);
-	cairo_set_line_cap(gc, CAIRO_LINE_CAP_SQUARE);
-	cairo_set_line_width(gc, 1);
+	cairo_t* cairo = gdk_cairo_create(pixmap);
+	cairo_set_line_cap(cairo, CAIRO_LINE_CAP_SQUARE);
+	cairo_set_line_width(cairo, 1);
 	
 	GdkColor color;
 	
@@ -225,21 +225,21 @@ static void draw_color_crosses(GdkDrawable* pixmap, int width, int height) {
 				color.green = 0xFFFF;
 				color.blue = 0xFFFF;
 			}
-			gdk_cairo_set_source_color(gc, &color);
+			gdk_cairo_set_source_color(cairo, &color);
 			
-			cairo_move_to(gc, 0.5f+x+arm_length, 0.5f+y);
-			cairo_line_to(gc, 0.5f+x+arm_length, 0.5f+y+cross_size);
-			cairo_stroke(gc);
+			cairo_move_to(cairo, 0.5f+x+arm_length, 0.5f+y);
+			cairo_line_to(cairo, 0.5f+x+arm_length, 0.5f+y+cross_size);
+			cairo_stroke(cairo);
 			
-			cairo_move_to(gc, 0.5f+x, 0.5f+y+arm_length);
-			cairo_line_to(gc, 0.5f+x+cross_size, 0.5f+y+arm_length);
-			cairo_stroke(gc);
+			cairo_move_to(cairo, 0.5f+x, 0.5f+y+arm_length);
+			cairo_line_to(cairo, 0.5f+x+cross_size, 0.5f+y+arm_length);
+			cairo_stroke(cairo);
 			
 			color_index++;
 		}
 		color_column++;
 	}
-	cairo_destroy(gc);
+	cairo_destroy(cairo);
 }
 
 static void show_pattern(gchar* patternname)
@@ -262,12 +262,12 @@ static void show_pattern(gchar* patternname)
 
 	// draw black background
 	GdkColor color;
-	cairo_t* gc = gdk_cairo_create(pixmap);
+	cairo_t* cairo = gdk_cairo_create(pixmap);
 	color.red = color.green = color.blue = 0x0000;
-	gdk_cairo_set_source_color(gc, &color);
-	cairo_rectangle(gc, 0, 0, drect.width, drect.height);
-	cairo_fill(gc);
-	cairo_destroy(gc);
+	gdk_cairo_set_source_color(cairo, &color);
+	cairo_rectangle(cairo, 0, 0, drect.width, drect.height);
+	cairo_fill(cairo);
+	cairo_destroy(cairo);
 
 	// TODO turn this string matching into an enum or similar
 	if (g_str_equal(patternname, "brightnesscontrast")) {
@@ -286,18 +286,18 @@ static void show_pattern(gchar* patternname)
 	}
 	else { // TODO when using enum above, this code can be deleted
 		int label_width, label_height;
-		cairo_t* gc = gdk_cairo_create(pixmap);
+		cairo_t* cairo = gdk_cairo_create(pixmap);
 		color.red = color.green = color.blue = 0xFFFF;
-		gdk_cairo_set_source_color(gc, &color);
+		gdk_cairo_set_source_color(cairo, &color);
 		gchar* tmp = g_strdup_printf(_("Unknown fullscreen pattern name: %s"), patternname);
 		PangoLayout* layout = pango_layout_new(gtk_widget_get_pango_context(fs_patterns_window));
 		pango_layout_set_markup(layout, tmp, -1);
 		g_free(tmp);
 		pango_layout_get_pixel_size(layout, &label_width, &label_height);
-		cairo_move_to(gc, (drect.width-label_width)/2, drect.height/8);
-		pango_cairo_show_layout(gc, layout);
+		cairo_move_to(cairo, (drect.width-label_width)/2, drect.height/8);
+		pango_cairo_show_layout(cairo, layout);
 		g_object_unref(layout);
-		cairo_destroy(gc);
+		cairo_destroy(cairo);
 	}
 
 	GdkPixbuf* pixbufs[4];

--- a/src/gddccontrol/fspatterns.c
+++ b/src/gddccontrol/fspatterns.c
@@ -84,6 +84,7 @@ static void drawShade(GdkDrawable* pixmap, int y_position, int shade_height, int
 	
 	cairo_t* gc = gdk_cairo_create(pixmap);
 	cairo_t* gcwhite = gdk_cairo_create(pixmap);
+	cairo_set_line_cap(gcwhite, CAIRO_LINE_CAP_SQUARE);
 	
 	int width, height;
 	gdk_pixmap_get_size(pixmap, &width, &height);
@@ -109,7 +110,6 @@ static void drawShade(GdkDrawable* pixmap, int y_position, int shade_height, int
 		cairo_line_to(gcwhite, x_position, y_position-1);
 		cairo_stroke(gcwhite);
 		// draw tick at shade border (top)
-		cairo_set_line_cap(gcwhite, CAIRO_LINE_CAP_SQUARE);
 		cairo_move_to(gcwhite, x_position, y_position+shade_height);
 		cairo_line_to(gcwhite, x_position, y_position+shade_height+5);
 		cairo_stroke(gcwhite);
@@ -130,7 +130,6 @@ static void drawShade(GdkDrawable* pixmap, int y_position, int shade_height, int
 	cairo_line_to(gcwhite, x_position, y_position-1);
 	cairo_stroke(gcwhite);
 	// draw tick at shade border (top)
-	cairo_set_line_cap(gcwhite, CAIRO_LINE_CAP_SQUARE);
 	cairo_move_to(gcwhite, x_position, y_position+shade_height);
 	cairo_line_to(gcwhite, x_position, y_position+shade_height+5);
 	cairo_stroke(gcwhite);
@@ -142,6 +141,7 @@ static void drawShade(GdkDrawable* pixmap, int y_position, int shade_height, int
 static void drawchecker(GdkDrawable* pixmap, int width, int height, gchar* text) {
 	int label_width, label_height;
 	cairo_t* gc = gdk_cairo_create(pixmap);
+	cairo_set_line_cap(gc, CAIRO_LINE_CAP_SQUARE);
 	GdkColor color;
 	color.red = color.green = color.blue = 0xFFFF;
 	gdk_cairo_set_source_color(gc, &color);
@@ -191,6 +191,7 @@ static void show_pattern(gchar* patternname)
 	int label_width, label_height;
 	GdkColor color;
 	cairo_t* gc = gdk_cairo_create(pixmap);
+	cairo_set_line_cap(gc, CAIRO_LINE_CAP_SQUARE);
 	color.red = color.green = color.blue = 0x0000;
 	gdk_cairo_set_source_color(gc, &color);
 	cairo_rectangle(gc, 0, 0, drect.width, drect.height);

--- a/src/gddccontrol/fspatterns.c
+++ b/src/gddccontrol/fspatterns.c
@@ -141,31 +141,27 @@ static void draw_shade(GdkDrawable* pixmap, int y_position, int shade_height, in
 static void draw_checker(GdkDrawable* pixmap, int width, int height, gchar* text) {
 	int label_width, label_height;
 	cairo_t* gc = gdk_cairo_create(pixmap);
-	cairo_set_line_cap(gc, CAIRO_LINE_CAP_SQUARE);
 	GdkColor color;
 	color.red = color.green = color.blue = 0xFFFF;
 	gdk_cairo_set_source_color(gc, &color);
 
-	// TODO
+	// draw checker pattern (alternating white pixels)
 	int x, y;
 	for (x = 0; x < width; x += 1) {
 		for (y = x%2; y < height; y += 2) {
-			// gdk_draw_point(pixmap, gc, x, y);
-			cairo_move_to(gc, x, y);
-			cairo_line_to(gc, x, y);
-			cairo_stroke(gc);
+			cairo_rectangle(gc, x, y, 1, 1);
+			cairo_fill(gc);
 		}
 	}
-	
+
+	// draw black label on grey background
 	PangoLayout* layout = pango_layout_new(gtk_widget_get_pango_context(fs_patterns_window));
 	pango_layout_set_markup(layout, text, -1);
 	pango_layout_get_pixel_size(layout, &label_width, &label_height);
-	
 	color.red = color.green = color.blue = 0x8000;
 	gdk_cairo_set_source_color(gc, &color);
 	cairo_rectangle(gc, (width-label_width)/2-5, 3*height/8-5, label_width+10, label_height+10);
 	cairo_fill(gc);
-	
 	color.red = color.green = color.blue = 0x0000;
 	gdk_cairo_set_source_color(gc, &color);
 	cairo_move_to(gc, (width-label_width)/2, 3*height/8);

--- a/src/gddccontrol/fspatterns.c
+++ b/src/gddccontrol/fspatterns.c
@@ -76,7 +76,7 @@ static void create_fullscreen_patterns_window()
 	gtk_widget_show(scrolled_window);
 }
 
-static void drawShade(GdkDrawable* pixmap, int y_position, int shade_height, int shade_count) {
+static void draw_shade(GdkDrawable* pixmap, int y_position, int shade_height, int shade_count) {
 	GdkColor color;
 	PangoLayout* layout;
 	gchar* tmp;
@@ -138,7 +138,7 @@ static void drawShade(GdkDrawable* pixmap, int y_position, int shade_height, int
 	cairo_destroy(gcwhite);
 }
 
-static void drawchecker(GdkDrawable* pixmap, int width, int height, gchar* text) {
+static void draw_checker(GdkDrawable* pixmap, int width, int height, gchar* text) {
 	int label_width, label_height;
 	cairo_t* gc = gdk_cairo_create(pixmap);
 	cairo_set_line_cap(gc, CAIRO_LINE_CAP_SQUARE);
@@ -252,7 +252,7 @@ static void show_pattern(gchar* patternname)
 	cairo_fill(gc);
 	// TODO turn this string matching into an Enum or similar
 	if (g_str_equal(patternname, "brightnesscontrast")) {
-		drawShade(pixmap, drect.height/8, drect.height/8, 21);
+		draw_shade(pixmap, drect.height/8, drect.height/8, 21);
 
 		color.red = color.green = color.blue = 0xFFFF;
 		gdk_cairo_set_source_color(gc, &color);
@@ -282,10 +282,10 @@ static void show_pattern(gchar* patternname)
 		cairo_stroke(gc);
 	}
 	else if (g_str_equal(patternname, "moire")) {
-		drawchecker(pixmap, drect.width, drect.height, _("Try to make moire patterns disappear."));
+		draw_checker(pixmap, drect.width, drect.height, _("Try to make moire patterns disappear."));
 	}
 	else if (g_str_equal(patternname, "clock")) {
-		drawchecker(pixmap, drect.width, drect.height,
+		draw_checker(pixmap, drect.width, drect.height,
 			_("Adjust Image Lock Coarse to make the vertical band disappear.\n"
 			  "Adjust Image Lock Fine to minimize movement on the screen."));
 	}

--- a/src/gddccontrol/fspatterns.c
+++ b/src/gddccontrol/fspatterns.c
@@ -120,6 +120,7 @@ static void drawShade(GdkDrawable* pixmap, int y_position, int shade_height, int
 		pango_layout_get_pixel_size(layout, &label_width, &label_height);
 		cairo_move_to(gcwhite, x_position+(shade_width-label_width)/2, y_position+shade_height+2);
 		pango_cairo_show_layout(gcwhite, layout);
+		g_object_unref(layout);
 		
 		x_position += shade_width;
 		color.red = color.green = color.blue = (shade_index+1)*0xFFFF/(shade_count-1);
@@ -132,9 +133,9 @@ static void drawShade(GdkDrawable* pixmap, int y_position, int shade_height, int
 	cairo_move_to(gcwhite, x_position, y_position+shade_height);
 	cairo_line_to(gcwhite, x_position, y_position+shade_height+5);
 	cairo_stroke(gcwhite);
-	
-	//g_object_unref(gc);
-	//g_object_unref(gcwhite);
+
+	cairo_destroy(gc);
+	cairo_destroy(gcwhite);
 }
 
 static void drawchecker(GdkDrawable* pixmap, int width, int height, gchar* text) {
@@ -169,8 +170,9 @@ static void drawchecker(GdkDrawable* pixmap, int width, int height, gchar* text)
 	gdk_cairo_set_source_color(gc, &color);
 	cairo_move_to(gc, (width-label_width)/2, 3*height/8);
 	pango_cairo_show_layout(gc, layout);
+	g_object_unref(layout);
 	
-	//g_object_unref(gc);
+	cairo_destroy(gc);
 }
 
 static void show_pattern(gchar* patternname)
@@ -216,6 +218,7 @@ static void show_pattern(gchar* patternname)
 		pango_layout_get_pixel_size(layout, &label_width, &label_height);
 		cairo_move_to(gc, (drect.width-label_width)/2, 3*drect.height/8);
 		pango_cairo_show_layout(gc, layout);
+		g_object_unref(layout);
 		
 		/* Fujitsu-Siemens blank lines for auto level (0xfe). */
 		color.red = color.green = color.blue = 0xFFFF;
@@ -287,14 +290,17 @@ static void show_pattern(gchar* patternname)
 		pango_layout_get_pixel_size(layout, &label_width, &label_height);
 		cairo_move_to(gc, (drect.width-label_width)/2, drect.height/8);
 		pango_cairo_show_layout(gc, layout);
+		g_object_unref(layout);
 	}
-	
+	cairo_destroy(gc);
+
 	GdkPixbuf* pixbufs[4];
 	
 	pixbufs[0] = gdk_pixbuf_get_from_drawable(NULL, pixmap, NULL, 0, 0, 0, 0, drect.width, top);
 	pixbufs[1] = gdk_pixbuf_get_from_drawable(NULL, pixmap, NULL, 0, bottom, 0, 0, drect.width, drect.height-bottom);
 	pixbufs[2] = gdk_pixbuf_get_from_drawable(NULL, pixmap, NULL, 0, top, 0, 0, left, bottom-top);
 	pixbufs[3] = gdk_pixbuf_get_from_drawable(NULL, pixmap, NULL, right, top, 0, 0, drect.width-right, bottom-top);
+	g_object_unref(pixmap);
 	
 	if (images[0])
 	{ /* GtkImages already exist */
@@ -307,7 +313,6 @@ static void show_pattern(gchar* patternname)
 		for (i = 0; i < 4; i++) {
 			images[i] = gtk_image_new_from_pixbuf(pixbufs[i]);
 			gtk_widget_show(images[i]);
-			g_object_unref(pixbufs[i]);
 		}
 		
 		gtk_table_attach(GTK_TABLE(table), images[0],       0, 3, 0, 1, GTK_FILL_EXPAND, GTK_FILL_EXPAND, 0, 0);
@@ -316,6 +321,9 @@ static void show_pattern(gchar* patternname)
 		gtk_table_attach(GTK_TABLE(table), images[3],       2, 3, 1, 2, GTK_FILL_EXPAND, GTK_FILL_EXPAND, 0, 0);
 		gtk_table_attach(GTK_TABLE(table), images[1],       0, 3, 2, 3, GTK_FILL_EXPAND, GTK_FILL_EXPAND, 0, 0);
 		gtk_widget_show(table);
+	}
+	for (i = 0; i < 4; i++) {
+		g_object_unref(pixbufs[i]);
 	}
 	
 	gtk_widget_set_size_request(scrolled_window, right-left, bottom-top);

--- a/src/gddccontrol/gprofile.c
+++ b/src/gddccontrol/gprofile.c
@@ -455,7 +455,7 @@ void show_profile_information(struct profile* profile, gboolean new_profile) {
 	tmp = g_strdup_printf("<span size='large' weight='ultrabold'>%s %s</span>", _("Profile information:"), profile->name);
 	gtk_label_set_markup(GTK_LABEL(label), tmp);
 	g_free(tmp);
-	gtk_box_pack_start(GTK_BOX(GTK_DIALOG(dialog)->vbox), label, FALSE, FALSE, 5);
+	gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(dialog)), label, FALSE, FALSE, 5);
 	gtk_widget_show(label);
 	
 	hbox = gtk_hbox_new(FALSE,0);
@@ -467,7 +467,7 @@ void show_profile_information(struct profile* profile, gboolean new_profile) {
 	gtk_box_pack_start(GTK_BOX(hbox), label, FALSE, FALSE, 5);
 	gtk_widget_show(label);
 	
-	gtk_box_pack_start(GTK_BOX(GTK_DIALOG(dialog)->vbox), hbox, FALSE, FALSE, 5);
+	gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(dialog)), hbox, FALSE, FALSE, 5);
 	gtk_widget_show(hbox);
 	
 	hbox = gtk_hbox_new(FALSE,0);
@@ -482,12 +482,12 @@ void show_profile_information(struct profile* profile, gboolean new_profile) {
 	g_signal_connect(GTK_ENTRY(entry), "changed", G_CALLBACK(entry_modified_callback), dialog);
 	gtk_widget_show(entry);
 	
-	gtk_box_pack_start(GTK_BOX(GTK_DIALOG(dialog)->vbox), hbox, FALSE, FALSE, 5);
+	gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(dialog)), hbox, FALSE, FALSE, 5);
 	gtk_widget_show(hbox);
 	
 	GtkWidget* tree = create_info_tree(profile, dialog);
 	
-	gtk_box_pack_start(GTK_BOX(GTK_DIALOG(dialog)->vbox), tree, FALSE, FALSE, 5);
+	gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(dialog)), tree, FALSE, FALSE, 5);
 	gtk_widget_show(tree);
 	
 	gint result = gtk_dialog_run(GTK_DIALOG(dialog));

--- a/src/gddccontrol/main.c
+++ b/src/gddccontrol/main.c
@@ -184,7 +184,7 @@ static gboolean window_changed(GtkWidget *widget,
 			return FALSE;
 		}
 		
-		i = gdk_screen_get_monitor_at_window(gdk_screen_get_default(), main_app_window->window);
+		i = gdk_screen_get_monitor_at_window(gdk_screen_get_default(), gtk_widget_get_window(main_app_window));
 		
 		if (i != current_monitor) {
 			int k = nextid;
@@ -589,7 +589,7 @@ int main( int argc, char *argv[] )
 		printf("%d: %d, %d %dx%d\n", nscreen, dest.x, dest.y, dest.width, dest.height);
 	}*/
 	
-	current_monitor = gdk_screen_get_monitor_at_window(screen, main_app_window->window);
+	current_monitor = gdk_screen_get_monitor_at_window(screen, gtk_widget_get_window(main_app_window));
 	
 	probe_monitors(NULL, NULL);
 	

--- a/src/gddccontrol/main.c
+++ b/src/gddccontrol/main.c
@@ -64,8 +64,6 @@ int num_monitor; /* total number of monitors */
 
 struct monitorlist* monlist;
 
-GtkTooltips *tooltips;
-
 gulong combo_box_changed_handler_id = 0;
 
 int mainrow = 0; /* Main center row in the table widget */
@@ -331,7 +329,7 @@ GtkWidget *stock_label_button(const gchar * stockid, const gchar *label_text, co
 	g_object_set_data(G_OBJECT(button), "button_label", label);
 	
 	if (tool_tip) {
-		gtk_tooltips_set_tip(GTK_TOOLTIPS(tooltips), button, tool_tip, NULL);
+		gtk_widget_set_tooltip_text(GTK_WIDGET(button), tool_tip);
 	}
 	
 	return button;
@@ -355,7 +353,7 @@ static void probe_monitors(GtkWidget *widget, gpointer data) {
 	{
 		snprintf(buffer, 256, "%s: %s",
 			current->filename, current->name);
-		gtk_combo_box_append_text(GTK_COMBO_BOX(combo_box), buffer);
+		gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(combo_box), buffer);
 	}
 	
 	combo_box_changed_handler_id = g_signal_connect(G_OBJECT(combo_box), "changed", G_CALLBACK(combo_change), NULL);
@@ -414,8 +412,6 @@ int main( int argc, char *argv[] )
 	g_thread_init(NULL);
 	combo_change_mutex = g_mutex_new();
 	
-	tooltips = gtk_tooltips_new();
-	
 	/* Full screen patterns test */
 	/*create_fullscreen_patterns_window();
 	show_pattern();
@@ -468,7 +464,7 @@ int main( int argc, char *argv[] )
 	gtk_widget_show(label);
 	gtk_box_pack_start(GTK_BOX(choice_hbox),label, 0, 0, 0);
 	
-	combo_box = gtk_combo_box_new_text();
+	combo_box = gtk_combo_box_text_new();
 	
 	gtk_widget_show(combo_box);
 


### PR DESCRIPTION
Prepare the GUI code for a future migration from gtk2 to gtk3 by following the first steps of [Migrating from GTK 2.x to GTK 3](https://docs.gtk.org/gtk3/migrating-2to3.html) until _Changes that need to be done at the time of the switch_.

Changes to `fspatterns.c`:
* Refactor fullscreen drawing to use cairo drawing primitives instead of GDK drawing primitives
* Refactor variable and function names for readability
* Drop disabled (commented out) code, mostly related to oldvboxbg
* Reference counting: Adapt for gtk deprecations
* Improve freeing/dereferencing thanks to Valgrind
  * PS: Quite a lot of memory is still leaked, which is hard to resolve due
to the design of gddccontrol and due to gtk2 internally leaking memory.
Both lead to lots of leaks which makes it hard to find actual leaks
caused by gddccontrol's code.
* Extract code from `show_pattern` into its own function `draw_color_crosses`
* Move code from `show_pattern` to `draw_shade`
* `draw_shade`: draw ticks for shade borders 2 pixels wide instead of 1
* `draw_shade`: draw ticks and labels for shade in white instead of gray
The last 2 items on the list above are the only user visible changes. All other changes should not be visible to the user.

Changes to other files:
* `configure.ac`: Add compile flags for gddccontrol
* gddccontrol `main.c`: adapt for gtk deprecations related to tooltips and combo boxes
* Multiple files: Use accessor functions instead of direct access

Open topics:
* This code is not tested or adapted for HiDPI and may behave unexpectedly on HiDPI monitors. This is not a regression, however, because gtk2 does not support HiDPI monitors at all.
* Continue porting to gtk3/gtk4 (see #153)