### PR TITLE
Fixed build with gcc-14

### DIFF
--- a/src/daemon/dbus_client.c
+++ b/src/daemon/dbus_client.c
@@ -80,7 +80,7 @@ int ddcci_dbus_open(DDCControl *proxy, struct monitor **_mon, const char *filena
 		return -1;
 	}
 
-	strncpy(&mon->pnpid, pnpid, 7);
+	strncpy((char *)&mon->pnpid, pnpid, 7);
 	mon->pnpid[7] = 0;
 
 	ddcci_parse_caps(mon->caps.raw_caps, &mon->caps, 1);

--- a/src/gddccontrol/gprofile.c
+++ b/src/gddccontrol/gprofile.c
@@ -455,7 +455,7 @@ void show_profile_information(struct profile* profile, gboolean new_profile) {
 	tmp = g_strdup_printf("<span size='large' weight='ultrabold'>%s %s</span>", _("Profile information:"), profile->name);
 	gtk_label_set_markup(GTK_LABEL(label), tmp);
 	g_free(tmp);
-	gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(dialog)), label, FALSE, FALSE, 5);
+	gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area((GtkDialog *)dialog)), label, FALSE, FALSE, 5);
 	gtk_widget_show(label);
 	
 	hbox = gtk_hbox_new(FALSE,0);
@@ -467,7 +467,7 @@ void show_profile_information(struct profile* profile, gboolean new_profile) {
 	gtk_box_pack_start(GTK_BOX(hbox), label, FALSE, FALSE, 5);
 	gtk_widget_show(label);
 	
-	gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(dialog)), hbox, FALSE, FALSE, 5);
+	gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area((GtkDialog *)dialog)), hbox, FALSE, FALSE, 5);
 	gtk_widget_show(hbox);
 	
 	hbox = gtk_hbox_new(FALSE,0);
@@ -482,12 +482,12 @@ void show_profile_information(struct profile* profile, gboolean new_profile) {
 	g_signal_connect(GTK_ENTRY(entry), "changed", G_CALLBACK(entry_modified_callback), dialog);
 	gtk_widget_show(entry);
 	
-	gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(dialog)), hbox, FALSE, FALSE, 5);
+	gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area((GtkDialog *)dialog)), hbox, FALSE, FALSE, 5);
 	gtk_widget_show(hbox);
 	
 	GtkWidget* tree = create_info_tree(profile, dialog);
 	
-	gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area(dialog)), tree, FALSE, FALSE, 5);
+	gtk_box_pack_start(GTK_BOX(gtk_dialog_get_content_area((GtkDialog *)dialog)), tree, FALSE, FALSE, 5);
 	gtk_widget_show(tree);
 	
 	gint result = gtk_dialog_run(GTK_DIALOG(dialog));


### PR DESCRIPTION
Quick and dirty fix for FTBFSs on Fedora Rawhide (f40) with gcc-14. It fixes e.g.:
```
dbus_client.c: In function 'ddcci_dbus_open':
dbus_client.c:83:17: error: passing argument 1 of 'strncpy' from incompatible pointer type [-Wincompatible-pointer-types]
   83 |         strncpy(&mon->pnpid, pnpid, 7);
      |                 ^~~~~~~~~~~
      |                 |
      |                 char (*)[8]
In file included from /usr/include/features.h:503,
                 from /usr/include/time.h:25,
                 from ../../src/lib/ddcci.h:24,
                 from dbus_client.h:24,
                 from dbus_client.c:21:
/usr/include/bits/string_fortified.h:92:1: note: expected 'char *' but argument is of type 'char (*)[8]'
```
