### PR TITLE
Improve Gtk3 code

### DIFF
--- a/.github/ci/Dockerfile
+++ b/.github/ci/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update \
         autoconf \
         build-essential \
         ca-certificates \
+        clang \
         dh-autoreconf \
         git \
         intltool \

--- a/.github/ci/Dockerfile
+++ b/.github/ci/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        astyle \
+        autoconf \
+        build-essential \
+        ca-certificates \
+        dh-autoreconf \
+        git \
+        intltool \
+        libgtk-3-dev \
+        libpci-dev \
+        libxml2-dev \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -24,7 +24,7 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Set up QEMU
-        run: docker run --privileged --rm tonistiigi/binfmt:qemu-v10.2.1 --install arm64
+        run: docker run --privileged --rm tonistiigi/binfmt:qemu-v10.2.1 --install arm64,arm
 
       - name: Set up Docker Buildx
         run: |
@@ -34,7 +34,7 @@ jobs:
       - name: Build and push image
         run: |
           docker buildx build \
-            --platform linux/amd64,linux/arm64 \
+            --platform linux/amd64,linux/arm64,linux/arm/v7 \
             --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
             --label "org.opencontainers.image.revision=${{ github.sha }}" \
             --tag ghcr.io/ddccontrol/ddccontrol-ci:latest \

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -1,0 +1,38 @@
+name: CI Image
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 3 * * 0"
+  push:
+    branches: [master]
+    paths:
+      - ".github/ci/Dockerfile"
+      - ".github/workflows/ci-image.yml"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build image
+        run: |
+          docker build \
+            --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
+            --label "org.opencontainers.image.revision=${{ github.sha }}" \
+            --tag ghcr.io/ddccontrol/ddccontrol-ci:latest \
+            --tag ghcr.io/ddccontrol/ddccontrol-ci:${{ github.sha }} \
+            .github/ci
+
+      - name: Push image
+        run: |
+          docker push ghcr.io/ddccontrol/ddccontrol-ci:latest
+          docker push ghcr.io/ddccontrol/ddccontrol-ci:${{ github.sha }}

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -23,16 +23,21 @@ jobs:
       - name: Log in to GitHub Container Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-      - name: Build image
+      - name: Set up QEMU
+        run: docker run --privileged --rm tonistiigi/binfmt:qemu-v10.2.1 --install arm64
+
+      - name: Set up Docker Buildx
         run: |
-          docker build \
+          docker buildx create --use
+          docker buildx inspect --bootstrap
+
+      - name: Build and push image
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
             --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
             --label "org.opencontainers.image.revision=${{ github.sha }}" \
             --tag ghcr.io/ddccontrol/ddccontrol-ci:latest \
             --tag ghcr.io/ddccontrol/ddccontrol-ci:${{ github.sha }} \
+            --push \
             .github/ci
-
-      - name: Push image
-        run: |
-          docker push ghcr.io/ddccontrol/ddccontrol-ci:latest
-          docker push ghcr.io/ddccontrol/ddccontrol-ci:${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,24 +9,13 @@ on:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    container:
+      image: ghcr.io/ddccontrol/ddccontrol-ci:latest
     strategy:
       matrix:
         compiler: [gcc]
     steps:
       - uses: actions/checkout@v6
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            astyle \
-            autoconf \
-            dh-autoreconf \
-            intltool \
-            libgtk-3-dev \
-            libpci-dev \
-            libxml2-dev \
-            pkg-config \
 
       - name: Set compiler
         run: |
@@ -37,11 +26,9 @@ jobs:
           fi
 
       - name: Build
-        env:
-          CFLAGS: ${{ matrix.cflags }}
         run: |
           ./autogen.sh
-          ./configure "$CFLAGS"
+          ./configure CFLAGS="$CFLAGS"
           make -j$(nproc)
 
       - name: Format code check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         compiler: [gcc]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get install -y --no-install-recommends \
             astyle \
             autoconf \
             dh-autoreconf \
@@ -42,7 +42,7 @@ jobs:
         run: |
           ./autogen.sh
           ./configure "$CFLAGS"
-          make -j4
+          make -j$(nproc)
 
       - name: Format code check
         run: ./scripts/format_code.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,38 +6,69 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   build:
-    name: build (${{ matrix.arch }}, ${{ matrix.compiler }})
-    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
-    container:
-      image: ghcr.io/ddccontrol/ddccontrol-ci:latest
+    name: build (${{ matrix.target.arch }}, ${{ matrix.compiler }})
+    runs-on: ${{ matrix.target.runner }}
     strategy:
       matrix:
-        arch: [amd64, arm64]
+        target:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+          - arch: armhf
+            platform: linux/arm/v7
+            runner: ubuntu-24.04
         compiler: [gcc, clang]
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set compiler
+      - name: Set up QEMU
+        if: matrix.target.arch == 'armhf'
+        run: docker run --privileged --rm tonistiigi/binfmt:qemu-v10.2.1 --install arm
+
+      - name: Prepare CI image
         run: |
-          if [ "${{ matrix.compiler }}" = "clang" ]; then
-            echo "CC=clang" >> $GITHUB_ENV
+          echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin || true
+          image=ghcr.io/ddccontrol/ddccontrol-ci:latest
+          if docker pull --platform "${{ matrix.target.platform }}" "$image"; then
+            echo "CI_IMAGE=$image" >> "$GITHUB_ENV"
           else
-            echo "CC=gcc" >> $GITHUB_ENV
+            image=ddccontrol-ci:${{ matrix.target.arch }}
+            docker buildx create --use
+            docker buildx inspect --bootstrap
+            docker buildx build \
+              --platform "${{ matrix.target.platform }}" \
+              --load \
+              --tag "$image" \
+              .github/ci
+            echo "CI_IMAGE=$image" >> "$GITHUB_ENV"
           fi
 
       - name: Build
         run: |
-          ./autogen.sh
-          ./configure CFLAGS="$CFLAGS"
-          make -j$(nproc)
-
-      - name: Format code check
-        run: ./scripts/format_code.sh
-
-      - name: Clean up formatted files
-        run: find -name "*.orig" -exec rm -v {} \;
-
-      - name: Post-build checks
-        run: ./scripts/travis_ci_after_build_checks.sh
+          docker run --rm \
+            --platform "${{ matrix.target.platform }}" \
+            -e CC="${{ matrix.compiler }}" \
+            -v "${{ github.workspace }}:/src:ro" \
+            "$CI_IMAGE" \
+            bash -lc '
+              set -e
+              cp -a /src /tmp/ddccontrol
+              cd /tmp/ddccontrol
+              git config --global --add safe.directory /tmp/ddccontrol
+              git clean -fdX
+              ./autogen.sh
+              ./configure CFLAGS="$CFLAGS"
+              make -j$(nproc)
+              ./scripts/format_code.sh
+              find -name "*.orig" -exec rm -v {} \;
+              ./scripts/travis_ci_after_build_checks.sh
+            '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,13 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    name: build (${{ matrix.arch }}, ${{ matrix.compiler }})
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     container:
       image: ghcr.io/ddccontrol/ddccontrol-ci:latest
     strategy:
       matrix:
+        arch: [amd64, arm64]
         compiler: [gcc, clang]
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       image: ghcr.io/ddccontrol/ddccontrol-ci:latest
     strategy:
       matrix:
-        compiler: [gcc]
+        compiler: [gcc, clang]
     steps:
       - uses: actions/checkout@v6
 

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ Makefile
 Makefile.in
 
 /scripts/tmp
+configure~
+po/Makefile.in.in~
+src/config.h.in~

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.la
 *.lo
 *.o
+*.orig
+.dirstamp
 .deps/
 .libs/
 /ABOUT-NLS

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+Use this section to tell people about which versions of your project are
+currently being supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 5.1.x   | :white_check_mark: |
+| 5.0.x   | :x:                |
+| 4.0.x   | :white_check_mark: |
+| < 4.0   | :x:                |
+
+## Reporting a Vulnerability
+
+Use this section to tell people how to report a vulnerability.
+
+Tell them where to go, how often they can expect to get an update on a
+reported vulnerability, what to expect if the vulnerability is accepted or
+declined, etc.

--- a/po/Makevars
+++ b/po/Makevars
@@ -41,13 +41,13 @@ PACKAGE_GNU = no
 # It can be your email address, or a mailing list address where translators
 # can write to without being subscribed, or the URL of a web page through
 # which the translators can contact you.
-MSGID_BUGS_ADDRESS = ddccontrol-devel@lists.sourceforge.net
+MSGID_BUGS_ADDRESS = https://github.com/ddccontrol/ddccontrol/issues/
 
 # This is the list of locale categories, beyond LC_MESSAGES, for which the
 # message catalogs shall be used.  It is usually empty.
 EXTRA_LOCALE_CATEGORIES =
 PACKAGE_GNU =
-MSGID_BUGS_ADDRESS =
+MSGID_BUGS_ADDRESS = https://github.com/ddccontrol/ddccontrol/issues/
 USE_MSGCTXT = no
 MSGMERGE_OPTIONS =
 MSGINIT_OPTIONS =

--- a/po/cs.po
+++ b/po/cs.po
@@ -5,38 +5,38 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: ddccontrol 0.4.3\n"
-"Report-Msgid-Bugs-To: ddccontrol-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2010-01-06 18:52+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/ddccontrol/ddccontrol/issues/\n"
+"POT-Creation-Date: 2026-05-13 15:12+0200\n"
 "PO-Revision-Date: 2010-07-07 14:57+0200\n"
 "Last-Translator: Stanislav Brabec <sbrabec@suse.cz>\n"
 "Language-Team: Czech <cs@li.org>\n"
+"Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/ddccontrol/main.c:83 ../src/ddccontrol/main.c:87
-#: ../src/ddccontrol/main.c:91
-msgid "Control"
-msgstr "Ovládání"
-
-#: ../src/ddccontrol/main.c:132
-#, c-format
+#: ../src/ddccontrol/main.c:85
+#, fuzzy, c-format
 msgid ""
 "Usage:\n"
-"%s [-b datadir] [-v] [-c] [-d] [-f] [-s] [-r ctrl [-w value]] [-p | dev]\n"
+"%s [-b datadir] [-v] [-c] [-d] [-f] [-s] [-r ctrl [-w value]] [-l (profile "
+"path)] [-p | dev]\n"
 "\tdev: device, e.g. dev:/dev/i2c-0\n"
 "\t-p : probe I2C devices to find monitor buses\n"
 "\t-c : query capability\n"
 "\t-d : query ctrls 0 - 255\n"
 "\t-r : query ctrl\n"
 "\t-w : value to write to ctrl\n"
+"\t-W : relatively change ctrl value (+/-)\n"
 "\t-f : force (avoid validity checks)\n"
 "\t-s : save settings\n"
 "\t-v : verbosity (specify more to increase)\n"
 "\t-b : ddccontrol-db directory (if other than %s)\n"
+"\t-l : load values from XML profile file\n"
 msgstr ""
 "Použití:\n"
-" %s [-b data_adr] [-v] [-c] [-d] [-f] [-s] [-r prvek [-w hodnota]] [-p | zař]\n"
+" %s [-b data_adr] [-v] [-c] [-d] [-f] [-s] [-r prvek [-w hodnota]] [-p | "
+"zař]\n"
 "\\tzař: zařízení, např. dev:/dev/i2c-0\n"
 "\\t-p: Hledat sběrnice monitorů mezi I2C zařízeními\n"
 "\\t-c: dotaz na schopnosti\n"
@@ -48,22 +48,22 @@ msgstr ""
 "\\t-v: upovidanost (pro zvýšení zadejte vyšší hodnotu)\n"
 "\\t-b: adresář s ddccontrol-db (je-li jiný než %s)\n"
 
-#: ../src/ddccontrol/main.c:150 ../src/ddccontrol/main.c:172
+#: ../src/ddccontrol/main.c:106 ../src/ddccontrol/main.c:128
 #, c-format
 msgid "Checking %s integrity...\n"
 msgstr "Kontrola integrity %s...\n"
 
-#: ../src/ddccontrol/main.c:152 ../src/ddccontrol/main.c:174
+#: ../src/ddccontrol/main.c:108 ../src/ddccontrol/main.c:130
 #, c-format
 msgid "[ FAILED ]\n"
 msgstr "[ SELHALO ]\n"
 
-#: ../src/ddccontrol/main.c:156 ../src/ddccontrol/main.c:179
+#: ../src/ddccontrol/main.c:112 ../src/ddccontrol/main.c:135
 #, c-format
 msgid "[ OK ]\n"
 msgstr "[ OK ]\n"
 
-#: ../src/ddccontrol/main.c:217
+#: ../src/ddccontrol/main.c:194
 #, c-format
 msgid ""
 "ddccontrol version %s\n"
@@ -78,76 +78,92 @@ msgstr ""
 "Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)\n"
 "Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)\n"
 "Tento program je šířen ABSOLUTNĚ BEZ ZÁRUKY.\n"
-"Můžete šířit kopie tohoto programu za dodržení podmínek GNU General Public License.\n"
+"Můžete šířit kopie tohoto programu za dodržení podmínek GNU General Public "
+"License.\n"
 "\n"
 
-#: ../src/ddccontrol/main.c:236
+#: ../src/ddccontrol/main.c:211
 #, c-format
 msgid "'%s' does not seem to be a valid register name\n"
 msgstr "'%s' nevypadá jako platné jméno registru\n"
 
-#: ../src/ddccontrol/main.c:242
+#: ../src/ddccontrol/main.c:217
 #, c-format
 msgid "You cannot use -w parameter without -r.\n"
 msgstr "Nelze použít parametr -w bez parametru -r.\n"
 
-#: ../src/ddccontrol/main.c:247
+#: ../src/ddccontrol/main.c:221 ../src/ddccontrol/main.c:231
 #, c-format
 msgid "'%s' does not seem to be a valid value.\n"
 msgstr "'%s' nevypadá jako platná hodnota.\n"
 
-#: ../src/ddccontrol/main.c:292 ../src/gddccontrol/main.c:415
+#: ../src/ddccontrol/main.c:227
+#, fuzzy, c-format
+msgid "You cannot use -W parameter without -r.\n"
+msgstr "Nelze použít parametr -w bez parametru -r.\n"
+
+#: ../src/ddccontrol/main.c:282 ../src/gddccontrol/main.c:432
 #, c-format
 msgid "Unable to initialize ddcci library.\n"
 msgstr "Nelze inicializovat knihovnu ddcci.\n"
 
-#: ../src/ddccontrol/main.c:304
+#: ../src/ddccontrol/main.c:288
+#, fuzzy, c-format
+msgid "Unable to initialize ddcci db library.\n"
+msgstr "Nelze inicializovat knihovnu ddcci.\n"
+
+#: ../src/ddccontrol/main.c:293
+#, c-format
+msgid "Failed to open D-Bus proxy, try with DDCCONTROL_NO_DAEMON=1.\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:310
 #, c-format
 msgid "Detected monitors :\n"
 msgstr "Detekované monitory:\n"
 
-#: ../src/ddccontrol/main.c:309
+#: ../src/ddccontrol/main.c:314
 #, c-format
 msgid " - Device: %s\n"
 msgstr "- Zařízení: %s\n"
 
-#: ../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 #, c-format
 msgid "   DDC/CI supported: %s\n"
 msgstr "   DDC/CI podporováno: %s\n"
 
-#: ../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 msgid "Yes"
 msgstr "Ano"
 
-#: ../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 msgid "No"
 msgstr "Ne"
 
-#: ../src/ddccontrol/main.c:311
+#: ../src/ddccontrol/main.c:316
 #, c-format
 msgid "   Monitor Name: %s\n"
 msgstr "   Jméno monitoru: %s\n"
 
-#: ../src/ddccontrol/main.c:312
+#: ../src/ddccontrol/main.c:317
 #, c-format
 msgid "   Input type: %s\n"
 msgstr "   Typ vstupu: %s\n"
 
-#: ../src/ddccontrol/main.c:312 ../src/ddccontrol/main.c:350
+#: ../src/ddccontrol/main.c:317 ../src/ddccontrol/main.c:364
 msgid "Digital"
 msgstr "Digitální"
 
-#: ../src/ddccontrol/main.c:312 ../src/ddccontrol/main.c:350
+#: ../src/ddccontrol/main.c:317 ../src/ddccontrol/main.c:364
 msgid "Analog"
 msgstr "Analogový"
 
-#: ../src/ddccontrol/main.c:316
+#: ../src/ddccontrol/main.c:321
 #, c-format
 msgid "  (Automatically selected)\n"
 msgstr "  (volen automaticky)\n"
 
-#: ../src/ddccontrol/main.c:326
+#: ../src/ddccontrol/main.c:333
 #, c-format
 msgid ""
 "No monitor supporting DDC/CI available.\n"
@@ -155,14 +171,15 @@ msgid ""
 "are loaded (i2c-dev, and your framebuffer driver).\n"
 msgstr ""
 "Žádný monitor podporující DDC/CI není k dispozici.\n"
-"Pokud to vaše grafická karta potřebuje, zkontrolujte, zda všechny požadované moduly jádra jsou zavedeny (i2c-dev, a vaše ovladače frame bufferu).\n"
+"Pokud to vaše grafická karta potřebuje, zkontrolujte, zda všechny požadované "
+"moduly jádra jsou zavedeny (i2c-dev, a vaše ovladače frame bufferu).\n"
 
-#: ../src/ddccontrol/main.c:339
+#: ../src/ddccontrol/main.c:346
 #, c-format
 msgid "Reading EDID and initializing DDC/CI at bus %s...\n"
 msgstr "Čte se EDID a inicializuje se DDC/CI na sběrnici %s...\n"
 
-#: ../src/ddccontrol/main.c:343
+#: ../src/ddccontrol/main.c:357
 #, c-format
 msgid ""
 "\n"
@@ -172,31 +189,169 @@ msgid ""
 msgstr ""
 "\n"
 "DDC/CI na %s není použitelný (%d).\n"
-"Pokud to vaše grafická karta potřebuje, zkontrolujte, zda všechny požadované moduly jádra jsou zavedeny (i2c-dev, a vaše ovladače frame bufferu).\n"
+"Pokud to vaše grafická karta potřebuje, zkontrolujte, zda všechny požadované "
+"moduly jádra jsou zavedeny (i2c-dev, a vaše ovladače frame bufferu).\n"
 
-#: ../src/ddccontrol/main.c:347
+#: ../src/ddccontrol/main.c:361
 #, c-format
 msgid ""
 "\n"
 "EDID readings:\n"
-msgstr "\nNačtená EDID:\n"
+msgstr ""
+"\n"
+"Načtená EDID:\n"
 
-#: ../src/ddccontrol/main.c:348
+#: ../src/ddccontrol/main.c:362
 #, c-format
 msgid "\tPlug and Play ID: %s [%s]\n"
 msgstr "\tIdentifikátor Plug and Play: %s [%s]\n"
 
-#: ../src/ddccontrol/main.c:350
+#: ../src/ddccontrol/main.c:364
 #, c-format
 msgid "\tInput type: %s\n"
 msgstr "\tTyp vstupu: %s\n"
 
-#. Put a big warning (in red if we are writing to a terminal).
-#: ../src/ddccontrol/main.c:354 ../src/ddccontrol/main.c:373
-msgid "=============================== WARNING ==============================="
-msgstr "============================== VAROVÁNÍ ==============================="
+#: ../src/ddccontrol/main.c:370
+#, c-format
+msgid ""
+"\n"
+"Capabilities:\n"
+msgstr ""
+"\n"
+"Schopnosti:\n"
 
-#: ../src/ddccontrol/main.c:357
+#: ../src/ddccontrol/main.c:374
+#, c-format
+msgid "Raw output: %s\n"
+msgstr "Surový výstup: %s\n"
+
+#: ../src/ddccontrol/main.c:376
+#, c-format
+msgid "Parsed output: \n"
+msgstr "Analyzovaný výstup:\n"
+
+#: ../src/ddccontrol/main.c:385
+#, c-format
+msgid "\tType: "
+msgstr "\tTyp: "
+
+#: ../src/ddccontrol/main.c:388
+#, c-format
+msgid "LCD"
+msgstr "LCD"
+
+#: ../src/ddccontrol/main.c:391
+#, c-format
+msgid "CRT"
+msgstr "CRT"
+
+#: ../src/ddccontrol/main.c:394
+#, c-format
+msgid "Unknown"
+msgstr "Neznámý"
+
+#: ../src/ddccontrol/main.c:403
+#, c-format
+msgid "Capabilities read fail.\n"
+msgstr "Nezdařilo se načíst schopnosti.\n"
+
+#: ../src/ddccontrol/main.c:417
+#, c-format
+msgid "Value cannot be lower than zero! %d -> %d\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:420
+#, c-format
+msgid "Value cannot be higher than maximum! %d / %d\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:428
+#, c-format
+msgid ""
+"\n"
+"Writing 0x%02x, 0x%02x(%d) (%dms delay)...\n"
+msgstr ""
+"\n"
+"Zápis 0x%02x, 0x%02x (%d) (zpoždění %dms)...\n"
+
+#: ../src/ddccontrol/main.c:431
+#, c-format
+msgid ""
+"\n"
+"Writing 0x%02x, 0x%02x(%d)...\n"
+msgstr ""
+"\n"
+"Zápis 0x%02x, 0x%02x (%d)...\n"
+
+#: ../src/ddccontrol/main.c:436
+#, c-format
+msgid ""
+"\n"
+"Reading 0x%02x...\n"
+msgstr ""
+"\n"
+"Čtení 0x%02x...\n"
+
+#: ../src/ddccontrol/main.c:445
+#, fuzzy, c-format
+msgid "Applied profile: %s\n"
+msgstr "Apply Profil"
+
+#: ../src/ddccontrol/main.c:447
+#, c-format
+msgid "Failed to apply profile: %s\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:451
+#, c-format
+msgid ""
+"\n"
+"Controls (valid/current/max) [Description - Value name]:\n"
+msgstr ""
+"\n"
+"Ovládací prvky (platný/současný/max) [Popis - Název hodnoty]:\n"
+
+#: ../src/ddccontrol/main.c:473
+#, c-format
+msgid "\t\t> id=%s, name=%s, address=%#x, delay=%dms, type=%d\n"
+msgstr "\t\t> id=%s, název=%s adresa=%#x, zpoždění=%dms, typ=%d\n"
+
+#: ../src/ddccontrol/main.c:478
+#, c-format
+msgid "\t\t  Possible values:\n"
+msgstr "\t\t  Možné hodnoty:\n"
+
+#: ../src/ddccontrol/main.c:482
+#, c-format
+msgid "\t\t\t> id=%s - name=%s, value=%d\n"
+msgstr "\t\t\t> id=%s - název=%s, hodnota=%d\n"
+
+#: ../src/ddccontrol/main.c:492
+#, c-format
+msgid "\t\t  supported, value=%d, maximum=%d\n"
+msgstr "\t\t  podporován, hodnota=%d, maximum=%d\n"
+
+#: ../src/ddccontrol/main.c:493
+#, c-format
+msgid "\t\t  not supported, value=%d, maximum=%d\n"
+msgstr "\t\t  není podporován, hodnota=%d, maximum=%d\n"
+
+#: ../src/ddccontrol/main.c:504
+#, c-format
+msgid ""
+"\n"
+"Saving settings...\n"
+msgstr ""
+"\n"
+"Ukládá se nastavení...\n"
+
+#. Put a big warning (in red if we are writing to a terminal).
+#: ../src/ddccontrol/main.c:516 ../src/ddccontrol/main.c:537
+msgid "=============================== WARNING ==============================="
+msgstr ""
+"============================== VAROVÁNÍ ==============================="
+
+#: ../src/ddccontrol/main.c:519
 #, c-format
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is\n"
@@ -207,7 +362,7 @@ msgstr ""
 "použije obecný profil výrobce vašeho monitoru. Některé ovládací prvky\n"
 "nemusí být podporovány, nebo nemusí fungovat podle očekávání.\n"
 
-#: ../src/ddccontrol/main.c:363
+#: ../src/ddccontrol/main.c:524
 #, c-format
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is\n"
@@ -218,123 +373,24 @@ msgstr ""
 "použije základní obecný profil. Mnoho ovládacích prvků nebude podporováno,\n"
 "a některé nemusí fungovat podle očekávání.\n"
 
-#: ../src/ddccontrol/main.c:368
+#: ../src/ddccontrol/main.c:529
 #, c-format
 msgid ""
+"Unsupported monitor detected.\n"
+"\n"
 "Please update ddccontrol-db, or, if you are already using the latest\n"
-"version, please send the output of the following command to\n"
-"ddccontrol-users@lists.sourceforge.net:\n"
+"version, please open this pre-filled GitHub issue:\n"
 msgstr ""
-"Prosím aktualizujte ddccontrol-db, nebo, pokud jste již používáte\n"
-"nejnovější verzi, zašlete prosím výstup následujícího příkazu na\n"
-"ddccontrol-users@lists.sourceforge.net:\n"
 
-#: ../src/ddccontrol/main.c:372 ../src/gddccontrol/notebook.c:695
+#: ../src/ddccontrol/main.c:534
+#, c-format
+msgid "Then attach the resulting report file of the following command:\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:536 ../src/gddccontrol/notebook.c:715
 #, c-format
 msgid "Thank you.\n"
 msgstr "Děkujeme.\n"
-
-#: ../src/ddccontrol/main.c:377
-#, c-format
-msgid ""
-"\n"
-"Capabilities:\n"
-msgstr "\nSchopnosti:\n"
-
-#: ../src/ddccontrol/main.c:381
-#, c-format
-msgid "Raw output: %s\n"
-msgstr "Surový výstup: %s\n"
-
-#: ../src/ddccontrol/main.c:383
-#, c-format
-msgid "Parsed output: \n"
-msgstr "Analyzovaný výstup:\n"
-
-#: ../src/ddccontrol/main.c:392
-#, c-format
-msgid "\tType: "
-msgstr "\tTyp: "
-
-#: ../src/ddccontrol/main.c:395
-#, c-format
-msgid "LCD"
-msgstr "LCD"
-
-#: ../src/ddccontrol/main.c:398
-#, c-format
-msgid "CRT"
-msgstr "CRT"
-
-#: ../src/ddccontrol/main.c:401
-#, c-format
-msgid "Unknown"
-msgstr "Neznámý"
-
-#: ../src/ddccontrol/main.c:410
-#, c-format
-msgid "Capabilities read fail.\n"
-msgstr "Nezdařilo se načíst schopnosti.\n"
-
-#: ../src/ddccontrol/main.c:418
-#, c-format
-msgid ""
-"\n"
-"Writing 0x%02x, 0x%02x(%d) (%dms delay)...\n"
-msgstr "\nZápis 0x%02x, 0x%02x (%d) (zpoždění %dms)...\n"
-
-#: ../src/ddccontrol/main.c:422
-#, c-format
-msgid ""
-"\n"
-"Writing 0x%02x, 0x%02x(%d)...\n"
-msgstr "\nZápis 0x%02x, 0x%02x (%d)...\n"
-
-#: ../src/ddccontrol/main.c:427
-#, c-format
-msgid ""
-"\n"
-"Reading 0x%02x...\n"
-msgstr "\nČtení 0x%02x...\n"
-
-#: ../src/ddccontrol/main.c:434
-#, c-format
-msgid ""
-"\n"
-"Controls (valid/current/max) [Description - Value name]:\n"
-msgstr "\nOvládací prvky (platný/současný/max) [Popis - Název hodnoty]:\n"
-
-#: ../src/ddccontrol/main.c:458
-#, c-format
-msgid "\t\t> id=%s, name=%s, address=%#x, delay=%dms, type=%d\n"
-msgstr "\t\t> id=%s, název=%s adresa=%#x, zpoždění=%dms, typ=%d\n"
-
-#: ../src/ddccontrol/main.c:463
-#, c-format
-msgid "\t\t  Possible values:\n"
-msgstr "\t\t  Možné hodnoty:\n"
-
-#: ../src/ddccontrol/main.c:467
-#, c-format
-msgid "\t\t\t> id=%s - name=%s, value=%d\n"
-msgstr "\t\t\t> id=%s - název=%s, hodnota=%d\n"
-
-#: ../src/ddccontrol/main.c:477
-#, c-format
-msgid "\t\t  supported, value=%d, maximum=%d\n"
-msgstr "\t\t  podporován, hodnota=%d, maximum=%d\n"
-
-#: ../src/ddccontrol/main.c:478
-#, c-format
-msgid "\t\t  not supported, value=%d, maximum=%d\n"
-msgstr "\t\t  není podporován, hodnota=%d, maximum=%d\n"
-
-#: ../src/ddccontrol/main.c:489
-#, c-format
-msgid ""
-"\n"
-"Saving settings...\n"
-msgstr "\nUkládá se nastavení...\n"
 
 #. arbitration or no acknowledge
 #: ../src/ddcpci/i2c-algo-bit.c:368
@@ -353,7 +409,7 @@ msgstr "i2c-algo-bit.o: readbytes: čas i2c_inb vypršel.\n"
 msgid "i2c-algo-bit.o: readbytes: Timeout at ack\n"
 msgstr "i2c-algo-bit.o: readbytes: v ACK timeout\n"
 
-#: ../src/ddcpci/intel740.c:103 ../src/ddcpci/intel810.c:161
+#: ../src/ddcpci/intel740.c:103 ../src/ddcpci/intel810.c:162
 #: ../src/ddcpci/nvidia.c:155 ../src/ddcpci/radeon.c:209
 #: ../src/ddcpci/sis.c:174 ../src/ddcpci/via.c:167
 #, c-format
@@ -375,61 +431,61 @@ msgstr "%s: Chyba: neznámý typ karty (%#x)\n"
 msgid "%s: Malloc error."
 msgstr " %s: Chyba malloc."
 
-#: ../src/ddcpci/intel810.c:171
+#: ../src/ddcpci/intel810.c:172
 msgid "i810_open: cannot open /dev/mem"
 msgstr "i810_open: nelze otevřít /dev/mem"
 
-#: ../src/ddcpci/intel810.c:206
+#: ../src/ddcpci/intel810.c:207
 #, c-format
 msgid "i810_open: Error: cannot find any valid MMIO PCI region.\n"
 msgstr "i810_open: Chyba: nelze najít žádný platný MMIO PCI region.\n"
 
-#: ../src/ddcpci/intel810.c:213
+#: ../src/ddcpci/intel810.c:214
 msgid "i810_open: mmap failed"
 msgstr "i810_open: mmap selhalo"
 
-#: ../src/ddcpci/main.c:154
+#: ../src/ddcpci/main.c:160
 msgid "==>Error while sending open message"
 msgstr "==>Chyba při odesílání otevírací zprávy"
 
-#: ../src/ddcpci/main.c:178 ../src/ddcpci/main.c:184 ../src/ddcpci/main.c:202
+#: ../src/ddcpci/main.c:184 ../src/ddcpci/main.c:190 ../src/ddcpci/main.c:208
 msgid "==>Error while sending data answer message"
 msgstr "==>Chyba při odesílání dat zprávy s odpovědí"
 
-#: ../src/ddcpci/main.c:251 ../src/ddcpci/main.c:266
+#: ../src/ddcpci/main.c:257 ../src/ddcpci/main.c:272
 msgid "==>Error while sending list message"
 msgstr "==>Chyba při odesílání zprávy se seznamem"
 
-#: ../src/ddcpci/main.c:284
+#: ../src/ddcpci/main.c:290
 #, c-format
 msgid "Invalid arguments.\n"
 msgstr "Neplatné argumenty.\n"
 
-#: ../src/ddcpci/main.c:290
+#: ../src/ddcpci/main.c:296
 #, c-format
 msgid "==>Can't read verbosity.\n"
 msgstr "==>Nelze přečíst upovídanost.\n"
 
-#: ../src/ddcpci/main.c:297
+#: ../src/ddcpci/main.c:303
 #, c-format
 msgid "==>Can't read key.\n"
 msgstr "==>Nelze načíst klíč.\n"
 
-#: ../src/ddcpci/main.c:302
+#: ../src/ddcpci/main.c:308
 #, c-format
 msgid "==>Can't open key %u\n"
 msgstr "==>Nelze otevřít klíč %u\n"
 
-#: ../src/ddcpci/main.c:316
+#: ../src/ddcpci/main.c:322
 #, c-format
 msgid "==>No command received for %ld seconds, aborting.\n"
 msgstr "==>Během %ld sekund nebyl přijat Žádný příkaz, ruší se.\n"
 
-#: ../src/ddcpci/main.c:324
+#: ../src/ddcpci/main.c:330
 msgid "==>Error while receiving query\n"
 msgstr "==>Chyba při příjmu dotazu\n"
 
-#: ../src/ddcpci/main.c:359
+#: ../src/ddcpci/main.c:365
 #, c-format
 msgid "==>Invalid query...\n"
 msgstr "==>Neplatný dotaz...\n"
@@ -478,7 +534,7 @@ msgstr "via_open: cannot open /dev/mem"
 msgid "via_open: mmap failed"
 msgstr "via_open: mmap selhalo"
 
-#: ../src/gddccontrol/fspatterns.c:195
+#: ../src/gddccontrol/fspatterns.c:137
 msgid ""
 "Adjust brightness and contrast following these rules:\n"
 " - Black must be as dark as possible.\n"
@@ -490,11 +546,11 @@ msgstr ""
 "- Bílá by měla být tak jasná, jak je to možné.\n"
 "- Musíte být schopni rozlišit každou úroveň šedé (zvláště 0 a 12).\n"
 
-#: ../src/gddccontrol/fspatterns.c:211
+#: ../src/gddccontrol/fspatterns.c:259
 msgid "Try to make moire patterns disappear."
 msgstr "Snažte se, aby moaré vzorky zmizely."
 
-#: ../src/gddccontrol/fspatterns.c:215
+#: ../src/gddccontrol/fspatterns.c:263
 msgid ""
 "Adjust Image Lock Coarse to make the vertical band disappear.\n"
 "Adjust Image Lock Fine to minimize movement on the screen."
@@ -502,7 +558,7 @@ msgstr ""
 "Nastavte Hrubý zámek obrazu tak, aby zmizel svislý pruh.\n"
 "Minimalizujte pohyb obrazovce nastavením Jemného zámku obrazu."
 
-#: ../src/gddccontrol/fspatterns.c:254
+#: ../src/gddccontrol/fspatterns.c:273
 #, c-format
 msgid "Unknown fullscreen pattern name: %s"
 msgstr "Neznámý název celoobrazovkového vzorku: %s"
@@ -521,28 +577,29 @@ msgid ""
 "profiles"
 msgstr "Přednastavení monitoru (kontrastu, jasu,...) a správa profilů"
 
-#: ../src/gddccontrol/gprofile.c:53
+#: ../src/gddccontrol/gprofile.c:54
 msgid "You must select at least one control to be saved in the profile."
-msgstr "Musíte vybrat alespoň jeden ovládací prvek, které má být uložen v profilu."
+msgstr ""
+"Musíte vybrat alespoň jeden ovládací prvek, které má být uložen v profilu."
 
-#: ../src/gddccontrol/gprofile.c:61
+#: ../src/gddccontrol/gprofile.c:62
 msgid "Creating profile..."
 msgstr "Vytváří se profil..."
 
-#: ../src/gddccontrol/gprofile.c:76
+#: ../src/gddccontrol/gprofile.c:77
 msgid "Error while creating profile."
 msgstr "Chyba při vytváření profilu."
 
-#: ../src/gddccontrol/gprofile.c:93
+#: ../src/gddccontrol/gprofile.c:94
 msgid "Applying profile..."
 msgstr "Použití profilu..."
 
-#: ../src/gddccontrol/gprofile.c:116
+#: ../src/gddccontrol/gprofile.c:117
 #, c-format
 msgid "Are you sure you want to delete the profile '%s'?"
 msgstr "Jste si jisti, že chcete smazat profil ' %s'?"
 
-#: ../src/gddccontrol/gprofile.c:142
+#: ../src/gddccontrol/gprofile.c:143
 msgid ""
 "Please select the controls you want to save in the profile using the "
 "checkboxes to the left of each control."
@@ -550,78 +607,78 @@ msgstr ""
 "Prosím zvolte ovládací prvky, které chcete uložit do profilu pomocí "
 "zaškrtávací políčka nalevo od každé kontroly."
 
-#: ../src/gddccontrol/gprofile.c:174
+#: ../src/gddccontrol/gprofile.c:175
 msgid "Profile Manager"
 msgstr "Správce profilů"
 
-#: ../src/gddccontrol/gprofile.c:193
+#: ../src/gddccontrol/gprofile.c:199
 msgid "Apply profile"
 msgstr "Apply Profil"
 
-#: ../src/gddccontrol/gprofile.c:198
+#: ../src/gddccontrol/gprofile.c:208
 msgid "Show profile details / Rename profile"
 msgstr "Show details profil / Přejmenovat profil"
 
-#: ../src/gddccontrol/gprofile.c:203
+#: ../src/gddccontrol/gprofile.c:217
 msgid "Delete profile"
 msgstr "Smazat profil"
 
-#: ../src/gddccontrol/gprofile.c:229
+#: ../src/gddccontrol/gprofile.c:253
 msgid "Create profile"
 msgstr "Vytvořit profil"
 
-#: ../src/gddccontrol/gprofile.c:235
+#: ../src/gddccontrol/gprofile.c:259
 msgid "Close profile manager"
 msgstr "Zavřít profil manažera"
 
-#: ../src/gddccontrol/gprofile.c:299
+#: ../src/gddccontrol/gprofile.c:321
 msgid "Control name"
 msgstr "Control name"
 
-#: ../src/gddccontrol/gprofile.c:310
+#: ../src/gddccontrol/gprofile.c:332
 msgid "Value"
 msgstr "Value"
 
-#: ../src/gddccontrol/gprofile.c:313
+#: ../src/gddccontrol/gprofile.c:335
 msgid "Address"
 msgstr "Address"
 
-#: ../src/gddccontrol/gprofile.c:316
+#: ../src/gddccontrol/gprofile.c:338
 msgid "Raw value"
 msgstr "Raw hodnota"
 
-#: ../src/gddccontrol/gprofile.c:434 ../src/gddccontrol/gprofile.c:454
+#: ../src/gddccontrol/gprofile.c:456 ../src/gddccontrol/gprofile.c:476
 msgid "Profile information:"
 msgstr "Profil informace:"
 
-#: ../src/gddccontrol/gprofile.c:463
+#: ../src/gddccontrol/gprofile.c:485
 #, c-format
 msgid "File name: %s"
 msgstr "Název souboru: %s"
 
-#: ../src/gddccontrol/gprofile.c:474
+#: ../src/gddccontrol/gprofile.c:496
 msgid "Profile name:"
 msgstr "Název profilu"
 
 #. Save
-#: ../src/gddccontrol/gprofile.c:496
+#: ../src/gddccontrol/gprofile.c:518
 msgid "Saving profile..."
 msgstr "Saving profil..."
 
-#: ../src/gddccontrol/gprofile.c:505
+#: ../src/gddccontrol/gprofile.c:527
 msgid "Error while saving profile."
 msgstr "Chyba při ukládání profilu."
 
-#: ../src/gddccontrol/main.c:177
+#: ../src/gddccontrol/main.c:204
 #, c-format
 msgid "Monitor changed (%d %d).\n"
 msgstr "Monitor změna (%d %d).\n"
 
-#: ../src/gddccontrol/main.c:330
+#: ../src/gddccontrol/main.c:356
 msgid "Probing for available monitors..."
 msgstr "Probing k dispozici monitory..."
 
-#: ../src/gddccontrol/main.c:369
+#: ../src/gddccontrol/main.c:385
 msgid ""
 "No monitor supporting DDC/CI available.\n"
 "\n"
@@ -633,47 +690,47 @@ msgstr ""
 "Pokud vaše grafická karta potřebuje, Zkontrolujte, zda všechny požadované "
 "moduly jádra jsou zavedeny (I2C-dev, a vaše frame buffer řidiče)."
 
-#: ../src/gddccontrol/main.c:421
+#: ../src/gddccontrol/main.c:438
 msgid "Unable to initialize ddcci library, see console for more details.\n"
 msgstr "Nelze inicializovat knihovnu ddcci, viz konzole pro více informací.\n"
 
-#: ../src/gddccontrol/main.c:431
+#: ../src/gddccontrol/main.c:450
 msgid "Monitor settings"
 msgstr "Nastavení monitoru"
 
-#: ../src/gddccontrol/main.c:455
+#: ../src/gddccontrol/main.c:474
 msgid "Current monitor: "
 msgstr "Aktuální monitor: "
 
-#: ../src/gddccontrol/main.c:465
+#: ../src/gddccontrol/main.c:484
 msgid "Refresh monitor list"
 msgstr "Aktualizovat seznam monitorů"
 
-#: ../src/gddccontrol/main.c:482
+#: ../src/gddccontrol/main.c:507
 msgid "Profile manager"
 msgstr "Správce profilů"
 
-#: ../src/gddccontrol/main.c:489
+#: ../src/gddccontrol/main.c:514
 msgid "Save profile"
 msgstr "Uložit profil"
 
-#: ../src/gddccontrol/main.c:495
+#: ../src/gddccontrol/main.c:520
 msgid "Cancel profile creation"
 msgstr "Zrušit vytvoření profilu"
 
-#: ../src/gddccontrol/main.c:519
+#: ../src/gddccontrol/main.c:549
 msgid "OK"
 msgstr "OK"
 
-#: ../src/gddccontrol/main.c:547
+#: ../src/gddccontrol/main.c:585
 msgid "Refresh"
 msgstr "Aktualizovat"
 
-#: ../src/gddccontrol/main.c:547
+#: ../src/gddccontrol/main.c:585
 msgid "Refresh all controls"
 msgstr "Aktualizovat všechny ovládací prvky"
 
-#: ../src/gddccontrol/main.c:554
+#: ../src/gddccontrol/main.c:592
 msgid "Close"
 msgstr "Zavřít"
 
@@ -681,33 +738,33 @@ msgstr "Zavřít"
 #. gtk_misc_set_alignment(GTK_MISC(moninfo), 0, 0);
 #.
 #. gtk_table_attach(GTK_TABLE(table), moninfo, 0, 1, 1, 2, GTK_FILL_EXPAND, 0, 5, 5);
-#: ../src/gddccontrol/main.c:593
+#: ../src/gddccontrol/main.c:634
 #, c-format
 msgid "Welcome to gddccontrol %s."
 msgstr "Vítejte v gddccontrol %s."
 
-#: ../src/gddccontrol/notebook.c:81
+#: ../src/gddccontrol/notebook.c:83
 msgid "Error while getting value"
 msgstr "Chyba při získávání hodnoty"
 
-#: ../src/gddccontrol/notebook.c:116 ../src/gddccontrol/notebook.c:128
+#: ../src/gddccontrol/notebook.c:118 ../src/gddccontrol/notebook.c:130
 #, c-format
 msgid "Refreshing controls values (%d%%)..."
 msgstr "Aktualizují se nastavené hodnoty (%d %%)..."
 
-#: ../src/gddccontrol/notebook.c:133
+#: ../src/gddccontrol/notebook.c:135
 msgid "Could not get the control_db struct related to a control."
 msgstr "Nelze získat control_db struct související s ovládáním."
 
-#: ../src/gddccontrol/notebook.c:493
+#: ../src/gddccontrol/notebook.c:495
 msgid "Show fullscreen patterns"
 msgstr "Zobrazit celoobrazovkové vzory"
 
-#: ../src/gddccontrol/notebook.c:525
+#: ../src/gddccontrol/notebook.c:527
 msgid "Section"
 msgstr "Oddíl"
 
-#: ../src/gddccontrol/notebook.c:572
+#: ../src/gddccontrol/notebook.c:574
 msgid ""
 "The current monitor is in the database but does not support DDC/CI.\n"
 "\n"
@@ -719,11 +776,13 @@ msgid ""
 msgstr ""
 "Současný monitor je v databázi, ale nepodporuje DDC/CI.\n"
 "\n"
-"K tomu často dochází při připojení VGA/DVI kabelu na nevhodný vstup u monitorů, které podporují DDC/CI pouze na jednom ze dvou vstupů.\n"
+"K tomu často dochází při připojení VGA/DVI kabelu na nevhodný vstup "
+"u monitorů, které podporují DDC/CI pouze na jednom ze dvou vstupů.\n"
 "\n"
-"Pokud má váš monitor má dva vstupy, prosím, zkuste připojit kabel na jiný vstup, a potom klikněte na obnovovací tlačítko poblíž seznamu monitorů."
+"Pokud má váš monitor má dva vstupy, prosím, zkuste připojit kabel na jiný "
+"vstup, a potom klikněte na obnovovací tlačítko poblíž seznamu monitorů."
 
-#: ../src/gddccontrol/notebook.c:583
+#: ../src/gddccontrol/notebook.c:585
 #, c-format
 msgid "Opening the monitor device (%s)..."
 msgstr "Otvírá se zařízení monitoru (%s)..."
@@ -735,547 +794,563 @@ msgid ""
 "the monitor list."
 msgstr ""
 "Došlo k chybě při otevírání zařízení monitoru.\n"
-"Možná, že byl tento monitor odpojen, klikněte na obnovovací tlačítko poblíž seznamu monitorů."
+"Možná, že byl tento monitor odpojen, klikněte na obnovovací tlačítko poblíž "
+"seznamu monitorů."
 
 #: ../src/gddccontrol/notebook.c:600
 #, c-format
 msgid ""
-"The current monitor is not supported, please run\n"
-"%s\n"
-"and send the output to ddccontrol-users@lists.sourceforge.net.\n"
-"Thanks."
+"Unsupported monitor detected.\n"
+"\n"
+"Please update ddccontrol-db, or, if you are already using the latest\n"
+"version, please open a github issue:\n"
+"https://github.com/ddccontrol/ddccontrol-db/issues/new?template=unsupported-"
+"monitor.yml\n"
+"Then attach the resulting report file of the following command:"
 msgstr ""
-"Aktuální monitor není podporován, spusťte\n"
-"%s\n"
-"a odešlete výstup na ddccontrol-users@lists.sourceforge.net.\n"
-"Děkujeme."
 
-#: ../src/gddccontrol/notebook.c:620
+#: ../src/gddccontrol/notebook.c:622
 msgid "Please click on a group name."
 msgstr "Prosím, klikněte na název skupiny."
 
-#: ../src/gddccontrol/notebook.c:639 ../src/gddccontrol/notebook.c:650
+#: ../src/gddccontrol/notebook.c:647 ../src/gddccontrol/notebook.c:658
 #, c-format
 msgid "Getting controls values (%d%%)..."
 msgstr "Získávají se nastavené hodnoty (%d %%)..."
 
-#: ../src/gddccontrol/notebook.c:664
+#: ../src/gddccontrol/notebook.c:683
 msgid "Loading profiles..."
 msgstr "Čtou se profily..."
 
-#: ../src/gddccontrol/notebook.c:677
+#: ../src/gddccontrol/notebook.c:696
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is "
 "using a generic profile for your monitor's manufacturer. Some controls may "
 "not be supported, or may not work as expected.\n"
-msgstr "Váš monitor není zanesen v databázi, ale ddccontrol používá obecný profil výrobce monitoru. Některé ovládací prvky nemusí být podporovány nebo nemusí fungovat podle očekávání.\n"
+msgstr ""
+"Váš monitor není zanesen v databázi, ale ddccontrol používá obecný profil "
+"výrobce monitoru. Některé ovládací prvky nemusí být podporovány nebo nemusí "
+"fungovat podle očekávání.\n"
 
-#: ../src/gddccontrol/notebook.c:683
+#: ../src/gddccontrol/notebook.c:702
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is "
 "using a basic generic profile. Many controls will not be supported, and some "
 "controls may not work as expected.\n"
-msgstr "Váš monitor není zanesen v databázi, ale ddccontrol používá obecný profil. Mnohé ovládací prvky nebudou podporovány, některé nemusí fungovat podle očekávání.\n"
+msgstr ""
+"Váš monitor není zanesen v databázi, ale ddccontrol používá obecný profil. "
+"Mnohé ovládací prvky nebudou podporovány, některé nemusí fungovat podle "
+"očekávání.\n"
 
-#: ../src/gddccontrol/notebook.c:688
+#: ../src/gddccontrol/notebook.c:707
 msgid "Warning!"
 msgstr "Varování!"
 
-#: ../src/gddccontrol/notebook.c:690
+#: ../src/gddccontrol/notebook.c:709
 msgid ""
-"Please update ddccontrol-db, or, if you are already using the latest "
-"version, please send the output of the following command to ddccontrol-"
-"users@lists.sourceforge.net:\n"
-msgstr "Prosím aktualizujte ddccontrol-db, nebo, pokud již používáte nejnovější verzi, zašlete prosím výstup následujícího příkazu na  ddccontrol-users@lists.sourceforge.net:\n"
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.server.in.in.h:1
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:184
-msgid "Monitor Profile Switcher"
-msgstr "Přepínač profilů monitoru"
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.server.in.in.h:2
-msgid "Quickly switch monitor profiles created with gddccontrol"
-msgstr "Rychle přepíná profily monitoru vytvořené pomocí gddccontrol"
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.xml.h:1
-msgid "_About..."
-msgstr "_O aplikaci..."
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.xml.h:2
-msgid "_Properties..."
-msgstr "_Vlastosti..."
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.xml.h:3
-msgid "_Run gddccontrol..."
-msgstr "_Spustit gddccontrol..."
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:189
-msgid ""
-"An applet for quick switching of monitor profiles.\n"
-"Based on libddccontrol and part of the ddccontrol project.\n"
-"(http://ddccontrol.sourceforge.net)"
+"Unsupported monitor detected.\n"
+"\n"
+"Please update ddccontrol-db, or, if you are already using the latest\n"
+"version, please open a github issue:\n"
+"https://github.com/ddccontrol/ddccontrol-db/issues/new?template=unsupported-"
+"monitor.yml\n"
+"Then attach the resulting report file of the following command:\n"
 msgstr ""
-"Applet pro rychlé přepínání profilů monitoru.\n"
-"Založeno na libddccontrol a části projektu ddccontrol.\n"
-"(http://ddccontrol.sourceforge.net)"
 
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:386
-msgid "Unable to initialize ddcci library"
-msgstr "Nelze inicializovat knihovnu ddcci"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:390
-msgid "No monitor configuration found. Please run gddccontrol first"
-msgstr "Žádné konfigurace monitoru nebyly nalezeny. Spusťte nejdříve gddccontrol"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:395
-msgid "An error occurred while opening the monitor device"
-msgstr "Došlo k chybě při otevírání zařízení monitoru"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:400
-msgid "Can't find any profiles"
-msgstr "Žádné profily nebyly nalezeny"
-
-#. only reached, if init was not finished
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:416
-msgid "error"
-msgstr "chyba"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:440
-msgid "Monitor:"
-msgstr "Monitor:"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:443
-msgid "Monitor Profile Switcher Properties"
-msgstr "Vlastnosti přepínače profilů monitoru"
-
-#: ../src/lib/conf.c:61 ../src/lib/conf.c:258 ../src/lib/conf.c:308
-#: ../src/lib/ddcci.c:1202
+#: ../src/lib/conf.c:63 ../src/lib/conf.c:260 ../src/lib/conf.c:310
+#: ../src/lib/ddcci.c:1306
 msgid "Cannot create filename (buffer too small)\n"
 msgstr "Nelze vytvořit jméno souboru (buffer je příliš malý)\n"
 
-#: ../src/lib/conf.c:86 ../src/lib/conf.c:363 ../src/lib/monitor_db.c:350
-#: ../src/lib/monitor_db.c:714
+#: ../src/lib/conf.c:88 ../src/lib/conf.c:367 ../src/lib/monitor_db.c:353
+#: ../src/lib/monitor_db.c:726
 #, c-format
 msgid "Document not parsed successfully.\n"
 msgstr "Dokument nebyl analyzován úspěšně.\n"
 
-#: ../src/lib/conf.c:93 ../src/lib/conf.c:370
+#: ../src/lib/conf.c:95 ../src/lib/conf.c:375
 #, c-format
 msgid "empty profile file\n"
 msgstr "prázdný soubor profilu\n"
 
-#: ../src/lib/conf.c:99 ../src/lib/conf.c:376
+#: ../src/lib/conf.c:101 ../src/lib/conf.c:382
 #, c-format
 msgid "profile of the wrong type, root node %s != profile"
 msgstr "profil nevhodného typu, kořenový uzel %s! = profil"
 
-#: ../src/lib/conf.c:105
+#: ../src/lib/conf.c:107
 msgid "Can't find ddccontrolversion property."
 msgstr "Nebyla nalezena vlastnost verze dccontrol."
 
-#: ../src/lib/conf.c:107
+#: ../src/lib/conf.c:109
 #, c-format
 msgid "ddccontrol has been upgraded since monitorlist was saved (%s vs %s).\n"
-msgstr "ddccontrol byl od posledního zápisu seznamu monitorů aktualizován (%s proti %s).\n"
+msgstr ""
+"ddccontrol byl od posledního zápisu seznamu monitorů aktualizován (%s proti "
+"%s).\n"
 
-#: ../src/lib/conf.c:124
+#: ../src/lib/conf.c:126
 msgid "Can't find filename property."
 msgstr "Nebyla nalezena vlastnost jména souboru."
 
-#: ../src/lib/conf.c:130
+#: ../src/lib/conf.c:132
 msgid "Can't find supported property."
 msgstr "Nebyla nalezena vlastnost podpory."
 
-#: ../src/lib/conf.c:133
+#: ../src/lib/conf.c:135
 msgid "Can't convert supported property to int."
 msgstr "Cannot convert podporována vlastnost int."
 
-#: ../src/lib/conf.c:138 ../src/lib/conf.c:385 ../src/lib/monitor_db.c:90
-#: ../src/lib/monitor_db.c:194 ../src/lib/monitor_db.c:370
-#: ../src/lib/monitor_db.c:426 ../src/lib/monitor_db.c:447
+#: ../src/lib/conf.c:140 ../src/lib/conf.c:392 ../src/lib/monitor_db.c:92
+#: ../src/lib/monitor_db.c:196 ../src/lib/monitor_db.c:373
+#: ../src/lib/monitor_db.c:429 ../src/lib/monitor_db.c:450
 msgid "Can't find name property."
 msgstr "Nebylo nalezeno jméno vlastnosti."
 
-#: ../src/lib/conf.c:144
+#: ../src/lib/conf.c:146
 msgid "Can't find digital property."
 msgstr "Cannot find digitální majetek."
 
-#: ../src/lib/conf.c:147
+#: ../src/lib/conf.c:149
 msgid "Can't convert digital property to int."
 msgstr "Cannot convert digitální majetek int."
 
-#: ../src/lib/conf.c:175 ../src/lib/conf.c:439
+#: ../src/lib/conf.c:177 ../src/lib/conf.c:447
 msgid "Cannot create the xml writer\n"
 msgstr "Nelze vytvořit xml spisovatel\n"
 
-#: ../src/lib/conf.c:239
+#: ../src/lib/conf.c:241
 msgid "Cannot read control value\n"
 msgstr "Cannot read kontrolní hodnota\n"
 
-#: ../src/lib/conf.c:276
+#: ../src/lib/conf.c:278
 msgid "Cannot write control value\n"
 msgstr "Cannot write kontrolní hodnota\n"
 
-#: ../src/lib/conf.c:313
+#: ../src/lib/conf.c:315
 msgid "Error while opening ddccontrol home directory."
 msgstr "Chyba při otevírání ddccontrol domovském adresáři."
 
-#: ../src/lib/conf.c:337
+#: ../src/lib/conf.c:340
 msgid "Error while reading ddccontrol home directory."
 msgstr "Chyba při čtení ddccontrol domovském adresáři."
 
-#: ../src/lib/conf.c:382
+#: ../src/lib/conf.c:389
 msgid "Can't find pnpid property."
 msgstr "Cannot find pnpid majetku."
 
-#: ../src/lib/conf.c:388 ../src/lib/conf.c:391
+#: ../src/lib/conf.c:395 ../src/lib/conf.c:398
 msgid "Can't find version property."
 msgstr "Cannot find version majetku."
 
-#: ../src/lib/conf.c:390 ../src/lib/monitor_db.c:752
+#: ../src/lib/conf.c:397 ../src/lib/monitor_db.c:764
 msgid "Can't convert version to int."
 msgstr "Cannot convert int verzi."
 
-#: ../src/lib/conf.c:393
+#: ../src/lib/conf.c:400
 #, c-format
 msgid "profile version (%d) is not supported (should be %d).\n"
 msgstr "Profil verzi (%d) není podporován (měl by být %d).\n"
 
-#: ../src/lib/conf.c:407 ../src/lib/monitor_db.c:229
+#: ../src/lib/conf.c:415 ../src/lib/monitor_db.c:233
 msgid "Can't find address property."
 msgstr "Cannot find adresu majetku."
 
-#: ../src/lib/conf.c:409 ../src/lib/monitor_db.c:231
+#: ../src/lib/conf.c:417 ../src/lib/monitor_db.c:235
 msgid "Can't convert address to int."
 msgstr "Cannot convert adresu int."
 
-#: ../src/lib/conf.c:413 ../src/lib/monitor_db.c:112
+#: ../src/lib/conf.c:421 ../src/lib/monitor_db.c:114
 msgid "Can't find value property."
 msgstr "Cannot find hodnotu majetku."
 
-#: ../src/lib/conf.c:415 ../src/lib/monitor_db.c:114
+#: ../src/lib/conf.c:423 ../src/lib/monitor_db.c:116
 msgid "Can't convert value to int."
 msgstr "Cannot convert hodnotu int."
 
-#: ../src/lib/conf.c:499
+#: ../src/lib/conf.c:507
 msgid "ddcci_delete_profile: Error, cannot delete profile.\n"
 msgstr "ddcci_delete_profile: Chyba, nelze smazat profil.\n"
 
-#: ../src/lib/conf.c:519
+#: ../src/lib/conf.c:527
 #, c-format
 msgid "ddcci_delete_profile: Error, could not find the profile to delete.\n"
 msgstr "ddcci_delete_profile: Chyba, nemohl najít profil smazat.\n"
 
-#: ../src/lib/ddcci.c:146
+#: ../src/lib/ddcci.c:148
 msgid "Error while initialisating the message queue"
 msgstr "Chyba při init mentalis Racing fronta zpráv"
 
-#: ../src/lib/ddcci.c:175
+#: ../src/lib/ddcci.c:177
 msgid "Error while sending quit message"
 msgstr "Chyba při odesílání zprávy quit"
 
-#: ../src/lib/ddcci.c:221
+#: ../src/lib/ddcci.c:223
 msgid "Error while sending heartbeat message"
 msgstr "Chyba při odesílání zprávy Heartbeat"
 
-#: ../src/lib/ddcci.c:239
+#: ../src/lib/ddcci.c:241
 #, c-format
 msgid "Failed to initialize ddccontrol database...\n"
 msgstr "Nepodařilo se inicializovat ddccontrol databází...\n"
 
-#: ../src/lib/ddcci.c:275 ../src/lib/ddcci.c:350
+#: ../src/lib/ddcci.c:247
+#, fuzzy, c-format
+msgid "Failed to initialize ADL...\n"
+msgstr "Nepodařilo se inicializovat ddccontrol databází...\n"
+
+#: ../src/lib/ddcci.c:292 ../src/lib/ddcci.c:383
 #, c-format
 msgid "ioctl returned %d\n"
 msgstr "ioctl vrátil %d\n"
 
-#: ../src/lib/ddcci.c:300
+#: ../src/lib/ddcci.c:321
 msgid "Error while sending write message"
 msgstr "Chyba při odesílání zprávy napsat"
 
-#: ../src/lib/ddcci.c:309
+#: ../src/lib/ddcci.c:330
 msgid "Error while reading write message answer"
 msgstr "Chyba při čtení zprávy napsat odpověď"
 
-#: ../src/lib/ddcci.c:376
+#: ../src/lib/ddcci.c:413
 msgid "Error while sending read message"
 msgstr "Chyba při odesílání zprávy číst"
 
-#: ../src/lib/ddcci.c:385
+#: ../src/lib/ddcci.c:422
 msgid "Error while reading read message answer"
 msgstr "Chyba při čtení zprávy číst odpověď"
 
-#: ../src/lib/ddcci.c:475
+#: ../src/lib/ddcci.c:518
 #, c-format
 msgid "Invalid response, first byte is 0x%02x, should be 0x%02x\n"
 msgstr "Invalid odpověď, první bajt je 0x %02x, by měla být 0x %02x\n"
 
-#: ../src/lib/ddcci.c:485
+#: ../src/lib/ddcci.c:528
 #, c-format
 msgid "Non-fatal error: Invalid response, magic is 0x%02x\n"
 msgstr "Non-Fatal error: Neplatná odpověď, magie je 0x %02x\n"
 
-#: ../src/lib/ddcci.c:492
+#: ../src/lib/ddcci.c:535
 #, c-format
 msgid "Invalid response, length is %d, should be %d at most\n"
 msgstr "Invalid odpověď, délka %d, by měla být maximálně %d\n"
 
-#: ../src/lib/ddcci.c:505
+#: ../src/lib/ddcci.c:548
 #, c-format
 msgid "Invalid response, corrupted data - xor is 0x%02x, length 0x%02x\n"
 msgstr "Invalid odpověď, poškozená data - XOR je 0x %02x, délka 0x %02x\n"
 
-#: ../src/lib/ddcci.c:658 ../src/lib/ddcci.c:680
+#: ../src/lib/ddcci.c:709 ../src/lib/ddcci.c:731
 #, c-format
 msgid "Can't convert value to int, invalid CAPS (buf=%s, pos=%d).\n"
 msgstr "Cannot convert hodnotu int, neplatné Capsis (buf = %s, pos = %d).\n"
 
-#: ../src/lib/ddcci.c:763
+#: ../src/lib/ddcci.c:814
 #, c-format
 msgid "Invalid sequence in caps.\n"
 msgstr "Neplatná sekvence v víčka.\n"
 
-#: ../src/lib/ddcci.c:841
+#: ../src/lib/ddcci.c:892
 #, c-format
 msgid "Corrupted EDID at 0x%02x.\n"
 msgstr "Corrupted EDID na 0x %02x.\n"
 
-#: ../src/lib/ddcci.c:853
+#: ../src/lib/ddcci.c:904
 #, c-format
 msgid "Serial number: %d\n"
 msgstr "Sériové číslo: %d\n"
 
-#: ../src/lib/ddcci.c:856
+#: ../src/lib/ddcci.c:907
 #, c-format
 msgid "Manufactured: Week %d, %d\n"
 msgstr "Výrobce: Týden %d, %d\n"
 
-#: ../src/lib/ddcci.c:859
+#: ../src/lib/ddcci.c:910
 #, c-format
 msgid "EDID version: %d.%d\n"
 msgstr "EDID version: %d. %d\n"
 
-#: ../src/lib/ddcci.c:862
+#: ../src/lib/ddcci.c:913
 #, c-format
 msgid "Maximum size: %d x %d (cm)\n"
 msgstr "Maximální velikost: %d × %d (cm)\n"
 
-#: ../src/lib/ddcci.c:873
+#: ../src/lib/ddcci.c:924
 #, c-format
 msgid "Reading EDID 0x%02x failed.\n"
 msgstr "Reading EDID 0x %02x selhal.\n"
 
-#: ../src/lib/ddcci.c:903
+#: ../src/lib/ddcci.c:954
 #, c-format
 msgid "Device: %s\n"
 msgstr "Device: %s\n"
 
-#: ../src/lib/ddcci.c:917
+#: ../src/lib/ddcci.c:968
 msgid "Error while sending open message"
 msgstr "Chyba při odesílání zprávy otevřít"
 
-#: ../src/lib/ddcci.c:925
+#: ../src/lib/ddcci.c:976
 msgid "Error while reading open message answer"
 msgstr "Chyba při čtení zpráv otevřené odpověď"
 
-#: ../src/lib/ddcci.c:933
+#: ../src/lib/ddcci.c:988 ../src/lib/ddcci.c:1001
 #, c-format
 msgid "Invalid filename (%s).\n"
 msgstr "Neplatný název souboru (%s).\n"
 
-#: ../src/lib/ddcci.c:1049
+#: ../src/lib/ddcci.c:993
+#, c-format
+msgid "ADL display not found (%s).\n"
+msgstr ""
+
+#: ../src/lib/ddcci.c:1125
 #, c-format
 msgid "ddcci_open returned %d\n"
 msgstr "ddcci_open vrátil %d\n"
 
-#: ../src/lib/ddcci.c:1062
+#: ../src/lib/ddcci.c:1138
 #, c-format
 msgid "Unknown monitor (%s)"
 msgstr "Unknown monitor (%s)"
 
-#: ../src/lib/ddcci.c:1083
+#: ../src/lib/ddcci.c:1159
 #, c-format
 msgid "Probing for available monitors"
 msgstr "Probing k dispozici monitory"
 
-#: ../src/lib/ddcci.c:1097
+#: ../src/lib/ddcci.c:1173
 msgid "Error while sending list message"
 msgstr "Chyba při odesílání zprávy Seznam"
 
-#: ../src/lib/ddcci.c:1106
+#: ../src/lib/ddcci.c:1182
 msgid "Error while reading list entry"
 msgstr "Chyba při čtení seznamu položku"
 
-#: ../src/lib/ddcci.c:1123
+#: ../src/lib/ddcci.c:1199
 #, c-format
 msgid "Found PCI device (%s)\n"
 msgstr "Found PCI zařízení (%s)\n"
 
-#: ../src/lib/ddcci.c:1157
+#: ../src/lib/ddcci.c:1239
 #, c-format
 msgid "Found I2C device (%s)\n"
 msgstr "Found I2C zařízení (%s)\n"
 
-#: ../src/lib/ddcci.c:1206
+#: ../src/lib/ddcci.c:1264
+#, fuzzy, c-format
+msgid "Found ADL display (%s)\n"
+msgstr "Found PCI zařízení (%s)\n"
+
+#: ../src/lib/ddcci.c:1310
 msgid "Error while getting information about ddccontrol home directory."
 msgstr "Chyba při získávání informací o ddccontrol domovském adresáři."
 
-#: ../src/lib/ddcci.c:1211
+#: ../src/lib/ddcci.c:1316
 msgid "Error while creating ddccontrol home directory."
 msgstr "Chyba při vytváření ddccontrol domovském adresáři."
 
-#: ../src/lib/ddcci.c:1216
+#: ../src/lib/ddcci.c:1322
 msgid ""
 "Error while getting information about ddccontrol home directory after "
 "creating it."
 msgstr ""
 "Chyba při získávání informací o ddccontrol domovský adresář po vytvoření to."
 
-#: ../src/lib/ddcci.c:1223
+#: ../src/lib/ddcci.c:1330
 msgid "Error: '.ddccontrol' in your home directory is not a directory."
 msgstr "Error: '. ddccontrol' ve vašem domovském adresáři není adresář."
 
-#: ../src/lib/ddcci.c:1231
+#: ../src/lib/ddcci.c:1339
 msgid "Error while getting information about ddccontrol profile directory."
 msgstr "Chyba při získávání informací o ddccontrol profilu."
 
-#: ../src/lib/ddcci.c:1236
+#: ../src/lib/ddcci.c:1345
 msgid "Error while creating ddccontrol profile directory."
 msgstr "Chyba při vytváření ddccontrol profilu."
 
-#: ../src/lib/ddcci.c:1241
+#: ../src/lib/ddcci.c:1351
 msgid ""
 "Error while getting information about ddccontrol profile directory after "
 "creating it."
 msgstr "Chyba při získávání informací o ddccontrol profilu po vytvoření to."
 
-#: ../src/lib/ddcci.c:1248
+#: ../src/lib/ddcci.c:1359
 msgid ""
 "Error: '.ddccontrol/profiles' in your home directory is not a directory."
 msgstr ""
 "Error: '. ddccontrol / profiles' ve vašem domovském adresáři není adresář."
 
-#: ../src/lib/monitor_db.c:82 ../src/lib/monitor_db.c:192
+#: ../src/lib/monitor_db.c:84 ../src/lib/monitor_db.c:194
 msgid "Can't find id property."
 msgstr "Cannot find id majetku."
 
-#: ../src/lib/monitor_db.c:151 ../src/lib/monitor_db.c:546
+#: ../src/lib/monitor_db.c:153 ../src/lib/monitor_db.c:549
 #, c-format
 msgid "Element %s (id=%s) has not been found (line %ld).\n"
 msgstr "Element %s (id = %s) nebyl nalezen (řádek %ld).\n"
 
-#: ../src/lib/monitor_db.c:205
+#: ../src/lib/monitor_db.c:207
 msgid "Invalid refresh type (!= none, != all)."
 msgstr "Invalid Obnovit typ (! nula! = all)."
 
-#: ../src/lib/monitor_db.c:238
+#: ../src/lib/monitor_db.c:242
 #, c-format
 msgid "Control %s has been discarded by the caps string.\n"
 msgstr "Control %s byl odstraňují víčka řetězce.\n"
 
-#: ../src/lib/monitor_db.c:246
+#: ../src/lib/monitor_db.c:250
 #, c-format
 msgid "Control %s (0x%02x) has already been defined.\n"
 msgstr "Control %s (0x %02x) již byl definován.\n"
 
-#: ../src/lib/monitor_db.c:259
+#: ../src/lib/monitor_db.c:263
 msgid "Can't convert delay to int."
 msgstr "Cannot convert zpoždění int."
 
-#: ../src/lib/monitor_db.c:267
+#: ../src/lib/monitor_db.c:271
 msgid "Can't find type property."
 msgstr "Cannot find typu vlastnictví."
 
-#: ../src/lib/monitor_db.c:292 ../src/lib/monitor_db.c:381
+#: ../src/lib/monitor_db.c:296 ../src/lib/monitor_db.c:384
 msgid "Invalid type."
 msgstr "Neplatný typ."
 
-#: ../src/lib/monitor_db.c:343
+#: ../src/lib/monitor_db.c:346
 #, c-format
 msgid "Database must be inited before reading a monitor file.\n"
 msgstr "Database musí být před čtením inited monitor souboru.\n"
 
-#: ../src/lib/monitor_db.c:357
+#: ../src/lib/monitor_db.c:360
 #, c-format
 msgid "empty monitor/%s.xml\n"
 msgstr "empty monitor / %s.xml\n"
 
-#: ../src/lib/monitor_db.c:363
+#: ../src/lib/monitor_db.c:366
 #, c-format
 msgid "monitor/%s.xml of the wrong type, root node %s != monitor"
 msgstr "monitor / %s.xml o nevhodný typ, kořen %s! = monitor"
 
-#: ../src/lib/monitor_db.c:464
+#: ../src/lib/monitor_db.c:467
 msgid "Can't find add or remove property in caps."
 msgstr "Cannot find přidat či odebrat majetek čepice."
 
-#: ../src/lib/monitor_db.c:466
+#: ../src/lib/monitor_db.c:469
 msgid "Invalid remove caps."
 msgstr "Invalid odstranit čepice."
 
-#: ../src/lib/monitor_db.c:468
+#: ../src/lib/monitor_db.c:471
 msgid "Invalid add caps."
 msgstr "Invalid přidat čepice."
 
-#: ../src/lib/monitor_db.c:473
+#: ../src/lib/monitor_db.c:476
 #, c-format
 msgid "Error, include recursion level > 15 (file: %s).\n"
 msgstr "Error, včetně rekurze úrovni> 15 (soubor: %s).\n"
 
-#: ../src/lib/monitor_db.c:479
+#: ../src/lib/monitor_db.c:482
 msgid "Can't find file property."
 msgstr "Nelze nalézt soubor majetku."
 
-#: ../src/lib/monitor_db.c:487
+#: ../src/lib/monitor_db.c:490
 msgid "Two controls part in XML file."
 msgstr "Dva ovládací část v souboru XML."
 
-#: ../src/lib/monitor_db.c:534
+#: ../src/lib/monitor_db.c:537
 msgid "Error enumerating controls in subgroup."
 msgstr "Error výčtu ovládacích prvků v podskupině."
 
-#: ../src/lib/monitor_db.c:589
+#: ../src/lib/monitor_db.c:601
 #, c-format
 msgid "document of the wrong type, can't find controls or include.\n"
 msgstr "doklad o nevhodný typ, nemohou najít ovládací prvky nebo obsahují.\n"
 
-#: ../src/lib/monitor_db.c:721
+#: ../src/lib/monitor_db.c:733
 #, c-format
 msgid "empty options.xml\n"
 msgstr "empty options.xml\n"
 
-#: ../src/lib/monitor_db.c:728
+#: ../src/lib/monitor_db.c:740
 #, c-format
 msgid "options.xml of the wrong type, root node %s != options"
 msgstr "options.xml o nevhodný typ, kořen %s! = volby"
 
-#: ../src/lib/monitor_db.c:738
+#: ../src/lib/monitor_db.c:750
 #, c-format
 msgid "options.xml dbversion attribute missing, please update your database.\n"
 msgstr ""
 "options.xml dbversion atribut chybí, aktualizujte prosím své databázi.\n"
 
-#: ../src/lib/monitor_db.c:745
+#: ../src/lib/monitor_db.c:757
 #, c-format
 msgid "options.xml date attribute missing, please update your database.\n"
 msgstr "options.xml datum atribut chybí, aktualizujte prosím své databázi.\n"
 
-#: ../src/lib/monitor_db.c:755
+#: ../src/lib/monitor_db.c:767
 #, c-format
 msgid ""
 "options.xml dbversion (%d) is greater than the supported version (%d).\n"
 msgstr "options.xml dbversion (%d) je větší než podporovanou verzi (%d).\n"
 
-#: ../src/lib/monitor_db.c:756
+#: ../src/lib/monitor_db.c:768
 #, c-format
 msgid "Please update ddccontrol program.\n"
 msgstr "Prosím aktualizujte ddccontrol programu.\n"
 
-#: ../src/lib/monitor_db.c:763
+#: ../src/lib/monitor_db.c:775
 #, c-format
 msgid "options.xml dbversion (%d) is less than the supported version (%d).\n"
 msgstr "options.xml dbversion (%d) je menší než podporovanou verzi (%d).\n"
 
-#: ../src/lib/monitor_db.c:764
+#: ../src/lib/monitor_db.c:776
 #, c-format
 msgid "Please update ddccontrol database.\n"
 msgstr "Prosím aktualizujte ddccontrol databázi.\n"
+
+#~ msgid "Control"
+#~ msgstr "Ovládání"
+
+#~ msgid "Monitor Profile Switcher"
+#~ msgstr "Přepínač profilů monitoru"
+
+#~ msgid "Quickly switch monitor profiles created with gddccontrol"
+#~ msgstr "Rychle přepíná profily monitoru vytvořené pomocí gddccontrol"
+
+#~ msgid "_About..."
+#~ msgstr "_O aplikaci..."
+
+#~ msgid "_Properties..."
+#~ msgstr "_Vlastosti..."
+
+#~ msgid "_Run gddccontrol..."
+#~ msgstr "_Spustit gddccontrol..."
+
+#~ msgid ""
+#~ "An applet for quick switching of monitor profiles.\n"
+#~ "Based on libddccontrol and part of the ddccontrol project.\n"
+#~ "(http://ddccontrol.sourceforge.net)"
+#~ msgstr ""
+#~ "Applet pro rychlé přepínání profilů monitoru.\n"
+#~ "Založeno na libddccontrol a části projektu ddccontrol.\n"
+#~ "(http://ddccontrol.sourceforge.net)"
+
+#~ msgid "Unable to initialize ddcci library"
+#~ msgstr "Nelze inicializovat knihovnu ddcci"
+
+#~ msgid "No monitor configuration found. Please run gddccontrol first"
+#~ msgstr ""
+#~ "Žádné konfigurace monitoru nebyly nalezeny. Spusťte nejdříve gddccontrol"
+
+#~ msgid "An error occurred while opening the monitor device"
+#~ msgstr "Došlo k chybě při otevírání zařízení monitoru"
+
+#~ msgid "Can't find any profiles"
+#~ msgstr "Žádné profily nebyly nalezeny"
+
+#~ msgid "error"
+#~ msgstr "chyba"
+
+#~ msgid "Monitor:"
+#~ msgstr "Monitor:"
+
+#~ msgid "Monitor Profile Switcher Properties"
+#~ msgstr "Vlastnosti přepínače profilů monitoru"

--- a/po/de.po
+++ b/po/de.po
@@ -3,40 +3,38 @@
 # This file is distributed under the same license as the ddccontrol package.
 # Christian Schilling <cschilling@gmx.de>, 2005.
 # Chris Leick <c.leick@vollbio.de>, 2010.
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: ddccontrol 0.4.2-6\n"
-"Report-Msgid-Bugs-To: ddccontrol-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2006-07-27 23:14+0200\n"
+"Report-Msgid-Bugs-To: https://github.com/ddccontrol/ddccontrol/issues/\n"
+"POT-Creation-Date: 2026-05-13 15:12+0200\n"
 "PO-Revision-Date: 2010-06-21 19:47+0200\n"
 "Last-Translator: Chris Leick <c.leick@vollbio.de>\n"
 "Language-Team: German <debian-l10n-german@lists.debian.org>\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-
-#: ../src/ddccontrol/main.c:83 ../src/ddccontrol/main.c:87
-#: ../src/ddccontrol/main.c:91
-msgid "Control"
-msgstr "Steuerung"
-
-#: ../src/ddccontrol/main.c:132
-#, c-format
+#: ../src/ddccontrol/main.c:85
+#, fuzzy, c-format
 msgid ""
 "Usage:\n"
-"%s [-b datadir] [-v] [-c] [-d] [-f] [-s] [-r ctrl [-w value]] [-p | dev]\n"
+"%s [-b datadir] [-v] [-c] [-d] [-f] [-s] [-r ctrl [-w value]] [-l (profile "
+"path)] [-p | dev]\n"
 "\tdev: device, e.g. dev:/dev/i2c-0\n"
 "\t-p : probe I2C devices to find monitor buses\n"
 "\t-c : query capability\n"
 "\t-d : query ctrls 0 - 255\n"
 "\t-r : query ctrl\n"
 "\t-w : value to write to ctrl\n"
+"\t-W : relatively change ctrl value (+/-)\n"
 "\t-f : force (avoid validity checks)\n"
 "\t-s : save settings\n"
 "\t-v : verbosity (specify more to increase)\n"
 "\t-b : ddccontrol-db directory (if other than %s)\n"
+"\t-l : load values from XML profile file\n"
 msgstr ""
 "Aufruf:\n"
 "%s [-b Datenverzeichnis] [-v] [-c] [-d] [-f] [-s] [-r Steuerung [-w Wert]]\n"
@@ -52,22 +50,22 @@ msgstr ""
 "\t-v   : Detailgrad (mehr angeben zum Erhöhen)\n"
 "\t-b   : Ddccontrol-db-Verzeichnis (falls nicht %s)\n"
 
-#: ../src/ddccontrol/main.c:150 ../src/ddccontrol/main.c:172
+#: ../src/ddccontrol/main.c:106 ../src/ddccontrol/main.c:128
 #, c-format
 msgid "Checking %s integrity...\n"
 msgstr "Integrität von %s wird geprüft ...\n"
 
-#: ../src/ddccontrol/main.c:152 ../src/ddccontrol/main.c:174
+#: ../src/ddccontrol/main.c:108 ../src/ddccontrol/main.c:130
 #, c-format
 msgid "[ FAILED ]\n"
 msgstr "[ FEHLGESCHLAGEN ]\n"
 
-#: ../src/ddccontrol/main.c:156 ../src/ddccontrol/main.c:179
+#: ../src/ddccontrol/main.c:112 ../src/ddccontrol/main.c:135
 #, c-format
 msgid "[ OK ]\n"
 msgstr "[ OK ]\n"
 
-#: ../src/ddccontrol/main.c:217
+#: ../src/ddccontrol/main.c:194
 #, c-format
 msgid ""
 "ddccontrol version %s\n"
@@ -86,73 +84,88 @@ msgstr ""
 "Public License« weitergeben.\n"
 "\n"
 
-#: ../src/ddccontrol/main.c:236
+#: ../src/ddccontrol/main.c:211
 #, c-format
 msgid "'%s' does not seem to be a valid register name\n"
 msgstr "»%s« scheint kein gültiger Registername zu sein\n"
 
-#: ../src/ddccontrol/main.c:242
+#: ../src/ddccontrol/main.c:217
 #, c-format
 msgid "You cannot use -w parameter without -r.\n"
 msgstr "Sie können den Parameter -w nicht ohne -r benutzen.\n"
 
-#: ../src/ddccontrol/main.c:247
+#: ../src/ddccontrol/main.c:221 ../src/ddccontrol/main.c:231
 #, c-format
 msgid "'%s' does not seem to be a valid value.\n"
 msgstr "»%s« scheint kein gültiger Wert zu sein.\n"
 
-#: ../src/ddccontrol/main.c:292 ../src/gddccontrol/main.c:414
+#: ../src/ddccontrol/main.c:227
+#, fuzzy, c-format
+msgid "You cannot use -W parameter without -r.\n"
+msgstr "Sie können den Parameter -w nicht ohne -r benutzen.\n"
+
+#: ../src/ddccontrol/main.c:282 ../src/gddccontrol/main.c:432
 #, c-format
 msgid "Unable to initialize ddcci library.\n"
 msgstr "Die Ddcci-Bibliothek kann nicht initialisiert werden.\n"
 
-#: ../src/ddccontrol/main.c:304
+#: ../src/ddccontrol/main.c:288
+#, fuzzy, c-format
+msgid "Unable to initialize ddcci db library.\n"
+msgstr "Die Ddcci-Bibliothek kann nicht initialisiert werden.\n"
+
+#: ../src/ddccontrol/main.c:293
+#, c-format
+msgid "Failed to open D-Bus proxy, try with DDCCONTROL_NO_DAEMON=1.\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:310
 #, c-format
 msgid "Detected monitors :\n"
 msgstr "Gefundene Monitore:\n"
 
-#: ../src/ddccontrol/main.c:309
+#: ../src/ddccontrol/main.c:314
 #, c-format
 msgid " - Device: %s\n"
 msgstr " - Gerät: %s\n"
 
-#: ../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 #, c-format
 msgid "   DDC/CI supported: %s\n"
 msgstr "   DDC/CI unterstützt: %s\n"
 
-#: ../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 msgid "Yes"
 msgstr "Ja"
 
-#: ../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 msgid "No"
 msgstr "Nein"
 
-#: ../src/ddccontrol/main.c:311
+#: ../src/ddccontrol/main.c:316
 #, c-format
 msgid "   Monitor Name: %s\n"
 msgstr "   Monitorname: %s\n"
 
-#: ../src/ddccontrol/main.c:312
+#: ../src/ddccontrol/main.c:317
 #, c-format
 msgid "   Input type: %s\n"
 msgstr "   Eingabetyp: %s\n"
 
-#: ../src/ddccontrol/main.c:312 ../src/ddccontrol/main.c:350
+#: ../src/ddccontrol/main.c:317 ../src/ddccontrol/main.c:364
 msgid "Digital"
 msgstr "Digital"
 
-#: ../src/ddccontrol/main.c:312 ../src/ddccontrol/main.c:350
+#: ../src/ddccontrol/main.c:317 ../src/ddccontrol/main.c:364
 msgid "Analog"
 msgstr "Analog"
 
-#: ../src/ddccontrol/main.c:316
+#: ../src/ddccontrol/main.c:321
 #, c-format
 msgid "  (Automatically selected)\n"
 msgstr "  (Automatisch ausgewählt)\n"
 
-#: ../src/ddccontrol/main.c:326
+#: ../src/ddccontrol/main.c:333
 #, c-format
 msgid ""
 "No monitor supporting DDC/CI available.\n"
@@ -163,13 +176,13 @@ msgstr ""
 "Falls es Ihre Grafikkarte erfordert, prüfen Sie, ob alle benötigten "
 "Kernelmodule geladen sind (»i2c-dev« und Ihr Framebuffer-Treiber).\n"
 
-#: ../src/ddccontrol/main.c:339
-#, c-format
 # http://de.wikipedia.org/wiki/Extended_Display_Identification_Data
+#: ../src/ddccontrol/main.c:346
+#, c-format
 msgid "Reading EDID and initializing DDC/CI at bus %s...\n"
 msgstr "EDID wird gelesen und DDC/CI an Bus %s initialisiert ...\n"
 
-#: ../src/ddccontrol/main.c:343
+#: ../src/ddccontrol/main.c:357
 #, c-format
 msgid ""
 "\n"
@@ -182,7 +195,7 @@ msgstr ""
 "Falls es Ihre Grafikkarte erfordert, prüfen Sie, ob alle benötigten "
 "Kernelmodule geladen sind (»i2c-dev« und Ihr Framebuffer-Treiber).\n"
 
-#: ../src/ddccontrol/main.c:347
+#: ../src/ddccontrol/main.c:361
 #, c-format
 msgid ""
 "\n"
@@ -191,23 +204,157 @@ msgstr ""
 "\n"
 "Gelesene EDIDs:\n"
 
-#: ../src/ddccontrol/main.c:348
+#: ../src/ddccontrol/main.c:362
 #, c-format
 msgid "\tPlug and Play ID: %s [%s]\n"
 msgstr "\tPlug-and-Play-ID: %s [%s]\n"
 
-#: ../src/ddccontrol/main.c:350
+#: ../src/ddccontrol/main.c:364
 #, c-format
 msgid "\tInput type: %s\n"
 msgstr "\tEingabetyp: %s\n"
 
+#: ../src/ddccontrol/main.c:370
+#, c-format
+msgid ""
+"\n"
+"Capabilities:\n"
+msgstr ""
+"\n"
+"Möglichkeiten:\n"
+
+#: ../src/ddccontrol/main.c:374
+#, c-format
+msgid "Raw output: %s\n"
+msgstr "Unverarbeitete Ausgabe: %s\n"
+
+#: ../src/ddccontrol/main.c:376
+#, c-format
+msgid "Parsed output: \n"
+msgstr "Ausgewertete Ausgabe: \n"
+
+#: ../src/ddccontrol/main.c:385
+#, c-format
+msgid "\tType: "
+msgstr "\tTyp: "
+
+#: ../src/ddccontrol/main.c:388
+#, c-format
+msgid "LCD"
+msgstr "LCD"
+
+#: ../src/ddccontrol/main.c:391
+#, c-format
+msgid "CRT"
+msgstr "CRT"
+
+#: ../src/ddccontrol/main.c:394
+#, c-format
+msgid "Unknown"
+msgstr "Unbekannt"
+
+#: ../src/ddccontrol/main.c:403
+#, c-format
+msgid "Capabilities read fail.\n"
+msgstr "Lesen der Möglichkeiten fehlgeschlagen.\n"
+
+#: ../src/ddccontrol/main.c:417
+#, c-format
+msgid "Value cannot be lower than zero! %d -> %d\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:420
+#, c-format
+msgid "Value cannot be higher than maximum! %d / %d\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:428
+#, c-format
+msgid ""
+"\n"
+"Writing 0x%02x, 0x%02x(%d) (%dms delay)...\n"
+msgstr ""
+"\n"
+"0x%02x, 0x%02x(%d) (%dms Verzögerung) wird geschrieben ...\n"
+
+#: ../src/ddccontrol/main.c:431
+#, c-format
+msgid ""
+"\n"
+"Writing 0x%02x, 0x%02x(%d)...\n"
+msgstr ""
+"\n"
+"0x%02x, 0x%02x(%d) wird geschrieben ...\n"
+
+#: ../src/ddccontrol/main.c:436
+#, c-format
+msgid ""
+"\n"
+"Reading 0x%02x...\n"
+msgstr ""
+"\n"
+"0x%02x wird gelesen ...\n"
+
+#: ../src/ddccontrol/main.c:445
+#, fuzzy, c-format
+msgid "Applied profile: %s\n"
+msgstr "Profil anwenden"
+
+#: ../src/ddccontrol/main.c:447
+#, c-format
+msgid "Failed to apply profile: %s\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:451
+#, c-format
+msgid ""
+"\n"
+"Controls (valid/current/max) [Description - Value name]:\n"
+msgstr ""
+"\n"
+"Steuerungen (gültig/aktuell/maximal) [Beschreibung - Wertname]:\n"
+
+#: ../src/ddccontrol/main.c:473
+#, c-format
+msgid "\t\t> id=%s, name=%s, address=%#x, delay=%dms, type=%d\n"
+msgstr "\t\t> ID=%s, Name=%s, Adresse=%#x, Verzögerung=%dms, Typ=%d\n"
+
+#: ../src/ddccontrol/main.c:478
+#, c-format
+msgid "\t\t  Possible values:\n"
+msgstr "\t\t  Mögliche Werte:\n"
+
+#: ../src/ddccontrol/main.c:482
+#, c-format
+msgid "\t\t\t> id=%s - name=%s, value=%d\n"
+msgstr "\t\t\t> ID=%s - Name=%s, Wert=%d\n"
+
+#: ../src/ddccontrol/main.c:492
+#, c-format
+msgid "\t\t  supported, value=%d, maximum=%d\n"
+msgstr "\t\t  unterstützt, Wert=%d, Maximum=%d\n"
+
+#: ../src/ddccontrol/main.c:493
+#, c-format
+msgid "\t\t  not supported, value=%d, maximum=%d\n"
+msgstr "\t\t  nicht unterstützt, Wert=%d, Maximum=%d\n"
+
+#: ../src/ddccontrol/main.c:504
+#, c-format
+msgid ""
+"\n"
+"Saving settings...\n"
+msgstr ""
+"\n"
+"Einstellungen werden gespeichert ...\n"
+
 #. Put a big warning (in red if we are writing to a terminal).
-#: ../src/ddccontrol/main.c:354 ../src/ddccontrol/main.c:373
+#: ../src/ddccontrol/main.c:516 ../src/ddccontrol/main.c:537
 msgid "=============================== WARNING ==============================="
 msgstr ""
 "=============================== WARNUNG ==============================="
 
-#: ../src/ddccontrol/main.c:357
+#: ../src/ddccontrol/main.c:519
 #, c-format
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is\n"
@@ -219,7 +366,7 @@ msgstr ""
 "Monitors. Einige Steuerungen werden möglicherweise nicht unterstützt oder\n"
 "funktionieren möglicherweise nicht wie erwartet.\n"
 
-#: ../src/ddccontrol/main.c:363
+#: ../src/ddccontrol/main.c:524
 #, c-format
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is\n"
@@ -230,135 +377,24 @@ msgstr ""
 "Ddccontol benutzt ein allgemeines Profil. Viele Steuerungen werden nicht\n"
 "unterstützt und funktionieren möglicherweise nicht wie erwartet.\n"
 
-#: ../src/ddccontrol/main.c:368
+#: ../src/ddccontrol/main.c:529
 #, c-format
 msgid ""
+"Unsupported monitor detected.\n"
+"\n"
 "Please update ddccontrol-db, or, if you are already using the latest\n"
-"version, please send the output of the following command to\n"
-"ddccontrol-users@lists.sourceforge.net:\n"
+"version, please open this pre-filled GitHub issue:\n"
 msgstr ""
-"Bitte aktualisieren Sie Ddccontrol-db oder senden Sie die Ausgabe des\n"
-"folgenden Befehls an »ddccontrol-users@lists.sourceforge.net«, falls Sie\n"
-"bereits die neuste Version benutzen:\n"
 
-#: ../src/ddccontrol/main.c:372 ../src/gddccontrol/notebook.c:695
+#: ../src/ddccontrol/main.c:534
+#, c-format
+msgid "Then attach the resulting report file of the following command:\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:536 ../src/gddccontrol/notebook.c:715
 #, c-format
 msgid "Thank you.\n"
 msgstr "Vielen Dank.\n"
-
-#: ../src/ddccontrol/main.c:377
-#, c-format
-msgid ""
-"\n"
-"Capabilities:\n"
-msgstr ""
-"\n"
-"Möglichkeiten:\n"
-
-#: ../src/ddccontrol/main.c:381
-#, c-format
-msgid "Raw output: %s\n"
-msgstr "Unverarbeitete Ausgabe: %s\n"
-
-#: ../src/ddccontrol/main.c:383
-#, c-format
-msgid "Parsed output: \n"
-msgstr "Ausgewertete Ausgabe: \n"
-
-#: ../src/ddccontrol/main.c:392
-#, c-format
-msgid "\tType: "
-msgstr "\tTyp: "
-
-#: ../src/ddccontrol/main.c:395
-#, c-format
-msgid "LCD"
-msgstr "LCD"
-
-#: ../src/ddccontrol/main.c:398
-#, c-format
-msgid "CRT"
-msgstr "CRT"
-
-#: ../src/ddccontrol/main.c:401
-#, c-format
-msgid "Unknown"
-msgstr "Unbekannt"
-
-#: ../src/ddccontrol/main.c:410
-#, c-format
-msgid "Capabilities read fail.\n"
-msgstr "Lesen der Möglichkeiten fehlgeschlagen.\n"
-
-#: ../src/ddccontrol/main.c:418
-#, c-format
-msgid ""
-"\n"
-"Writing 0x%02x, 0x%02x(%d) (%dms delay)...\n"
-msgstr ""
-"\n"
-"0x%02x, 0x%02x(%d) (%dms Verzögerung) wird geschrieben ...\n"
-
-#: ../src/ddccontrol/main.c:422
-#, c-format
-msgid ""
-"\n"
-"Writing 0x%02x, 0x%02x(%d)...\n"
-msgstr ""
-"\n"
-"0x%02x, 0x%02x(%d) wird geschrieben ...\n"
-
-#: ../src/ddccontrol/main.c:427
-#, c-format
-msgid ""
-"\n"
-"Reading 0x%02x...\n"
-msgstr ""
-"\n"
-"0x%02x wird gelesen ...\n"
-
-#: ../src/ddccontrol/main.c:434
-#, c-format
-msgid ""
-"\n"
-"Controls (valid/current/max) [Description - Value name]:\n"
-msgstr ""
-"\n"
-"Steuerungen (gültig/aktuell/maximal) [Beschreibung - Wertname]:\n"
-
-#: ../src/ddccontrol/main.c:458
-#, c-format
-msgid "\t\t> id=%s, name=%s, address=%#x, delay=%dms, type=%d\n"
-msgstr "\t\t> ID=%s, Name=%s, Adresse=%#x, Verzögerung=%dms, Typ=%d\n"
-
-#: ../src/ddccontrol/main.c:463
-#, c-format
-msgid "\t\t  Possible values:\n"
-msgstr "\t\t  Mögliche Werte:\n"
-
-#: ../src/ddccontrol/main.c:467
-#, c-format
-msgid "\t\t\t> id=%s - name=%s, value=%d\n"
-msgstr "\t\t\t> ID=%s - Name=%s, Wert=%d\n"
-
-#: ../src/ddccontrol/main.c:477
-#, c-format
-msgid "\t\t  supported, value=%d, maximum=%d\n"
-msgstr "\t\t  unterstützt, Wert=%d, Maximum=%d\n"
-
-#: ../src/ddccontrol/main.c:478
-#, c-format
-msgid "\t\t  not supported, value=%d, maximum=%d\n"
-msgstr "\t\t  nicht unterstützt, Wert=%d, Maximum=%d\n"
-
-#: ../src/ddccontrol/main.c:489
-#, c-format
-msgid ""
-"\n"
-"Saving settings...\n"
-msgstr ""
-"\n"
-"Einstellungen werden gespeichert ...\n"
 
 #. arbitration or no acknowledge
 #: ../src/ddcpci/i2c-algo-bit.c:368
@@ -377,8 +413,9 @@ msgstr "i2c-algo-bit.o: Readbytes: i2c_inb Zeitüberschreitung.\n"
 msgid "i2c-algo-bit.o: readbytes: Timeout at ack\n"
 msgstr "i2c-algo-bit.o: Readbytes: Zeitüberschreitung bei Bestätigung\n"
 
-#: ../src/ddcpci/intel740.c:103 ../src/ddcpci/intel810.c:161
+#: ../src/ddcpci/intel740.c:103 ../src/ddcpci/intel810.c:162
 #: ../src/ddcpci/nvidia.c:155 ../src/ddcpci/radeon.c:209
+#: ../src/ddcpci/sis.c:174 ../src/ddcpci/via.c:167
 #, c-format
 msgid "%s: Malloc error.\n"
 msgstr "%s: Malloc-Fehler.\n"
@@ -398,62 +435,61 @@ msgstr "%s: Fehler: Unbekannter Kartentyp (%#x)\n"
 msgid "%s: Malloc error."
 msgstr "%s: Malloc-Fehler."
 
-#: ../src/ddcpci/intel810.c:171
+#: ../src/ddcpci/intel810.c:172
 msgid "i810_open: cannot open /dev/mem"
 msgstr "i810_open: /dev/mem kann nicht geöffnet werden"
 
-#: ../src/ddcpci/intel810.c:206
+#: ../src/ddcpci/intel810.c:207
 #, c-format
 msgid "i810_open: Error: cannot find any valid MMIO PCI region.\n"
-msgstr ""
-"i810_open: Fehler: Es wurde kein gültiger MMIO-PCI-Bereich gefunden.\n"
+msgstr "i810_open: Fehler: Es wurde kein gültiger MMIO-PCI-Bereich gefunden.\n"
 
-#: ../src/ddcpci/intel810.c:213
+#: ../src/ddcpci/intel810.c:214
 msgid "i810_open: mmap failed"
 msgstr "i810_open: Mmap fehlgeschlagen"
 
-#: ../src/ddcpci/main.c:154
+#: ../src/ddcpci/main.c:160
 msgid "==>Error while sending open message"
 msgstr "==>Fehler beim Senden der geöffneten Nachricht"
 
-#: ../src/ddcpci/main.c:178 ../src/ddcpci/main.c:184 ../src/ddcpci/main.c:202
+#: ../src/ddcpci/main.c:184 ../src/ddcpci/main.c:190 ../src/ddcpci/main.c:208
 msgid "==>Error while sending data answer message"
 msgstr "==>Fehler beim Senden der Daten-Antwortnachricht"
 
-#: ../src/ddcpci/main.c:251 ../src/ddcpci/main.c:266
+#: ../src/ddcpci/main.c:257 ../src/ddcpci/main.c:272
 msgid "==>Error while sending list message"
 msgstr "==>Fehler beim Senden der Listennachricht"
 
-#: ../src/ddcpci/main.c:284
+#: ../src/ddcpci/main.c:290
 #, c-format
 msgid "Invalid arguments.\n"
 msgstr "Ungültige Argumente.\n"
 
-#: ../src/ddcpci/main.c:290
+#: ../src/ddcpci/main.c:296
 #, c-format
 msgid "==>Can't read verbosity.\n"
 msgstr "==>Detailgrad kann nicht gelesen werden.\n"
 
-#: ../src/ddcpci/main.c:297
+#: ../src/ddcpci/main.c:303
 #, c-format
 msgid "==>Can't read key.\n"
 msgstr "==>Schlüssel kann nicht gelesen werden.\n"
 
-#: ../src/ddcpci/main.c:302
+#: ../src/ddcpci/main.c:308
 #, c-format
 msgid "==>Can't open key %u\n"
 msgstr "==>Schlüssel %u kann nicht geöffnet werden.\n"
 
-#: ../src/ddcpci/main.c:316
+#: ../src/ddcpci/main.c:322
 #, c-format
 msgid "==>No command received for %ld seconds, aborting.\n"
 msgstr "==>%ld Sekunden keinen Befehl empfangen, wird abgebrochen.\n"
 
-#: ../src/ddcpci/main.c:324
+#: ../src/ddcpci/main.c:330
 msgid "==>Error while receiving query\n"
 msgstr "==>Fehler beim Empfangen der Abfrage\n"
 
-#: ../src/ddcpci/main.c:359
+#: ../src/ddcpci/main.c:365
 #, c-format
 msgid "==>Invalid query...\n"
 msgstr "==>Ungültige Abfrage ...\n"
@@ -484,7 +520,27 @@ msgstr "radeon_open: /dev/mem kann nicht geöffnet werden"
 msgid "radeon_open: mmap failed"
 msgstr "radeon_open: Mmap fehlfeschlagen"
 
-#: ../src/gddccontrol/fspatterns.c:195
+#: ../src/ddcpci/sis.c:133
+#, fuzzy, c-format
+msgid "sis.c:init_i2c_bus: Malloc error."
+msgstr "nvidia.c:init_i2c_bus: Malloc-Fehler"
+
+#: ../src/ddcpci/via.c:125
+#, fuzzy, c-format
+msgid "via.c:init_i2c_bus: Malloc error."
+msgstr "nvidia.c:init_i2c_bus: Malloc-Fehler"
+
+#: ../src/ddcpci/via.c:177
+#, fuzzy
+msgid "via_open: cannot open /dev/mem"
+msgstr "nvidia_open: /dev/mem kann nicht geöffnet werden"
+
+#: ../src/ddcpci/via.c:186
+#, fuzzy
+msgid "via_open: mmap failed"
+msgstr "nvidia_open: Mmap fehlfeschlagen"
+
+#: ../src/gddccontrol/fspatterns.c:137
 msgid ""
 "Adjust brightness and contrast following these rules:\n"
 " - Black must be as dark as possible.\n"
@@ -496,11 +552,11 @@ msgstr ""
 " - Weiß sollte so hell wie möglich sein.\n"
 " - Sie müssen jede Graustufe unterscheiden können (insbesondere 0 und 12).\n"
 
-#: ../src/gddccontrol/fspatterns.c:211
+#: ../src/gddccontrol/fspatterns.c:259
 msgid "Try to make moire patterns disappear."
 msgstr "Versuchen, flammenartige Muster verschwinden zu lassen"
 
-#: ../src/gddccontrol/fspatterns.c:215
+#: ../src/gddccontrol/fspatterns.c:263
 msgid ""
 "Adjust Image Lock Coarse to make the vertical band disappear.\n"
 "Adjust Image Lock Fine to minimize movement on the screen."
@@ -508,114 +564,130 @@ msgstr ""
 "Grobe Bildsperre anpassen, um vertikales Band verschwinden zu lassen.\n"
 "Feine Bildsperre anpassen, um Bewegung auf dem Bildschirm zu minimieren."
 
-#: ../src/gddccontrol/fspatterns.c:254
+#: ../src/gddccontrol/fspatterns.c:273
 #, c-format
 msgid "Unknown fullscreen pattern name: %s"
 msgstr "Unbekannter Mustername für Vollbild: %s"
 
-#: ../src/gddccontrol/gprofile.c:53
+#: ../src/gddccontrol/gddccontrol.desktop.in.h:1
+#, fuzzy
+msgid "DDC Control"
+msgstr "Steuerung"
+
+#: ../src/gddccontrol/gddccontrol.desktop.in.h:2
+#, fuzzy
+msgid "Monitor Settings"
+msgstr "Bildschirmeinstellungen"
+
+#: ../src/gddccontrol/gddccontrol.desktop.in.h:3
+msgid ""
+"Set your monitor preferences (contrast, brightness,...) and manage your "
+"profiles"
+msgstr ""
+
+#: ../src/gddccontrol/gprofile.c:54
 msgid "You must select at least one control to be saved in the profile."
 msgstr ""
 "Sie müssen mindestens eine Steuerung zum Speichern in diesem Profil\n"
 "auswählen."
 
-#: ../src/gddccontrol/gprofile.c:61
+#: ../src/gddccontrol/gprofile.c:62
 msgid "Creating profile..."
 msgstr "Profil wird erstellt ..."
 
-#: ../src/gddccontrol/gprofile.c:76
+#: ../src/gddccontrol/gprofile.c:77
 msgid "Error while creating profile."
 msgstr "Fehler beim Erstellen des Profils"
 
-#: ../src/gddccontrol/gprofile.c:93
+#: ../src/gddccontrol/gprofile.c:94
 msgid "Applying profile..."
 msgstr "Profil wird angewandt ..."
 
-#: ../src/gddccontrol/gprofile.c:116
+#: ../src/gddccontrol/gprofile.c:117
 #, c-format
 msgid "Are you sure you want to delete the profile '%s'?"
 msgstr "Sind Sie sicher, dass Sie das Profil »%s« löschen wollen?"
 
-#: ../src/gddccontrol/gprofile.c:142
+#: ../src/gddccontrol/gprofile.c:143
 msgid ""
 "Please select the controls you want to save in the profile using the "
 "checkboxes to the left of each control."
 msgstr ""
-"Bitte wählen Sie die Steuerungen, die Sie im Profil speichern möchten, "
-"indem Sie die Auswahlkästchen links von jeder Steuerung benutzen."
+"Bitte wählen Sie die Steuerungen, die Sie im Profil speichern möchten, indem "
+"Sie die Auswahlkästchen links von jeder Steuerung benutzen."
 
-#: ../src/gddccontrol/gprofile.c:174
+#: ../src/gddccontrol/gprofile.c:175
 msgid "Profile Manager"
 msgstr "Profilverwaltung"
 
-#: ../src/gddccontrol/gprofile.c:193
+#: ../src/gddccontrol/gprofile.c:199
 msgid "Apply profile"
 msgstr "Profil anwenden"
 
-#: ../src/gddccontrol/gprofile.c:198
+#: ../src/gddccontrol/gprofile.c:208
 msgid "Show profile details / Rename profile"
 msgstr "Profildetails anzeigen / Profil umbenennen"
 
-#: ../src/gddccontrol/gprofile.c:203
+#: ../src/gddccontrol/gprofile.c:217
 msgid "Delete profile"
 msgstr "Profil löschen"
 
-#: ../src/gddccontrol/gprofile.c:229
+#: ../src/gddccontrol/gprofile.c:253
 msgid "Create profile"
 msgstr "Profil erstellen"
 
-#: ../src/gddccontrol/gprofile.c:235
+#: ../src/gddccontrol/gprofile.c:259
 msgid "Close profile manager"
 msgstr "Profilverwaltung schließen"
 
-#: ../src/gddccontrol/gprofile.c:299
+#: ../src/gddccontrol/gprofile.c:321
 msgid "Control name"
 msgstr "Steuerungsname"
 
-#: ../src/gddccontrol/gprofile.c:310
+#: ../src/gddccontrol/gprofile.c:332
 msgid "Value"
 msgstr "Wert"
 
-#: ../src/gddccontrol/gprofile.c:313
+#: ../src/gddccontrol/gprofile.c:335
 msgid "Address"
 msgstr "Adresse"
 
-#: ../src/gddccontrol/gprofile.c:316
+#: ../src/gddccontrol/gprofile.c:338
 msgid "Raw value"
 msgstr "Roher Wert"
 
-#: ../src/gddccontrol/gprofile.c:434 ../src/gddccontrol/gprofile.c:454
+#: ../src/gddccontrol/gprofile.c:456 ../src/gddccontrol/gprofile.c:476
 msgid "Profile information:"
 msgstr "Profilinformationen:"
 
-#: ../src/gddccontrol/gprofile.c:463
+#: ../src/gddccontrol/gprofile.c:485
 #, c-format
 msgid "File name: %s"
 msgstr "Dateiname: %s"
 
-#: ../src/gddccontrol/gprofile.c:474
+#: ../src/gddccontrol/gprofile.c:496
 msgid "Profile name:"
 msgstr "Profilname:"
 
 #. Save
-#: ../src/gddccontrol/gprofile.c:496
+#: ../src/gddccontrol/gprofile.c:518
 msgid "Saving profile..."
 msgstr "Profil wird gespeichert ..."
 
-#: ../src/gddccontrol/gprofile.c:505
+#: ../src/gddccontrol/gprofile.c:527
 msgid "Error while saving profile."
 msgstr "Fehler beim Speichern des Profils"
 
-#: ../src/gddccontrol/main.c:177
+#: ../src/gddccontrol/main.c:204
 #, c-format
 msgid "Monitor changed (%d %d).\n"
 msgstr "Monitor geändert (%d %d)\n"
 
-#: ../src/gddccontrol/main.c:329
+#: ../src/gddccontrol/main.c:356
 msgid "Probing for available monitors..."
 msgstr "Es wird nach verfügbaren Monitoren gesucht ..."
 
-#: ../src/gddccontrol/main.c:368
+#: ../src/gddccontrol/main.c:385
 msgid ""
 "No monitor supporting DDC/CI available.\n"
 "\n"
@@ -627,50 +699,49 @@ msgstr ""
 "Falls es Ihre Grafikkarte erfordert, prüfen Sie, ob alle benötigten "
 "Kernelmodule geladen sind (»i2c-dev« und Ihr Framebuffer-Treiber)."
 
-
-#: ../src/gddccontrol/main.c:420
+#: ../src/gddccontrol/main.c:438
 msgid "Unable to initialize ddcci library, see console for more details.\n"
 msgstr ""
 "Ddcci-Bibliothek kann nicht initialisiert werden. Schauen Sie in die\n"
 "Konsole, um weitere Details zu erhalten.\n"
 
-#: ../src/gddccontrol/main.c:430
+#: ../src/gddccontrol/main.c:450
 msgid "Monitor settings"
 msgstr "Bildschirmeinstellungen"
 
-#: ../src/gddccontrol/main.c:454
+#: ../src/gddccontrol/main.c:474
 msgid "Current monitor: "
 msgstr "Aktueller Monitor: "
 
-#: ../src/gddccontrol/main.c:464
+#: ../src/gddccontrol/main.c:484
 msgid "Refresh monitor list"
 msgstr "Monitorliste aktualisieren"
 
-#: ../src/gddccontrol/main.c:481
+#: ../src/gddccontrol/main.c:507
 msgid "Profile manager"
 msgstr "Profilverwaltung"
 
-#: ../src/gddccontrol/main.c:488
+#: ../src/gddccontrol/main.c:514
 msgid "Save profile"
 msgstr "Profil speichern"
 
-#: ../src/gddccontrol/main.c:494
+#: ../src/gddccontrol/main.c:520
 msgid "Cancel profile creation"
 msgstr "Erstellen des Profils abbrechen"
 
-#: ../src/gddccontrol/main.c:518
+#: ../src/gddccontrol/main.c:549
 msgid "OK"
 msgstr "OK"
 
-#: ../src/gddccontrol/main.c:546
+#: ../src/gddccontrol/main.c:585
 msgid "Refresh"
 msgstr "Aktualisieren"
 
-#: ../src/gddccontrol/main.c:546
+#: ../src/gddccontrol/main.c:585
 msgid "Refresh all controls"
 msgstr "Alle Steuerungen aktualisieren"
 
-#: ../src/gddccontrol/main.c:553
+#: ../src/gddccontrol/main.c:592
 msgid "Close"
 msgstr "Schließen"
 
@@ -678,35 +749,35 @@ msgstr "Schließen"
 #. gtk_misc_set_alignment(GTK_MISC(moninfo), 0, 0);
 #.
 #. gtk_table_attach(GTK_TABLE(table), moninfo, 0, 1, 1, 2, GTK_FILL_EXPAND, 0, 5, 5);
-#: ../src/gddccontrol/main.c:592
+#: ../src/gddccontrol/main.c:634
 #, c-format
 msgid "Welcome to gddccontrol %s."
 msgstr "Willkommen zu Gddccontrol %s."
 
-#: ../src/gddccontrol/notebook.c:81
+#: ../src/gddccontrol/notebook.c:83
 msgid "Error while getting value"
 msgstr "Fehler bei der Abfrage des Wertes"
 
-#: ../src/gddccontrol/notebook.c:116 ../src/gddccontrol/notebook.c:128
+#: ../src/gddccontrol/notebook.c:118 ../src/gddccontrol/notebook.c:130
 #, c-format
 msgid "Refreshing controls values (%d%%)..."
 msgstr "Steuerungswerte werden aktualisiert (%d%%) ..."
 
-#: ../src/gddccontrol/notebook.c:133
+#: ../src/gddccontrol/notebook.c:135
 msgid "Could not get the control_db struct related to a control."
 msgstr ""
-"Die Struktur »control_db«, die sich auf eine Steuerung bezieht, konnte "
-"nicht abgefragt werden."
+"Die Struktur »control_db«, die sich auf eine Steuerung bezieht, konnte nicht "
+"abgefragt werden."
 
-#: ../src/gddccontrol/notebook.c:493
+#: ../src/gddccontrol/notebook.c:495
 msgid "Show fullscreen patterns"
 msgstr "Vollbildmuster anzeigen"
 
-#: ../src/gddccontrol/notebook.c:525
+#: ../src/gddccontrol/notebook.c:527
 msgid "Section"
 msgstr "Abschnitt"
 
-#: ../src/gddccontrol/notebook.c:572
+#: ../src/gddccontrol/notebook.c:574
 msgid ""
 "The current monitor is in the database but does not support DDC/CI.\n"
 "\n"
@@ -718,15 +789,15 @@ msgid ""
 msgstr ""
 "Der aktuelle Monitor ist in der Datenbank, unterstützt jedoch kein DDC/CI.\n"
 "\n"
-"Dies tritt oft dann auf, wenn Sie ein VGA-/DVI-Kabel an den falschen "
-"Eingang eines Monitors mit zwei Eingängen anschließen, von denen nur einer "
-"DDC/CI unterstützt.\n"
+"Dies tritt oft dann auf, wenn Sie ein VGA-/DVI-Kabel an den falschen Eingang "
+"eines Monitors mit zwei Eingängen anschließen, von denen nur einer DDC/CI "
+"unterstützt.\n"
 "\n"
 "Falls Ihr Monitor zwei Eingänge hat, versuchen Sie das Kabel in den anderen "
 "Eingang zu stecken und klicken Sie auf den Aktualisierungsknopf bei der "
 "Monitorliste."
 
-#: ../src/gddccontrol/notebook.c:583
+#: ../src/gddccontrol/notebook.c:585
 #, c-format
 msgid "Opening the monitor device (%s)..."
 msgstr "Das Monitor (%s) wird geöffnet ..."
@@ -744,576 +815,582 @@ msgstr ""
 #: ../src/gddccontrol/notebook.c:600
 #, c-format
 msgid ""
-"The current monitor is not supported, please run\n"
-"%s\n"
-"and send the output to ddccontrol-users@lists.sourceforge.net.\n"
-"Thanks."
+"Unsupported monitor detected.\n"
+"\n"
+"Please update ddccontrol-db, or, if you are already using the latest\n"
+"version, please open a github issue:\n"
+"https://github.com/ddccontrol/ddccontrol-db/issues/new?template=unsupported-"
+"monitor.yml\n"
+"Then attach the resulting report file of the following command:"
 msgstr ""
-"Der aktuelle Monitor wird nicht unterstützt. Bitte führen Sie\n"
-"%s aus und senden Sie die Ausgabe an\n"
-"»ddccontrol-users@lists.sourceforge.net«. Vielen Dank."
 
-#: ../src/gddccontrol/notebook.c:620
+#: ../src/gddccontrol/notebook.c:622
 msgid "Please click on a group name."
 msgstr "Bitte klicken Sie auf einen Gruppennamen."
 
-#: ../src/gddccontrol/notebook.c:639 ../src/gddccontrol/notebook.c:650
+#: ../src/gddccontrol/notebook.c:647 ../src/gddccontrol/notebook.c:658
 #, c-format
 msgid "Getting controls values (%d%%)..."
 msgstr "Steuerungswerte (%d%%) werden abgefragt ..."
 
-#: ../src/gddccontrol/notebook.c:664
+#: ../src/gddccontrol/notebook.c:683
 msgid "Loading profiles..."
 msgstr "Profile werden geladen ..."
 
-#: ../src/gddccontrol/notebook.c:677
+#: ../src/gddccontrol/notebook.c:696
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is "
 "using a generic profile for your monitor's manufacturer. Some controls may "
 "not be supported, or may not work as expected.\n"
 msgstr ""
 "Für Ihren Monitor gibt es keine Unterstützung in der Datenbank, aber "
-"Ddccontrol benutzt ein allgemeines Profil für Ihren Monitorhersteller. "
-"Es könnte sein, daß einige Steuerungen nicht unterstützt werden oder nicht "
-"wie erwartet funktionieren.\n"
+"Ddccontrol benutzt ein allgemeines Profil für Ihren Monitorhersteller. Es "
+"könnte sein, daß einige Steuerungen nicht unterstützt werden oder nicht wie "
+"erwartet funktionieren.\n"
 
-#: ../src/gddccontrol/notebook.c:683
+#: ../src/gddccontrol/notebook.c:702
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is "
 "using a basic generic profile. Many controls will not be supported, and some "
 "controls may not work as expected.\n"
 msgstr ""
 "Für Ihren Monitor gibt es keine Unterstützung in der Datenbank, aber "
-"Ddccontrol benutzt ein allgemeines Profil für Ihren Monitorhersteller. "
-"Viele Steuerungen werden nicht unterstützt und einige Steuerungen könnten "
-"nicht wie erwartet funktionieren.\n"
+"Ddccontrol benutzt ein allgemeines Profil für Ihren Monitorhersteller. Viele "
+"Steuerungen werden nicht unterstützt und einige Steuerungen könnten nicht "
+"wie erwartet funktionieren.\n"
 
-#: ../src/gddccontrol/notebook.c:688
+#: ../src/gddccontrol/notebook.c:707
 msgid "Warning!"
 msgstr "Warnung"
 
-#: ../src/gddccontrol/notebook.c:690
+#: ../src/gddccontrol/notebook.c:709
 msgid ""
-"Please update ddccontrol-db, or, if you are already using the latest "
-"version, please send the output of the following command to ddccontrol-"
-"users@lists.sourceforge.net:\n"
+"Unsupported monitor detected.\n"
+"\n"
+"Please update ddccontrol-db, or, if you are already using the latest\n"
+"version, please open a github issue:\n"
+"https://github.com/ddccontrol/ddccontrol-db/issues/new?template=unsupported-"
+"monitor.yml\n"
+"Then attach the resulting report file of the following command:\n"
 msgstr ""
-"Bitte aktualisieren Sie »ddccontrol-db« oder senden Sie die Ausgabe des "
-"folgenden Befehls an »ddccontrol-users@lists.sourceforge.net«, falls Sie "
-"bereits die neuste Version verwenden:\n"
 
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.server.in.in.h:1
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:184
-msgid "Monitor Profile Switcher"
-msgstr "Monitor-Profilumschalter"
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.server.in.in.h:2
-msgid "Quickly switch monitor profiles created with gddccontrol"
-msgstr ""
-"Schnelles Umschalten zwischen Profilen, die mit Gddccontrol erstellt wurden"
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.xml.h:1
-msgid "_About..."
-msgstr "_Über ..."
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.xml.h:2
-msgid "_Properties..."
-msgstr "_Eigenschaften ..."
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.xml.h:3
-msgid "_Run gddccontrol..."
-msgstr "_Gddccontrol ausführen ..."
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:189
-msgid ""
-"An applet for quick switching of monitor profiles.\n"
-"Based on libddccontrol and part of the ddccontrol project.\n"
-"(http://ddccontrol.sourceforge.net)"
-msgstr ""
-"Ein Applet zum schnellen Wechseln zwischen Bildschirmprofilen.\n"
-"Basiert auf Libddccontrol und ist Teil des Ddccontrol-Projektes.\n"
-"(http://ddccontrol.sourceforge.net)"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:386
-msgid "Unable to initialize ddcci library"
-msgstr "»ddcci«-Bibliothek kann nicht initialisiert werden"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:390
-msgid "No monitor configuration found. Please run gddccontrol first"
-msgstr ""
-"Keine Monitorkonfiguration gefunden. Bitte führen Sie zuerst Gddccontrol aus"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:395
-msgid "An error occurred while opening the monitor device"
-msgstr "Beim Öffnen dess Monitors ist ein Fehler aufgetreten"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:400
-msgid "Can't find any profiles"
-msgstr "Es wurden keine Profile gefunden"
-
-#. only reached, if init was not finished
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:416
-msgid "error"
-msgstr "Fehler"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:440
-msgid "Monitor:"
-msgstr "Monitor:"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:443
-msgid "Monitor Profile Switcher Properties"
-msgstr "Eigenschaften des Monitor-Profilumschalters"
-
-#: ../src/lib/conf.c:61 ../src/lib/conf.c:258 ../src/lib/conf.c:308
-#: ../src/lib/ddcci.c:1202
+#: ../src/lib/conf.c:63 ../src/lib/conf.c:260 ../src/lib/conf.c:310
+#: ../src/lib/ddcci.c:1306
 msgid "Cannot create filename (buffer too small)\n"
 msgstr "Dateiname kann nicht erstellt werden (Puffer zu klein)\n"
 
-#: ../src/lib/conf.c:86 ../src/lib/conf.c:363 ../src/lib/monitor_db.c:350
-#: ../src/lib/monitor_db.c:714
+#: ../src/lib/conf.c:88 ../src/lib/conf.c:367 ../src/lib/monitor_db.c:353
+#: ../src/lib/monitor_db.c:726
 #, c-format
 msgid "Document not parsed successfully.\n"
 msgstr "Dokument nicht erfolgreich ausgewertet\n"
 
-#: ../src/lib/conf.c:93 ../src/lib/conf.c:370
+#: ../src/lib/conf.c:95 ../src/lib/conf.c:375
 #, c-format
 msgid "empty profile file\n"
 msgstr "leere Profildatei\n"
 
-#: ../src/lib/conf.c:99 ../src/lib/conf.c:376
+#: ../src/lib/conf.c:101 ../src/lib/conf.c:382
 #, c-format
 msgid "profile of the wrong type, root node %s != profile"
 msgstr "Profile des falschen Typs, Wurzelknoten %s != Profil"
 
-#: ../src/lib/conf.c:105
+#: ../src/lib/conf.c:107
 msgid "Can't find ddccontrolversion property."
 msgstr "Eigenschaft »ddccontrolversion« kann nicht gefunden werden"
 
-#: ../src/lib/conf.c:107
+#: ../src/lib/conf.c:109
 #, c-format
 msgid "ddccontrol has been upgraded since monitorlist was saved (%s vs %s).\n"
 msgstr ""
 "Es wurde seit des Speicherns der Monitorliste ein Upgrade von Ddccontrol "
 "durchgeführt (%s vs %s).\n"
 
-#: ../src/lib/conf.c:124
+#: ../src/lib/conf.c:126
 msgid "Can't find filename property."
 msgstr "Dateinamen-Eigenschaft kann nicht gefunden werden."
 
-#: ../src/lib/conf.c:130
+#: ../src/lib/conf.c:132
 msgid "Can't find supported property."
 msgstr "Unterstützte Eigenschaft kann nicht gefunden werden."
 
-#: ../src/lib/conf.c:133
+#: ../src/lib/conf.c:135
 msgid "Can't convert supported property to int."
 msgstr "Unterstützte Eigenschaft kann nicht in Ganzzahl umgewandelt werden."
 
-#: ../src/lib/conf.c:138 ../src/lib/conf.c:385 ../src/lib/monitor_db.c:90
-#: ../src/lib/monitor_db.c:194 ../src/lib/monitor_db.c:370
-#: ../src/lib/monitor_db.c:426 ../src/lib/monitor_db.c:447
+#: ../src/lib/conf.c:140 ../src/lib/conf.c:392 ../src/lib/monitor_db.c:92
+#: ../src/lib/monitor_db.c:196 ../src/lib/monitor_db.c:373
+#: ../src/lib/monitor_db.c:429 ../src/lib/monitor_db.c:450
 msgid "Can't find name property."
 msgstr "Namen-Eigenschaft kann nicht gefunden werden."
 
-#: ../src/lib/conf.c:144
+#: ../src/lib/conf.c:146
 msgid "Can't find digital property."
 msgstr "Digitale Eigenschaft kann nicht gefunden werden."
 
-#: ../src/lib/conf.c:147
+#: ../src/lib/conf.c:149
 msgid "Can't convert digital property to int."
 msgstr "Digitale Eigenschaft kann nicht in Ganzzahl umgewandelt werden."
 
-#: ../src/lib/conf.c:175 ../src/lib/conf.c:439
+#: ../src/lib/conf.c:177 ../src/lib/conf.c:447
 msgid "Cannot create the xml writer\n"
 msgstr "Der XML-Schreiber kann nicht erstellt werden\n"
 
-#: ../src/lib/conf.c:239
+#: ../src/lib/conf.c:241
 msgid "Cannot read control value\n"
 msgstr "Steuerungswert kann nicht gelesen werden\n"
 
-#: ../src/lib/conf.c:276
+#: ../src/lib/conf.c:278
 msgid "Cannot write control value\n"
 msgstr "Steuerungswert kann nicht geschreiben werden\n"
 
-#: ../src/lib/conf.c:313
+#: ../src/lib/conf.c:315
 msgid "Error while opening ddccontrol home directory."
 msgstr "Fehler beim Öffnen des Ddccontrol-Wurzelverzeichnisses"
 
-#: ../src/lib/conf.c:337
+#: ../src/lib/conf.c:340
 msgid "Error while reading ddccontrol home directory."
 msgstr "Fehler beim Lesen des Ddccontrol-Wurzelverzeichnisses"
 
-#: ../src/lib/conf.c:382
+#: ../src/lib/conf.c:389
 msgid "Can't find pnpid property."
 msgstr "Eigenschaft Pnpid wurde nicht gefunden."
 
-#: ../src/lib/conf.c:388 ../src/lib/conf.c:391
+#: ../src/lib/conf.c:395 ../src/lib/conf.c:398
 msgid "Can't find version property."
 msgstr "Eigenschaft Version wurde nicht gefunden."
 
-#: ../src/lib/conf.c:390 ../src/lib/monitor_db.c:752
+#: ../src/lib/conf.c:397 ../src/lib/monitor_db.c:764
 msgid "Can't convert version to int."
 msgstr "Version kann nicht in Ganzzahl umgewandelt werden."
 
-#: ../src/lib/conf.c:393
+#: ../src/lib/conf.c:400
 #, c-format
 msgid "profile version (%d) is not supported (should be %d).\n"
 msgstr "Profilversion (%d) wird nicht unterstützt (Sollte %d sein).\n"
 
-#: ../src/lib/conf.c:407 ../src/lib/monitor_db.c:229
+#: ../src/lib/conf.c:415 ../src/lib/monitor_db.c:233
 msgid "Can't find address property."
 msgstr "Eigenschaft Adresse wurde nicht gefunden."
 
-#: ../src/lib/conf.c:409 ../src/lib/monitor_db.c:231
+#: ../src/lib/conf.c:417 ../src/lib/monitor_db.c:235
 msgid "Can't convert address to int."
 msgstr "Adresse kann nicht in Ganzzahl umgewandelt werden."
 
-#: ../src/lib/conf.c:413 ../src/lib/monitor_db.c:112
+#: ../src/lib/conf.c:421 ../src/lib/monitor_db.c:114
 msgid "Can't find value property."
 msgstr "Eigenschaft Wert wurde nicht gefunden."
 
-#: ../src/lib/conf.c:415 ../src/lib/monitor_db.c:114
+#: ../src/lib/conf.c:423 ../src/lib/monitor_db.c:116
 msgid "Can't convert value to int."
 msgstr "Wert kann nicht in Ganzzahl umgewandelt werden."
 
-#: ../src/lib/conf.c:499
+#: ../src/lib/conf.c:507
 msgid "ddcci_delete_profile: Error, cannot delete profile.\n"
 msgstr "ddcci_delete_profile: Fehler, Profil kann nicht gelöscht werden.\n"
 
-#: ../src/lib/conf.c:519
+#: ../src/lib/conf.c:527
 #, c-format
 msgid "ddcci_delete_profile: Error, could not find the profile to delete.\n"
 msgstr ""
 "ddcci_delete_profile: Fehler, zu löschendes Profil konnte nicht gefunden "
 "werden.\n"
 
-#: ../src/lib/ddcci.c:146
+#: ../src/lib/ddcci.c:148
 msgid "Error while initialisating the message queue"
 msgstr "Fehler beim Initialisieren der Nachrichtenwarteschlange"
 
-#: ../src/lib/ddcci.c:175
+#: ../src/lib/ddcci.c:177
 msgid "Error while sending quit message"
 msgstr "Fehler beim Senden der Beenden-Nachricht"
 
-#: ../src/lib/ddcci.c:221
+#: ../src/lib/ddcci.c:223
 msgid "Error while sending heartbeat message"
 msgstr "Fehler beim Senden der Herzschlag-Nachricht"
 
-#: ../src/lib/ddcci.c:239
+#: ../src/lib/ddcci.c:241
 #, c-format
 msgid "Failed to initialize ddccontrol database...\n"
 msgstr "Initialisieren der Ddccontrol-Datenbank fehlgeschlagen ...\n"
 
-#: ../src/lib/ddcci.c:275 ../src/lib/ddcci.c:350
+#: ../src/lib/ddcci.c:247
+#, fuzzy, c-format
+msgid "Failed to initialize ADL...\n"
+msgstr "Initialisieren der Ddccontrol-Datenbank fehlgeschlagen ...\n"
+
+#: ../src/lib/ddcci.c:292 ../src/lib/ddcci.c:383
 #, c-format
 msgid "ioctl returned %d\n"
 msgstr "»ioctl« gab %d zurück\n"
 
-#: ../src/lib/ddcci.c:300
+#: ../src/lib/ddcci.c:321
 msgid "Error while sending write message"
 msgstr "Fehler beim Senden der Schreib-Nachricht"
 
-#: ../src/lib/ddcci.c:309
+#: ../src/lib/ddcci.c:330
 msgid "Error while reading write message answer"
 msgstr "Fehler beim Lesen der Antwort auf die Schreib-Nachricht"
 
-#: ../src/lib/ddcci.c:376
+#: ../src/lib/ddcci.c:413
 msgid "Error while sending read message"
 msgstr "Fehler beim Senden der Lese-Nachricht"
 
-#: ../src/lib/ddcci.c:385
+#: ../src/lib/ddcci.c:422
 msgid "Error while reading read message answer"
 msgstr "Fehler beim Lesen der Antwort auf die Lese-Nachricht"
 
-#: ../src/lib/ddcci.c:475
+#: ../src/lib/ddcci.c:518
 #, c-format
 msgid "Invalid response, first byte is 0x%02x, should be 0x%02x\n"
 msgstr "Ungültige Antwort, erstes Byte ist 0x%02x, sollte 0x%02x sein\n"
 
-#: ../src/lib/ddcci.c:485
+#: ../src/lib/ddcci.c:528
 #, c-format
 msgid "Non-fatal error: Invalid response, magic is 0x%02x\n"
 msgstr "Kein fataler Fehler: Ungültige Anwort, magisch ist 0x%02x\n"
 
-#: ../src/lib/ddcci.c:492
+#: ../src/lib/ddcci.c:535
 #, c-format
 msgid "Invalid response, length is %d, should be %d at most\n"
 msgstr "Ungültige Antwort, Länge ist %d, sollte höchstens %d sein\n"
 
-#: ../src/lib/ddcci.c:505
+#: ../src/lib/ddcci.c:548
 #, c-format
 msgid "Invalid response, corrupted data - xor is 0x%02x, length 0x%02x\n"
 msgstr "Ungültige Antwort, beschädigte Daten - xor ist 0x%02x, Länge 0x%02x\n"
 
-#: ../src/lib/ddcci.c:658 ../src/lib/ddcci.c:680
+#: ../src/lib/ddcci.c:709 ../src/lib/ddcci.c:731
 #, c-format
 msgid "Can't convert value to int, invalid CAPS (buf=%s, pos=%d).\n"
 msgstr ""
 "Wert kann nicht in Ganzzahl konvertiert werden, ungültige CAPS (Puffer=%s, "
 "Position=%d).\n"
 
-#: ../src/lib/ddcci.c:763
+#: ../src/lib/ddcci.c:814
 #, c-format
 msgid "Invalid sequence in caps.\n"
 msgstr "Ungültige Abfolge in CAPS.\n"
 
-#: ../src/lib/ddcci.c:841
+#: ../src/lib/ddcci.c:892
 #, c-format
 msgid "Corrupted EDID at 0x%02x.\n"
 msgstr "Beschädigte EDID bei 0x%02x.\n"
 
-#: ../src/lib/ddcci.c:853
+#: ../src/lib/ddcci.c:904
 #, c-format
 msgid "Serial number: %d\n"
 msgstr "Serielle Zahl: %d\n"
 
-#: ../src/lib/ddcci.c:856
+#: ../src/lib/ddcci.c:907
 #, c-format
 msgid "Manufactured: Week %d, %d\n"
 msgstr "Hergestellt: Woche %d, %d\n"
 
-#: ../src/lib/ddcci.c:859
+#: ../src/lib/ddcci.c:910
 #, c-format
 msgid "EDID version: %d.%d\n"
 msgstr "EDID-Version: %d.%d\n"
 
-#: ../src/lib/ddcci.c:862
+#: ../src/lib/ddcci.c:913
 #, c-format
 msgid "Maximum size: %d x %d (cm)\n"
 msgstr "Maximale Größe: %d x %d (cm)\n"
 
-#: ../src/lib/ddcci.c:873
+#: ../src/lib/ddcci.c:924
 #, c-format
 msgid "Reading EDID 0x%02x failed.\n"
 msgstr "Lesen von EDID 0x%02x fehlgeschlagen\n"
 
-#: ../src/lib/ddcci.c:903
+#: ../src/lib/ddcci.c:954
 #, c-format
 msgid "Device: %s\n"
 msgstr "Gerät: %s\n"
 
-#: ../src/lib/ddcci.c:917
+#: ../src/lib/ddcci.c:968
 msgid "Error while sending open message"
 msgstr "Fehler beim Senden der Öffnen-Nachricht"
 
-#: ../src/lib/ddcci.c:925
+#: ../src/lib/ddcci.c:976
 msgid "Error while reading open message answer"
 msgstr "Fehler beim Lesen der Antwort auf die Öffnen-Nachricht"
 
-#: ../src/lib/ddcci.c:933
+#: ../src/lib/ddcci.c:988 ../src/lib/ddcci.c:1001
 #, c-format
 msgid "Invalid filename (%s).\n"
 msgstr "Ungültiger Dateiname (%s).\n"
 
-#: ../src/lib/ddcci.c:1049
+#: ../src/lib/ddcci.c:993
+#, c-format
+msgid "ADL display not found (%s).\n"
+msgstr ""
+
+#: ../src/lib/ddcci.c:1125
 #, c-format
 msgid "ddcci_open returned %d\n"
 msgstr "ddcci_open gab %d zurück\n"
 
-#: ../src/lib/ddcci.c:1062
+#: ../src/lib/ddcci.c:1138
 #, c-format
 msgid "Unknown monitor (%s)"
 msgstr "Unbekannter Monitor (%s)"
 
-#: ../src/lib/ddcci.c:1083
+#: ../src/lib/ddcci.c:1159
 #, c-format
 msgid "Probing for available monitors"
 msgstr "Es wird nach verfügbaren Monitoren gesucht"
 
-#: ../src/lib/ddcci.c:1097
+#: ../src/lib/ddcci.c:1173
 msgid "Error while sending list message"
 msgstr "Fehler beim Senden der Listennachricht"
 
-#: ../src/lib/ddcci.c:1106
+#: ../src/lib/ddcci.c:1182
 msgid "Error while reading list entry"
 msgstr "Fehler beim Lesen des Listeneintrags"
 
-#: ../src/lib/ddcci.c:1123
+#: ../src/lib/ddcci.c:1199
 #, c-format
 msgid "Found PCI device (%s)\n"
 msgstr "PCI-Gerät gefunden (%s)\n"
 
-#: ../src/lib/ddcci.c:1157
+#: ../src/lib/ddcci.c:1239
 #, c-format
 msgid "Found I2C device (%s)\n"
 msgstr "IC2-Gerät gefunden (%s)\n"
 
-#: ../src/lib/ddcci.c:1206
+#: ../src/lib/ddcci.c:1264
+#, fuzzy, c-format
+msgid "Found ADL display (%s)\n"
+msgstr "PCI-Gerät gefunden (%s)\n"
+
+#: ../src/lib/ddcci.c:1310
 msgid "Error while getting information about ddccontrol home directory."
 msgstr ""
 "Fehler bei der Abfrage von Informationen über das Ddccontrol-Home-Verzeichnis"
 
-#: ../src/lib/ddcci.c:1211
+#: ../src/lib/ddcci.c:1316
 msgid "Error while creating ddccontrol home directory."
 msgstr "Fehler beim Erstellen des Ddccontrol-Home-Verzeichnisses"
 
-#: ../src/lib/ddcci.c:1216
+#: ../src/lib/ddcci.c:1322
 msgid ""
 "Error while getting information about ddccontrol home directory after "
 "creating it."
 msgstr ""
-"Fehler bei der Abfrage von Informationen über das Ddccontrol-Home-Verzeichnis "
-"nach seiner Erstellung"
+"Fehler bei der Abfrage von Informationen über das Ddccontrol-Home-"
+"Verzeichnis nach seiner Erstellung"
 
-#: ../src/lib/ddcci.c:1223
+#: ../src/lib/ddcci.c:1330
 msgid "Error: '.ddccontrol' in your home directory is not a directory."
 msgstr "Fehler: ».ddccontrol« ist in Ihrem Home-Verzeichnis kein Verzeichnis."
 
-#: ../src/lib/ddcci.c:1231
+#: ../src/lib/ddcci.c:1339
 msgid "Error while getting information about ddccontrol profile directory."
 msgstr ""
-"Fehler bei der Abfrage von Informationen über das Ddccontrol-Profilverzeichnis"
+"Fehler bei der Abfrage von Informationen über das Ddccontrol-"
+"Profilverzeichnis"
 
-#: ../src/lib/ddcci.c:1236
+#: ../src/lib/ddcci.c:1345
 msgid "Error while creating ddccontrol profile directory."
 msgstr "Fehler beim Erstellen des Ddccontrol-Profilverzeichnisses"
 
-#: ../src/lib/ddcci.c:1241
+#: ../src/lib/ddcci.c:1351
 msgid ""
 "Error while getting information about ddccontrol profile directory after "
 "creating it."
 msgstr ""
-"Fehler bei der Abfrage von Informationen über das Ddccontrol-Profilverzeichnis"
-"nach seiner Erstellung"
+"Fehler bei der Abfrage von Informationen über das Ddccontrol-"
+"Profilverzeichnisnach seiner Erstellung"
 
-#: ../src/lib/ddcci.c:1248
+#: ../src/lib/ddcci.c:1359
 msgid ""
 "Error: '.ddccontrol/profiles' in your home directory is not a directory."
 msgstr ""
-"Fehler: ».ddccontrol/profiles« ist in Ihrem Home-Verzeichnis kein Verzeichnis."
+"Fehler: ».ddccontrol/profiles« ist in Ihrem Home-Verzeichnis kein "
+"Verzeichnis."
 
-#: ../src/lib/monitor_db.c:82 ../src/lib/monitor_db.c:192
+#: ../src/lib/monitor_db.c:84 ../src/lib/monitor_db.c:194
 msgid "Can't find id property."
 msgstr "ID-Eigenschaft konnte nicht gefunden werden."
 
-#: ../src/lib/monitor_db.c:151 ../src/lib/monitor_db.c:546
+#: ../src/lib/monitor_db.c:153 ../src/lib/monitor_db.c:549
 #, c-format
 msgid "Element %s (id=%s) has not been found (line %ld).\n"
 msgstr "Element %s (id=%s) wurde nicht gefunden (Zeile %ld).\n"
 
-#: ../src/lib/monitor_db.c:205
+#: ../src/lib/monitor_db.c:207
 msgid "Invalid refresh type (!= none, != all)."
 msgstr "Ungültiger Aktualisierungstyp (!= none, != all)"
 
-#: ../src/lib/monitor_db.c:238
+#: ../src/lib/monitor_db.c:242
 #, c-format
 msgid "Control %s has been discarded by the caps string.\n"
 msgstr "Steuerung %s wurde von der CAPS-Zeichenkette verworfen.\n"
 
-#: ../src/lib/monitor_db.c:246
+#: ../src/lib/monitor_db.c:250
 #, c-format
 msgid "Control %s (0x%02x) has already been defined.\n"
 msgstr "Steuerung %s (0x%02x) wurde bereits definiert.\n"
 
-#: ../src/lib/monitor_db.c:259
+#: ../src/lib/monitor_db.c:263
 msgid "Can't convert delay to int."
 msgstr "Verzögerung kann nicht in Ganzzahl konvertiert werden."
 
-#: ../src/lib/monitor_db.c:267
+#: ../src/lib/monitor_db.c:271
 msgid "Can't find type property."
 msgstr "Typ-Eigenschaft konnte nicht gefunden werden."
 
-#: ../src/lib/monitor_db.c:292 ../src/lib/monitor_db.c:381
+#: ../src/lib/monitor_db.c:296 ../src/lib/monitor_db.c:384
 msgid "Invalid type."
 msgstr "Ungültiger Typ"
 
-#: ../src/lib/monitor_db.c:343
-#, c-format
 # s/inited/intialized
+#: ../src/lib/monitor_db.c:346
+#, c-format
 msgid "Database must be inited before reading a monitor file.\n"
 msgstr ""
 "Datenbank muss Intitialisiert sein, bevor eine Monitordatei gelesen wird.\n"
 
-#: ../src/lib/monitor_db.c:357
+#: ../src/lib/monitor_db.c:360
 #, c-format
 msgid "empty monitor/%s.xml\n"
 msgstr "Leerer Monitor/%s.xml\n"
 
-#: ../src/lib/monitor_db.c:363
+#: ../src/lib/monitor_db.c:366
 #, c-format
 msgid "monitor/%s.xml of the wrong type, root node %s != monitor"
 msgstr "Monitor/%s.xml vom falschen Typ, Wurzelknoten %s != Monitor"
 
-#: ../src/lib/monitor_db.c:464
+#: ../src/lib/monitor_db.c:467
 msgid "Can't find add or remove property in caps."
 msgstr "Hinzufügen- oder Entfernen-Eigenschaft konnte nicht gefunden werden."
 
-#: ../src/lib/monitor_db.c:466
+#: ../src/lib/monitor_db.c:469
 msgid "Invalid remove caps."
 msgstr "Üngultiges CAPS-Entfernen"
 
-#: ../src/lib/monitor_db.c:468
+#: ../src/lib/monitor_db.c:471
 msgid "Invalid add caps."
 msgstr "Üngultiges CAPS-Hinzufügen"
 
-#: ../src/lib/monitor_db.c:473
+#: ../src/lib/monitor_db.c:476
 #, c-format
 msgid "Error, include recursion level > 15 (file: %s).\n"
 msgstr "Fehler, beinhaltetet Rekursionsstufe > 15 (Datei: %s).\n"
 
-#: ../src/lib/monitor_db.c:479
+#: ../src/lib/monitor_db.c:482
 msgid "Can't find file property."
 msgstr "Dateieigenschaft konnte nicht gefunden werden."
 
-#: ../src/lib/monitor_db.c:487
+#: ../src/lib/monitor_db.c:490
 msgid "Two controls part in XML file."
 msgstr "Zwei Steuerungsteile in XML-Datei"
 
-#: ../src/lib/monitor_db.c:534
+#: ../src/lib/monitor_db.c:537
 msgid "Error enumerating controls in subgroup."
 msgstr "Fehler beim Aufzählen der Steuerungen in der Untergruppe"
 
-#: ../src/lib/monitor_db.c:589
+#: ../src/lib/monitor_db.c:601
 #, c-format
 msgid "document of the wrong type, can't find controls or include.\n"
 msgstr ""
 "Dokument vom falschen Typ, Steuerungen können nicht gefunden oder beigefügt "
 "werden.\n"
 
-#: ../src/lib/monitor_db.c:721
+#: ../src/lib/monitor_db.c:733
 #, c-format
 msgid "empty options.xml\n"
 msgstr "leere »options.xml«\n"
 
-#: ../src/lib/monitor_db.c:728
+#: ../src/lib/monitor_db.c:740
 #, c-format
 msgid "options.xml of the wrong type, root node %s != options"
 msgstr "»options.xml« vom falschen Typ, Wurzelknoten %s != Optionen"
 
-#: ../src/lib/monitor_db.c:738
+#: ../src/lib/monitor_db.c:750
 #, c-format
 msgid "options.xml dbversion attribute missing, please update your database.\n"
 msgstr ""
 "Dbversions-Attribut von »options.xml« fehlt, bitte aktualisieren Sie Ihre "
 "Datenbank.\n"
 
-#: ../src/lib/monitor_db.c:745
+#: ../src/lib/monitor_db.c:757
 #, c-format
 msgid "options.xml date attribute missing, please update your database.\n"
 msgstr ""
 "Datumsattribut von »options.xml« fehlt, bitte aktualisieren Sie Ihre "
 "Datenbank.\n"
 
-#: ../src/lib/monitor_db.c:755
+#: ../src/lib/monitor_db.c:767
 #, c-format
 msgid ""
 "options.xml dbversion (%d) is greater than the supported version (%d).\n"
 msgstr ""
-"Dbversion (%d) von »options.xml« ist größer als die unterstützte "
-"Version (%d)\n"
+"Dbversion (%d) von »options.xml« ist größer als die unterstützte Version "
+"(%d)\n"
 
-#: ../src/lib/monitor_db.c:756
+#: ../src/lib/monitor_db.c:768
 #, c-format
 msgid "Please update ddccontrol program.\n"
 msgstr "Bitte aktualisieren Sie das Programm Ddccontrol.\n"
 
-#: ../src/lib/monitor_db.c:763
+#: ../src/lib/monitor_db.c:775
 #, c-format
 msgid "options.xml dbversion (%d) is less than the supported version (%d).\n"
 msgstr ""
-"Dbversion (%d) von »options.xml« ist kleiner als die unterstützte "
-"Version (%d)\n"
+"Dbversion (%d) von »options.xml« ist kleiner als die unterstützte Version "
+"(%d)\n"
 
-#: ../src/lib/monitor_db.c:764
+#: ../src/lib/monitor_db.c:776
 #, c-format
 msgid "Please update ddccontrol database.\n"
 msgstr "Bitte aktualisieren Sie die Ddccontrol-Datenbank.\n"
+
+#, c-format
+#~ msgid "Monitor Profile Switcher"
+#~ msgstr "Monitor-Profilumschalter"
+
+#~ msgid "Quickly switch monitor profiles created with gddccontrol"
+#~ msgstr ""
+#~ "Schnelles Umschalten zwischen Profilen, die mit Gddccontrol erstellt "
+#~ "wurden"
+
+#~ msgid "_About..."
+#~ msgstr "_Über ..."
+
+#~ msgid "_Properties..."
+#~ msgstr "_Eigenschaften ..."
+
+#~ msgid "_Run gddccontrol..."
+#~ msgstr "_Gddccontrol ausführen ..."
+
+#~ msgid ""
+#~ "An applet for quick switching of monitor profiles.\n"
+#~ "Based on libddccontrol and part of the ddccontrol project.\n"
+#~ "(http://ddccontrol.sourceforge.net)"
+#~ msgstr ""
+#~ "Ein Applet zum schnellen Wechseln zwischen Bildschirmprofilen.\n"
+#~ "Basiert auf Libddccontrol und ist Teil des Ddccontrol-Projektes.\n"
+#~ "(http://ddccontrol.sourceforge.net)"
+
+#~ msgid "Unable to initialize ddcci library"
+#~ msgstr "»ddcci«-Bibliothek kann nicht initialisiert werden"
+
+#~ msgid "No monitor configuration found. Please run gddccontrol first"
+#~ msgstr ""
+#~ "Keine Monitorkonfiguration gefunden. Bitte führen Sie zuerst Gddccontrol "
+#~ "aus"
+
+#~ msgid "An error occurred while opening the monitor device"
+#~ msgstr "Beim Öffnen dess Monitors ist ein Fehler aufgetreten"
+
+#~ msgid "Can't find any profiles"
+#~ msgstr "Es wurden keine Profile gefunden"
+
+#~ msgid "error"
+#~ msgstr "Fehler"
+
+#~ msgid "Monitor:"
+#~ msgstr "Monitor:"
+
+#~ msgid "Monitor Profile Switcher Properties"
+#~ msgstr "Eigenschaften des Monitor-Profilumschalters"

--- a/po/es.po
+++ b/po/es.po
@@ -7,35 +7,34 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.4.3\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2007-10-28 04:48-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/ddccontrol/ddccontrol/issues/\n"
+"POT-Creation-Date: 2026-05-13 15:12+0200\n"
 "PO-Revision-Date: 2007-1028 04:52-0400\n"
 "Last-Translator: Roberto C. Sánchez <roberto@connexer.com>\n"
 "Language-Team: Spanish <es@li.org>\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../../po/../src/ddccontrol/main.c:83 ../../po/../src/ddccontrol/main.c:87
-#: ../../po/../src/ddccontrol/main.c:91
-msgid "Control"
-msgstr "Control"
-
-#: ../../po/../src/ddccontrol/main.c:132
-#, c-format
+#: ../src/ddccontrol/main.c:85
+#, fuzzy, c-format
 msgid ""
 "Usage:\n"
-"%s [-b datadir] [-v] [-c] [-d] [-f] [-s] [-r ctrl [-w value]] [-p | dev]\n"
+"%s [-b datadir] [-v] [-c] [-d] [-f] [-s] [-r ctrl [-w value]] [-l (profile "
+"path)] [-p | dev]\n"
 "\tdev: device, e.g. dev:/dev/i2c-0\n"
 "\t-p : probe I2C devices to find monitor buses\n"
 "\t-c : query capability\n"
 "\t-d : query ctrls 0 - 255\n"
 "\t-r : query ctrl\n"
 "\t-w : value to write to ctrl\n"
+"\t-W : relatively change ctrl value (+/-)\n"
 "\t-f : force (avoid validity checks)\n"
 "\t-s : save settings\n"
 "\t-v : verbosity (specify more to increase)\n"
 "\t-b : ddccontrol-db directory (if other than %s)\n"
+"\t-l : load values from XML profile file\n"
 msgstr ""
 "Uso:\n"
 "%s [-b datadir] [-v] [-c] [-d] [-f] [-s] [-r ctrl [-w value]] [-p | dev]\n"
@@ -50,22 +49,22 @@ msgstr ""
 "\t-v : verbosidad (especificar más para aumentar)\n"
 "\t-b : directorio ddccontrol-db (si no es %s)\n"
 
-#: ../../po/../src/ddccontrol/main.c:150 ../../po/../src/ddccontrol/main.c:172
+#: ../src/ddccontrol/main.c:106 ../src/ddccontrol/main.c:128
 #, c-format
 msgid "Checking %s integrity...\n"
 msgstr "Chequeando integridad de %s...\n"
 
-#: ../../po/../src/ddccontrol/main.c:152 ../../po/../src/ddccontrol/main.c:174
+#: ../src/ddccontrol/main.c:108 ../src/ddccontrol/main.c:130
 #, c-format
 msgid "[ FAILED ]\n"
 msgstr "[ FALLÓ ]\n"
 
-#: ../../po/../src/ddccontrol/main.c:156 ../../po/../src/ddccontrol/main.c:179
+#: ../src/ddccontrol/main.c:112 ../src/ddccontrol/main.c:135
 #, c-format
 msgid "[ OK ]\n"
 msgstr "[ BIEN ]\n"
 
-#: ../../po/../src/ddccontrol/main.c:217
+#: ../src/ddccontrol/main.c:194
 #, c-format
 msgid ""
 "ddccontrol version %s\n"
@@ -84,74 +83,88 @@ msgstr ""
 "General Public License.\n"
 "\n"
 
-#: ../../po/../src/ddccontrol/main.c:236
+#: ../src/ddccontrol/main.c:211
 #, c-format
 msgid "'%s' does not seem to be a valid register name\n"
 msgstr "'%s' no se parece a un nombre válido de registro\n"
 
-#: ../../po/../src/ddccontrol/main.c:242
+#: ../src/ddccontrol/main.c:217
 #, c-format
 msgid "You cannot use -w parameter without -r.\n"
 msgstr "No puedes usar al parámetro -w sin -r.\n"
 
-#: ../../po/../src/ddccontrol/main.c:247
+#: ../src/ddccontrol/main.c:221 ../src/ddccontrol/main.c:231
 #, c-format
 msgid "'%s' does not seem to be a valid value.\n"
 msgstr "'%s; no se parece a un valor válido.\n"
 
-#: ../../po/../src/ddccontrol/main.c:292
-#: ../../po/../src/gddccontrol/main.c:414
+#: ../src/ddccontrol/main.c:227
+#, fuzzy, c-format
+msgid "You cannot use -W parameter without -r.\n"
+msgstr "No puedes usar al parámetro -w sin -r.\n"
+
+#: ../src/ddccontrol/main.c:282 ../src/gddccontrol/main.c:432
 #, c-format
 msgid "Unable to initialize ddcci library.\n"
 msgstr "No se pudo inicializar la biblioteca ddcci.\n"
 
-#: ../../po/../src/ddccontrol/main.c:304
+#: ../src/ddccontrol/main.c:288
+#, fuzzy, c-format
+msgid "Unable to initialize ddcci db library.\n"
+msgstr "No se pudo inicializar la biblioteca ddcci.\n"
+
+#: ../src/ddccontrol/main.c:293
+#, c-format
+msgid "Failed to open D-Bus proxy, try with DDCCONTROL_NO_DAEMON=1.\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:310
 #, c-format
 msgid "Detected monitors :\n"
 msgstr "Monitores detectados :\n"
 
-#: ../../po/../src/ddccontrol/main.c:309
+#: ../src/ddccontrol/main.c:314
 #, c-format
 msgid " - Device: %s\n"
 msgstr " - Dispositivo: %s\n"
 
-#: ../../po/../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 #, c-format
 msgid "   DDC/CI supported: %s\n"
 msgstr "   DDC/CI soportado: %s\n"
 
-#: ../../po/../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 msgid "Yes"
 msgstr "Sí"
 
-#: ../../po/../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 msgid "No"
 msgstr "No"
 
-#: ../../po/../src/ddccontrol/main.c:311
+#: ../src/ddccontrol/main.c:316
 #, c-format
 msgid "   Monitor Name: %s\n"
 msgstr "   Nombre de Montor %s\n"
 
-#: ../../po/../src/ddccontrol/main.c:312
+#: ../src/ddccontrol/main.c:317
 #, c-format
 msgid "   Input type: %s\n"
 msgstr "   Tipo de entrada: %s\n"
 
-#: ../../po/../src/ddccontrol/main.c:312 ../../po/../src/ddccontrol/main.c:350
+#: ../src/ddccontrol/main.c:317 ../src/ddccontrol/main.c:364
 msgid "Digital"
 msgstr "Digital"
 
-#: ../../po/../src/ddccontrol/main.c:312 ../../po/../src/ddccontrol/main.c:350
+#: ../src/ddccontrol/main.c:317 ../src/ddccontrol/main.c:364
 msgid "Analog"
 msgstr "Analógico"
 
-#: ../../po/../src/ddccontrol/main.c:316
+#: ../src/ddccontrol/main.c:321
 #, c-format
 msgid "  (Automatically selected)\n"
 msgstr "  (Escogido automaticamente)\n"
 
-#: ../../po/../src/ddccontrol/main.c:326
+#: ../src/ddccontrol/main.c:333
 #, c-format
 msgid ""
 "No monitor supporting DDC/CI available.\n"
@@ -160,14 +173,15 @@ msgid ""
 msgstr ""
 "No hay monitor disponible que soporta DDC/CI.\n"
 "Si le hace falta a tu tarjeta de gráficos, por favor verifique que todos los "
-"módulos requeridos del núcleo están cargados (i2c-dev, y el manejador del framebuffer).\n"
+"módulos requeridos del núcleo están cargados (i2c-dev, y el manejador del "
+"framebuffer).\n"
 
-#: ../../po/../src/ddccontrol/main.c:339
+#: ../src/ddccontrol/main.c:346
 #, c-format
 msgid "Reading EDID and initializing DDC/CI at bus %s...\n"
 msgstr "Leendo EDID e incializando DDC/CI en el bus %s...\n"
 
-#: ../../po/../src/ddccontrol/main.c:343
+#: ../src/ddccontrol/main.c:357
 #, c-format
 msgid ""
 "\n"
@@ -178,9 +192,10 @@ msgstr ""
 "\n"
 "DDC/CI en %s es inutilizable (%d).\n"
 "Si le hace falta a tu tarjeta de gráficos, por favor verifique que todos los "
-"módulos requeridos del núcleo están cargados (i2c-dev, y el manejador del framebuffer).\n"
+"módulos requeridos del núcleo están cargados (i2c-dev, y el manejador del "
+"framebuffer).\n"
 
-#: ../../po/../src/ddccontrol/main.c:347
+#: ../src/ddccontrol/main.c:361
 #, c-format
 msgid ""
 "\n"
@@ -189,22 +204,158 @@ msgstr ""
 "\n"
 "Lecturas EDID:\n"
 
-#: ../../po/../src/ddccontrol/main.c:348
+#: ../src/ddccontrol/main.c:362
 #, c-format
 msgid "\tPlug and Play ID: %s [%s]\n"
-msgstr "\tIdentificación Plug and Play: [%s]\n"
+msgstr "\tIdentificación Plug and Play: %s [%s]\n"
 
-#: ../../po/../src/ddccontrol/main.c:350
+#: ../src/ddccontrol/main.c:364
 #, c-format
 msgid "\tInput type: %s\n"
 msgstr "\tTipo de entrada: %s\n"
 
-#. Put a big warning (in red if we are writing to a terminal).
-#: ../../po/../src/ddccontrol/main.c:354 ../../po/../src/ddccontrol/main.c:373
-msgid "=============================== WARNING ==============================="
-msgstr "================================ AVISO ================================"
+#: ../src/ddccontrol/main.c:370
+#, c-format
+msgid ""
+"\n"
+"Capabilities:\n"
+msgstr ""
+"\n"
+"Habilidades:\n"
 
-#: ../../po/../src/ddccontrol/main.c:357
+#: ../src/ddccontrol/main.c:374
+#, c-format
+msgid "Raw output: %s\n"
+msgstr "Salida sin preparar: %s\n"
+
+#: ../src/ddccontrol/main.c:376
+#, c-format
+msgid "Parsed output: \n"
+msgstr "Salida perparada: \n"
+
+#: ../src/ddccontrol/main.c:385
+#, c-format
+msgid "\tType: "
+msgstr "\tTipo: "
+
+#: ../src/ddccontrol/main.c:388
+#, c-format
+msgid "LCD"
+msgstr "visor de cristal líquido"
+
+#: ../src/ddccontrol/main.c:391
+#, c-format
+msgid "CRT"
+msgstr "CRT"
+
+#: ../src/ddccontrol/main.c:394
+#, c-format
+msgid "Unknown"
+msgstr "Desconocido"
+
+#: ../src/ddccontrol/main.c:403
+#, c-format
+msgid "Capabilities read fail.\n"
+msgstr "Fallo de lectura de habilidades.\n"
+
+#: ../src/ddccontrol/main.c:417
+#, c-format
+msgid "Value cannot be lower than zero! %d -> %d\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:420
+#, c-format
+msgid "Value cannot be higher than maximum! %d / %d\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:428
+#, c-format
+msgid ""
+"\n"
+"Writing 0x%02x, 0x%02x(%d) (%dms delay)...\n"
+msgstr ""
+"\n"
+"Escribiendo 0x%02x, 0x%02x(%d) (demora de %dms)...\n"
+
+#: ../src/ddccontrol/main.c:431
+#, c-format
+msgid ""
+"\n"
+"Writing 0x%02x, 0x%02x(%d)...\n"
+msgstr ""
+"\n"
+"Escribiendo 0x%02x, 0x%02x(%d)...\n"
+
+#: ../src/ddccontrol/main.c:436
+#, c-format
+msgid ""
+"\n"
+"Reading 0x%02x...\n"
+msgstr ""
+"\n"
+"Leendo 0x%02x...\n"
+
+#: ../src/ddccontrol/main.c:445
+#, fuzzy, c-format
+msgid "Applied profile: %s\n"
+msgstr "Aplicar perfíl"
+
+#: ../src/ddccontrol/main.c:447
+#, c-format
+msgid "Failed to apply profile: %s\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:451
+#, c-format
+msgid ""
+"\n"
+"Controls (valid/current/max) [Description - Value name]:\n"
+msgstr ""
+"\n"
+"Controles (válido/actual/máximo) [Descripción - Nombre de valor]:\n"
+
+#: ../src/ddccontrol/main.c:473
+#, c-format
+msgid "\t\t> id=%s, name=%s, address=%#x, delay=%dms, type=%d\n"
+msgstr ""
+"\t\t> identificación=%s, nombre=%s, dirección=%#x, demora=%dms, tipo=%d\n"
+
+#: ../src/ddccontrol/main.c:478
+#, c-format
+msgid "\t\t  Possible values:\n"
+msgstr "\t\t  Valores posibles:\n"
+
+#: ../src/ddccontrol/main.c:482
+#, c-format
+msgid "\t\t\t> id=%s - name=%s, value=%d\n"
+msgstr "\t\t\t> identificación=%s - nombre=%s, valor=%d\n"
+
+#: ../src/ddccontrol/main.c:492
+#, c-format
+msgid "\t\t  supported, value=%d, maximum=%d\n"
+msgstr "\t\t  soportado, valor=%d, máximo=%d\n"
+
+#: ../src/ddccontrol/main.c:493
+#, c-format
+msgid "\t\t  not supported, value=%d, maximum=%d\n"
+msgstr "\t\t  no soportado, valor=%d, máximo=%d\n"
+
+#: ../src/ddccontrol/main.c:504
+#, c-format
+msgid ""
+"\n"
+"Saving settings...\n"
+msgstr ""
+"\n"
+"Guardando configuración...\n"
+
+#. Put a big warning (in red if we are writing to a terminal).
+#: ../src/ddccontrol/main.c:516 ../src/ddccontrol/main.c:537
+msgid "=============================== WARNING ==============================="
+msgstr ""
+"================================ AVISO ================================"
+
+#: ../src/ddccontrol/main.c:519
 #, c-format
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is\n"
@@ -213,9 +364,10 @@ msgid ""
 msgstr ""
 "No hay soporte para tu monitor en el base de datos, pero ddccontrol está\n"
 "utilizando un perfíl genérico que corresponde al fabricante de tu monitor.\n"
-"Algunos controles no serán soportados, o no funcionarán de la forma esperado.\n"
+"Algunos controles no serán soportados, o no funcionarán de la forma "
+"esperado.\n"
 
-#: ../../po/../src/ddccontrol/main.c:363
+#: ../src/ddccontrol/main.c:524
 #, c-format
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is\n"
@@ -226,262 +378,170 @@ msgstr ""
 "utilizando un perfíl genérico. Muchos controles no serán soportados, y\n"
 "algunos controles no funcionarán de la forma esperado.\n"
 
-#: ../../po/../src/ddccontrol/main.c:368
+#: ../src/ddccontrol/main.c:529
 #, c-format
 msgid ""
+"Unsupported monitor detected.\n"
+"\n"
 "Please update ddccontrol-db, or, if you are already using the latest\n"
-"version, please send the output of the following command to\n"
-"ddccontrol-users@lists.sourceforge.net:\n"
+"version, please open this pre-filled GitHub issue:\n"
 msgstr ""
-"Por favor actualize ddccontrol-db, o, si ya estás usando la versión\n"
-"última, por favor mande la salida de esta instrucción a\n"
-"ddccontrol-users@lists.sourceforge.net:\n"
 
-#: ../../po/../src/ddccontrol/main.c:372
-#: ../../po/../src/gddccontrol/notebook.c:695
+#: ../src/ddccontrol/main.c:534
+#, c-format
+msgid "Then attach the resulting report file of the following command:\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:536 ../src/gddccontrol/notebook.c:715
 #, c-format
 msgid "Thank you.\n"
 msgstr "Gracias.\n"
 
-#: ../../po/../src/ddccontrol/main.c:377
-#, c-format
-msgid ""
-"\n"
-"Capabilities:\n"
-msgstr ""
-"\n"
-"Habilidades:\n"
-
-#: ../../po/../src/ddccontrol/main.c:381
-#, c-format
-msgid "Raw output: %s\n"
-msgstr "Salida sin preparar: %s\n"
-
-#: ../../po/../src/ddccontrol/main.c:383
-#, c-format
-msgid "Parsed output: \n"
-msgstr "Salida perparada: \n"
-
-#: ../../po/../src/ddccontrol/main.c:392
-#, c-format
-msgid "\tType: "
-msgstr "\tTipo: "
-
-#: ../../po/../src/ddccontrol/main.c:395
-#, c-format
-msgid "LCD"
-msgstr "visor de cristal líquido"
-
-#: ../../po/../src/ddccontrol/main.c:398
-#, c-format
-msgid "CRT"
-msgstr "CRT"
-
-#: ../../po/../src/ddccontrol/main.c:401
-#, c-format
-msgid "Unknown"
-msgstr "Desconocido"
-
-#: ../../po/../src/ddccontrol/main.c:410
-#, c-format
-msgid "Capabilities read fail.\n"
-msgstr "Fallo de lectura de habilidades.\n"
-
-#: ../../po/../src/ddccontrol/main.c:418
-#, c-format
-msgid ""
-"\n"
-"Writing 0x%02x, 0x%02x(%d) (%dms delay)...\n"
-msgstr ""
-"\n"
-"Escribiendo 0x%02x, 0x%02x(%d) (demora de %dms)...\n"
-
-#: ../../po/../src/ddccontrol/main.c:422
-#, c-format
-msgid ""
-"\n"
-"Writing 0x%02x, 0x%02x(%d)...\n"
-msgstr ""
-"\n"
-"Escribiendo 0x%02x, 0x%02x(%d)...\n"
-
-#: ../../po/../src/ddccontrol/main.c:427
-#, c-format
-msgid ""
-"\n"
-"Reading 0x%02x...\n"
-msgstr ""
-"\n"
-"Leendo 0x%02x...\n"
-
-#: ../../po/../src/ddccontrol/main.c:434
-#, c-format
-msgid ""
-"\n"
-"Controls (valid/current/max) [Description - Value name]:\n"
-msgstr ""
-"\n"
-"Controles (válido/actual/máximo) [Descripción - Nombre de valor]:\n"
-
-#: ../../po/../src/ddccontrol/main.c:458
-#, c-format
-msgid "\t\t> id=%s, name=%s, address=%#x, delay=%dms, type=%d\n"
-msgstr "\t\t> identificación=%s, nombre=%s, dirección=%#x, demora=%dms, tipo=%d\n"
-
-#: ../../po/../src/ddccontrol/main.c:463
-#, c-format
-msgid "\t\t  Possible values:\n"
-msgstr "\t\t  Valores posibles:\n"
-
-#: ../../po/../src/ddccontrol/main.c:467
-#, c-format
-msgid "\t\t\t> id=%s - name=%s, value=%d\n"
-msgstr "\t\t\t> identificación=%s - nombre=%s, valor=%d\n"
-
-#: ../../po/../src/ddccontrol/main.c:477
-#, c-format
-msgid "\t\t  supported, value=%d, maximum=%d\n"
-msgstr "\t\t  soportado, valor=%d, máximo=%d\n"
-
-#: ../../po/../src/ddccontrol/main.c:478
-#, c-format
-msgid "\t\t  not supported, value=%d, maximum=%d\n"
-msgstr "\t\t  no soportado, valor=%d, máximo=%d\n"
-
-#: ../../po/../src/ddccontrol/main.c:489
-#, c-format
-msgid ""
-"\n"
-"Saving settings...\n"
-msgstr ""
-"\n"
-"Guardando configuración...\n"
-
 #. arbitration or no acknowledge
-#: ../../po/../src/ddcpci/i2c-algo-bit.c:368
+#: ../src/ddcpci/i2c-algo-bit.c:368
 #, c-format
 msgid "sendbytes: error - bailout.\n"
 msgstr "sendbytes: error - saliendo.\n"
 
 #. read timed out
-#: ../../po/../src/ddcpci/i2c-algo-bit.c:395
+#: ../src/ddcpci/i2c-algo-bit.c:395
 #, c-format
 msgid "i2c-algo-bit.o: readbytes: i2c_inb timed out.\n"
 msgstr "i2c-algo-bit.o: readbytes: i2c_inb desconexión por tiempo.\n"
 
-#: ../../po/../src/ddcpci/i2c-algo-bit.c:414
+#: ../src/ddcpci/i2c-algo-bit.c:414
 #, c-format
 msgid "i2c-algo-bit.o: readbytes: Timeout at ack\n"
 msgstr "i2c-algo-bit.o: readbytes: Desconexión por tiempo en ack\n"
 
-#: ../../po/../src/ddcpci/intel740.c:103 ../../po/../src/ddcpci/intel810.c:161
-#: ../../po/../src/ddcpci/nvidia.c:155 ../../po/../src/ddcpci/radeon.c:209
+#: ../src/ddcpci/intel740.c:103 ../src/ddcpci/intel810.c:162
+#: ../src/ddcpci/nvidia.c:155 ../src/ddcpci/radeon.c:209
+#: ../src/ddcpci/sis.c:174 ../src/ddcpci/via.c:167
 #, c-format
 msgid "%s: Malloc error.\n"
 msgstr "%s: Error malloc.\n"
 
-#: ../../po/../src/ddcpci/intel740.c:109
+#: ../src/ddcpci/intel740.c:109
 #, c-format
 msgid "%s: ioperm failed"
 msgstr "%s: falló ioperm"
 
-#: ../../po/../src/ddcpci/intel740.c:121
+#: ../src/ddcpci/intel740.c:121
 #, c-format
 msgid "%s: Error: unknown card type (%#x)\n"
 msgstr "%s: Error: tipo de tarjeta desconocido (%#x)\n"
 
-#: ../../po/../src/ddcpci/intel810.c:105
+#: ../src/ddcpci/intel810.c:105
 #, c-format
 msgid "%s: Malloc error."
 msgstr "%s: Error malloc."
 
-#: ../../po/../src/ddcpci/intel810.c:171
+#: ../src/ddcpci/intel810.c:172
 msgid "i810_open: cannot open /dev/mem"
 msgstr "i810_open: no se puede abrir /dev/mem"
 
-#: ../../po/../src/ddcpci/intel810.c:206
+#: ../src/ddcpci/intel810.c:207
 #, c-format
 msgid "i810_open: Error: cannot find any valid MMIO PCI region.\n"
 msgstr "i810_open: Error: no se encuentran regiones MMIO PCI válidos.\n"
 
-#: ../../po/../src/ddcpci/intel810.c:213
+#: ../src/ddcpci/intel810.c:214
 msgid "i810_open: mmap failed"
 msgstr "i810_open: mmap failed"
 
-#: ../../po/../src/ddcpci/main.c:154
+#: ../src/ddcpci/main.c:160
 msgid "==>Error while sending open message"
 msgstr "==>Error mandando mensaje para abrir"
 
-#: ../../po/../src/ddcpci/main.c:178 ../../po/../src/ddcpci/main.c:184
-#: ../../po/../src/ddcpci/main.c:202
+#: ../src/ddcpci/main.c:184 ../src/ddcpci/main.c:190 ../src/ddcpci/main.c:208
 msgid "==>Error while sending data answer message"
 msgstr "==>Error mandando mensaje para contestar datos"
 
-#: ../../po/../src/ddcpci/main.c:251 ../../po/../src/ddcpci/main.c:266
+#: ../src/ddcpci/main.c:257 ../src/ddcpci/main.c:272
 msgid "==>Error while sending list message"
 msgstr "==>Error mandando mensaje para listar"
 
-#: ../../po/../src/ddcpci/main.c:284
+#: ../src/ddcpci/main.c:290
 #, c-format
 msgid "Invalid arguments.\n"
 msgstr "Argumentos inválidos.\n"
 
-#: ../../po/../src/ddcpci/main.c:290
+#: ../src/ddcpci/main.c:296
 #, c-format
 msgid "==>Can't read verbosity.\n"
 msgstr "==>No se puede leer verbosidád.\n"
 
-#: ../../po/../src/ddcpci/main.c:297
+#: ../src/ddcpci/main.c:303
 #, c-format
 msgid "==>Can't read key.\n"
 msgstr "==>No se puede leer llave.\n"
 
-#: ../../po/../src/ddcpci/main.c:302
+#: ../src/ddcpci/main.c:308
 #, c-format
 msgid "==>Can't open key %u\n"
 msgstr "==>No se puede abrir llave %u\n"
 
-#: ../../po/../src/ddcpci/main.c:316
+#: ../src/ddcpci/main.c:322
 #, c-format
 msgid "==>No command received for %ld seconds, aborting.\n"
 msgstr "==>Instrucción no recibido por %ld segundos, abortando.\n"
 
-#: ../../po/../src/ddcpci/main.c:324
+#: ../src/ddcpci/main.c:330
 msgid "==>Error while receiving query\n"
 msgstr "==>Error mientras recibiendo cuestión\n"
 
-#: ../../po/../src/ddcpci/main.c:359
+#: ../src/ddcpci/main.c:365
 #, c-format
 msgid "==>Invalid query...\n"
 msgstr "==>Cuestión inválido...\n"
 
-#: ../../po/../src/ddcpci/nvidia.c:122
+#: ../src/ddcpci/nvidia.c:122
 #, c-format
 msgid "nvidia.c:init_i2c_bus: Malloc error."
 msgstr "nvidia.c:init_i2c_bus: Error malloc."
 
-#: ../../po/../src/ddcpci/nvidia.c:165
+#: ../src/ddcpci/nvidia.c:165
 msgid "nvidia_open: cannot open /dev/mem"
 msgstr "nvidia_open: no se puede abrir /dev/mem"
 
-#: ../../po/../src/ddcpci/nvidia.c:175
+#: ../src/ddcpci/nvidia.c:175
 msgid "nvidia_open: mmap failed"
 msgstr "nvidia_open: falló mmap"
 
-#: ../../po/../src/ddcpci/radeon.c:173
+#: ../src/ddcpci/radeon.c:173
 #, c-format
 msgid "radeon.c:init_i2c_bus: Malloc error."
 msgstr "radeon.c:init_i2c_bus: Error malloc."
 
-#: ../../po/../src/ddcpci/radeon.c:221
+#: ../src/ddcpci/radeon.c:221
 msgid "radeon_open: cannot open /dev/mem"
 msgstr "radeon_open: no se puede abrir /dev/mem"
 
-#: ../../po/../src/ddcpci/radeon.c:230
+#: ../src/ddcpci/radeon.c:230
 msgid "radeon_open: mmap failed"
 msgstr "radeon_open: falló mmap"
 
-#: ../../po/../src/gddccontrol/fspatterns.c:195
+#: ../src/ddcpci/sis.c:133
+#, fuzzy, c-format
+msgid "sis.c:init_i2c_bus: Malloc error."
+msgstr "nvidia.c:init_i2c_bus: Error malloc."
+
+#: ../src/ddcpci/via.c:125
+#, fuzzy, c-format
+msgid "via.c:init_i2c_bus: Malloc error."
+msgstr "nvidia.c:init_i2c_bus: Error malloc."
+
+#: ../src/ddcpci/via.c:177
+#, fuzzy
+msgid "via_open: cannot open /dev/mem"
+msgstr "nvidia_open: no se puede abrir /dev/mem"
+
+#: ../src/ddcpci/via.c:186
+#, fuzzy
+msgid "via_open: mmap failed"
+msgstr "nvidia_open: falló mmap"
+
+#: ../src/gddccontrol/fspatterns.c:137
 msgid ""
 "Adjust brightness and contrast following these rules:\n"
 " - Black must be as dark as possible.\n"
@@ -493,45 +553,63 @@ msgstr ""
 " - Blanco debe ser lo mas vivo posible.\n"
 " - Tu tienes que distinguir cada nivel de gris (especialmente 0 y 12).\n"
 
-#: ../../po/../src/gddccontrol/fspatterns.c:211
+#: ../src/gddccontrol/fspatterns.c:259
 msgid "Try to make moire patterns disappear."
 msgstr "Intente hacer los patrones moire desaparecer."
 
-#: ../../po/../src/gddccontrol/fspatterns.c:215
+#: ../src/gddccontrol/fspatterns.c:263
 msgid ""
 "Adjust Image Lock Coarse to make the vertical band disappear.\n"
 "Adjust Image Lock Fine to minimize movement on the screen."
 msgstr ""
-"Ajuste Seguro Grueso de Imagen para hacer las bandas verticales desaparecer.\n"
+"Ajuste Seguro Grueso de Imagen para hacer las bandas verticales "
+"desaparecer.\n"
 "Ajuste Seguri Fino de Imagen para minimizar movimiento en la pantalla."
 
-#: ../../po/../src/gddccontrol/fspatterns.c:254
+#: ../src/gddccontrol/fspatterns.c:273
 #, c-format
 msgid "Unknown fullscreen pattern name: %s"
 msgstr "Patrón de pantalla entero desconocido: %s"
 
-#: ../../po/../src/gddccontrol/gprofile.c:53
-msgid "You must select at least one control to be saved in the profile."
-msgstr "Tienes que escoger por lo menos un control que sea guardado en el perfíl."
+#: ../src/gddccontrol/gddccontrol.desktop.in.h:1
+#, fuzzy
+msgid "DDC Control"
+msgstr "Control"
 
-#: ../../po/../src/gddccontrol/gprofile.c:61
+#: ../src/gddccontrol/gddccontrol.desktop.in.h:2
+#, fuzzy
+msgid "Monitor Settings"
+msgstr "Configuración de monitor"
+
+#: ../src/gddccontrol/gddccontrol.desktop.in.h:3
+msgid ""
+"Set your monitor preferences (contrast, brightness,...) and manage your "
+"profiles"
+msgstr ""
+
+#: ../src/gddccontrol/gprofile.c:54
+msgid "You must select at least one control to be saved in the profile."
+msgstr ""
+"Tienes que escoger por lo menos un control que sea guardado en el perfíl."
+
+#: ../src/gddccontrol/gprofile.c:62
 msgid "Creating profile..."
 msgstr "Creando perfíl..."
 
-#: ../../po/../src/gddccontrol/gprofile.c:76
+#: ../src/gddccontrol/gprofile.c:77
 msgid "Error while creating profile."
 msgstr "Error creando perfíl."
 
-#: ../../po/../src/gddccontrol/gprofile.c:93
+#: ../src/gddccontrol/gprofile.c:94
 msgid "Applying profile..."
 msgstr "Aplicando perfíl..."
 
-#: ../../po/../src/gddccontrol/gprofile.c:116
+#: ../src/gddccontrol/gprofile.c:117
 #, c-format
 msgid "Are you sure you want to delete the profile '%s'?"
 msgstr "Estás seguro que quieres borrar el perfíl '%s'?"
 
-#: ../../po/../src/gddccontrol/gprofile.c:142
+#: ../src/gddccontrol/gprofile.c:143
 msgid ""
 "Please select the controls you want to save in the profile using the "
 "checkboxes to the left of each control."
@@ -539,79 +617,78 @@ msgstr ""
 "Por favor escoge los controles que quieres guardar en el perfíl utilizando "
 "las cajitas a la izquierda de cada control."
 
-#: ../../po/../src/gddccontrol/gprofile.c:174
+#: ../src/gddccontrol/gprofile.c:175
 msgid "Profile Manager"
 msgstr "Gerente de Perfiles"
 
-#: ../../po/../src/gddccontrol/gprofile.c:193
+#: ../src/gddccontrol/gprofile.c:199
 msgid "Apply profile"
 msgstr "Aplicar perfíl"
 
-#: ../../po/../src/gddccontrol/gprofile.c:198
+#: ../src/gddccontrol/gprofile.c:208
 msgid "Show profile details / Rename profile"
 msgstr "Enseñar detalles del perfíl / Renombrar perfíl"
 
-#: ../../po/../src/gddccontrol/gprofile.c:203
+#: ../src/gddccontrol/gprofile.c:217
 msgid "Delete profile"
 msgstr "Borrar perfíl"
 
-#: ../../po/../src/gddccontrol/gprofile.c:229
+#: ../src/gddccontrol/gprofile.c:253
 msgid "Create profile"
 msgstr "Crear perfíl"
 
-#: ../../po/../src/gddccontrol/gprofile.c:235
+#: ../src/gddccontrol/gprofile.c:259
 msgid "Close profile manager"
 msgstr "Cerrar gerente de perfiles"
 
-#: ../../po/../src/gddccontrol/gprofile.c:299
+#: ../src/gddccontrol/gprofile.c:321
 msgid "Control name"
 msgstr "Nombre de control"
 
-#: ../../po/../src/gddccontrol/gprofile.c:310
+#: ../src/gddccontrol/gprofile.c:332
 msgid "Value"
 msgstr "Valor"
 
-#: ../../po/../src/gddccontrol/gprofile.c:313
+#: ../src/gddccontrol/gprofile.c:335
 msgid "Address"
 msgstr "Dirección"
 
-#: ../../po/../src/gddccontrol/gprofile.c:316
+#: ../src/gddccontrol/gprofile.c:338
 msgid "Raw value"
 msgstr "Valor sin preparar"
 
-#: ../../po/../src/gddccontrol/gprofile.c:434
-#: ../../po/../src/gddccontrol/gprofile.c:454
+#: ../src/gddccontrol/gprofile.c:456 ../src/gddccontrol/gprofile.c:476
 msgid "Profile information:"
 msgstr "Información de perfíl:"
 
-#: ../../po/../src/gddccontrol/gprofile.c:463
+#: ../src/gddccontrol/gprofile.c:485
 #, c-format
 msgid "File name: %s"
 msgstr "Nombre de ficher: %s"
 
-#: ../../po/../src/gddccontrol/gprofile.c:474
+#: ../src/gddccontrol/gprofile.c:496
 msgid "Profile name:"
 msgstr "Nombre de perfíl:"
 
 #. Save
-#: ../../po/../src/gddccontrol/gprofile.c:496
+#: ../src/gddccontrol/gprofile.c:518
 msgid "Saving profile..."
 msgstr "Guardando perfíl..."
 
-#: ../../po/../src/gddccontrol/gprofile.c:505
+#: ../src/gddccontrol/gprofile.c:527
 msgid "Error while saving profile."
 msgstr "Error guardando perfíl."
 
-#: ../../po/../src/gddccontrol/main.c:177
+#: ../src/gddccontrol/main.c:204
 #, c-format
 msgid "Monitor changed (%d %d).\n"
 msgstr "Monitor cambiado (%d %d).\n"
 
-#: ../../po/../src/gddccontrol/main.c:329
+#: ../src/gddccontrol/main.c:356
 msgid "Probing for available monitors..."
 msgstr "Investigando monitores disponibles..."
 
-#: ../../po/../src/gddccontrol/main.c:368
+#: ../src/gddccontrol/main.c:385
 msgid ""
 "No monitor supporting DDC/CI available.\n"
 "\n"
@@ -621,49 +698,51 @@ msgstr ""
 "No hay monitor disponible que soporta DDC/CI.\n"
 "\n"
 "Si le hace falta a tu tarjeta de gráficos, por favor verifique que todos los "
-"módulos requeridos del núcleo están cargados (i2c-dev, y el manejador del framebuffer)."
+"módulos requeridos del núcleo están cargados (i2c-dev, y el manejador del "
+"framebuffer)."
 
-#: ../../po/../src/gddccontrol/main.c:420
+#: ../src/gddccontrol/main.c:438
 msgid "Unable to initialize ddcci library, see console for more details.\n"
-msgstr "No se pudo inicializar la biblioteca ddcci, vea la consola para detalles.\n"
+msgstr ""
+"No se pudo inicializar la biblioteca ddcci, vea la consola para detalles.\n"
 
-#: ../../po/../src/gddccontrol/main.c:430
+#: ../src/gddccontrol/main.c:450
 msgid "Monitor settings"
 msgstr "Configuración de monitor"
 
-#: ../../po/../src/gddccontrol/main.c:454
+#: ../src/gddccontrol/main.c:474
 msgid "Current monitor: "
 msgstr "Monitor actial: "
 
-#: ../../po/../src/gddccontrol/main.c:464
+#: ../src/gddccontrol/main.c:484
 msgid "Refresh monitor list"
 msgstr "Actualizar lista de monitores"
 
-#: ../../po/../src/gddccontrol/main.c:481
+#: ../src/gddccontrol/main.c:507
 msgid "Profile manager"
 msgstr "Gerente de perfiles"
 
-#: ../../po/../src/gddccontrol/main.c:488
+#: ../src/gddccontrol/main.c:514
 msgid "Save profile"
 msgstr "Guardar perfíl"
 
-#: ../../po/../src/gddccontrol/main.c:494
+#: ../src/gddccontrol/main.c:520
 msgid "Cancel profile creation"
 msgstr "Cancelar creación de perfíl"
 
-#: ../../po/../src/gddccontrol/main.c:518
+#: ../src/gddccontrol/main.c:549
 msgid "OK"
 msgstr "Bien"
 
-#: ../../po/../src/gddccontrol/main.c:546
+#: ../src/gddccontrol/main.c:585
 msgid "Refresh"
 msgstr "Actualizar"
 
-#: ../../po/../src/gddccontrol/main.c:546
+#: ../src/gddccontrol/main.c:585
 msgid "Refresh all controls"
 msgstr "Actualizar todos los controles"
 
-#: ../../po/../src/gddccontrol/main.c:553
+#: ../src/gddccontrol/main.c:592
 msgid "Close"
 msgstr "Cerrar"
 
@@ -671,34 +750,33 @@ msgstr "Cerrar"
 #. gtk_misc_set_alignment(GTK_MISC(moninfo), 0, 0);
 #.
 #. gtk_table_attach(GTK_TABLE(table), moninfo, 0, 1, 1, 2, GTK_FILL_EXPAND, 0, 5, 5);
-#: ../../po/../src/gddccontrol/main.c:592
+#: ../src/gddccontrol/main.c:634
 #, c-format
 msgid "Welcome to gddccontrol %s."
 msgstr "Bienvenidos a gddccontrol %s."
 
-#: ../../po/../src/gddccontrol/notebook.c:81
+#: ../src/gddccontrol/notebook.c:83
 msgid "Error while getting value"
 msgstr "Error obteniendo valor"
 
-#: ../../po/../src/gddccontrol/notebook.c:116
-#: ../../po/../src/gddccontrol/notebook.c:128
+#: ../src/gddccontrol/notebook.c:118 ../src/gddccontrol/notebook.c:130
 #, c-format
 msgid "Refreshing controls values (%d%%)..."
 msgstr "Actualizando valores de control (%d%%)..."
 
-#: ../../po/../src/gddccontrol/notebook.c:133
+#: ../src/gddccontrol/notebook.c:135
 msgid "Could not get the control_db struct related to a control."
 msgstr "No se pudo obtener la estructura control_db relacionado a un control."
 
-#: ../../po/../src/gddccontrol/notebook.c:493
+#: ../src/gddccontrol/notebook.c:495
 msgid "Show fullscreen patterns"
 msgstr "Enseñe patrones de pantalla entero"
 
-#: ../../po/../src/gddccontrol/notebook.c:525
+#: ../src/gddccontrol/notebook.c:527
 msgid "Section"
 msgstr "Sección"
 
-#: ../../po/../src/gddccontrol/notebook.c:572
+#: ../src/gddccontrol/notebook.c:574
 msgid ""
 "The current monitor is in the database but does not support DDC/CI.\n"
 "\n"
@@ -711,17 +789,19 @@ msgstr ""
 "El monitor actual está en el base de datos pero on soporta DDC/CI.\n"
 "\n"
 "Muchas veces, esto pasa cuando tu connectas el cable VGA/DVI a la entrada "
-"incorrecto de monitores soportando DDC/CI solamente en una de las dos entradas.\n"
+"incorrecto de monitores soportando DDC/CI solamente en una de las dos "
+"entradas.\n"
 "\n"
 "Si tu monitor tiene dos entradas, por favor intente conectar el cable a la "
-"otra entrada, y entonces presione el botón para actualizar la lista de monitores."
+"otra entrada, y entonces presione el botón para actualizar la lista de "
+"monitores."
 
-#: ../../po/../src/gddccontrol/notebook.c:583
+#: ../src/gddccontrol/notebook.c:585
 #, c-format
 msgid "Opening the monitor device (%s)..."
 msgstr "Abriendo el dispositivo del monitor (%s)..."
 
-#: ../../po/../src/gddccontrol/notebook.c:591
+#: ../src/gddccontrol/notebook.c:591
 msgid ""
 "An error occurred while opening the monitor device.\n"
 "Maybe this monitor was disconnected, please click on the refresh button near "
@@ -731,34 +811,32 @@ msgstr ""
 "Tal vez este monitor estaba desconectado, por favor presione el botón para "
 "actualizar la list de monitores."
 
-#: ../../po/../src/gddccontrol/notebook.c:600
+#: ../src/gddccontrol/notebook.c:600
 #, c-format
 msgid ""
-"The current monitor is not supported, please run\n"
-"%s\n"
-"and send the output to ddccontrol-users@lists.sourceforge.net.\n"
-"Thanks."
+"Unsupported monitor detected.\n"
+"\n"
+"Please update ddccontrol-db, or, if you are already using the latest\n"
+"version, please open a github issue:\n"
+"https://github.com/ddccontrol/ddccontrol-db/issues/new?template=unsupported-"
+"monitor.yml\n"
+"Then attach the resulting report file of the following command:"
 msgstr ""
-"El monitor actual no es soportado, por favor ejecute\n"
-"%s\n"
-"y mande la salida a ddccontrol-users@lists.sourceforge.net.\n"
-"Gracias."
 
-#: ../../po/../src/gddccontrol/notebook.c:620
+#: ../src/gddccontrol/notebook.c:622
 msgid "Please click on a group name."
 msgstr "Por favor haz clic en el nombre de un grupo."
 
-#: ../../po/../src/gddccontrol/notebook.c:639
-#: ../../po/../src/gddccontrol/notebook.c:650
+#: ../src/gddccontrol/notebook.c:647 ../src/gddccontrol/notebook.c:658
 #, c-format
 msgid "Getting controls values (%d%%)..."
 msgstr "Obteniendo valores de controles (%d%%)..."
 
-#: ../../po/../src/gddccontrol/notebook.c:664
+#: ../src/gddccontrol/notebook.c:683
 msgid "Loading profiles..."
 msgstr "Cargando perfiles..."
 
-#: ../../po/../src/gddccontrol/notebook.c:677
+#: ../src/gddccontrol/notebook.c:696
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is "
 "using a generic profile for your monitor's manufacturer. Some controls may "
@@ -766,9 +844,10 @@ msgid ""
 msgstr ""
 "No hay soporte para tu monitor en el base de datos, pero ddccontrol está "
 "utilizando un perfíl genérico que corresponde al fabricante de tu monitor. "
-"Algunos controles no serán soportados, o no funcionarán de la forma esperado.\n"
+"Algunos controles no serán soportados, o no funcionarán de la forma "
+"esperado.\n"
 
-#: ../../po/../src/gddccontrol/notebook.c:683
+#: ../src/gddccontrol/notebook.c:702
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is "
 "using a basic generic profile. Many controls will not be supported, and some "
@@ -778,357 +857,315 @@ msgstr ""
 "utilizando un perfíl genérico. Muchos controles no serán soportados, y "
 "algunos controles no funcionarán de la forma esperado.\n"
 
-#: ../../po/../src/gddccontrol/notebook.c:688
+#: ../src/gddccontrol/notebook.c:707
 msgid "Warning!"
 msgstr "Aviso!"
 
-#: ../../po/../src/gddccontrol/notebook.c:690
+#: ../src/gddccontrol/notebook.c:709
 msgid ""
-"Please update ddccontrol-db, or, if you are already using the latest "
-"version, please send the output of the following command to "
-"ddccontrol-users@lists.sourceforge.net:\n"
+"Unsupported monitor detected.\n"
+"\n"
+"Please update ddccontrol-db, or, if you are already using the latest\n"
+"version, please open a github issue:\n"
+"https://github.com/ddccontrol/ddccontrol-db/issues/new?template=unsupported-"
+"monitor.yml\n"
+"Then attach the resulting report file of the following command:\n"
 msgstr ""
-"Por favor actualize ddccontrol-db, o, si ya estás usando la versión\n"
-"última, por favor mande la salida de esta instrucción a\n"
-"ddccontrol-users@lists.sourceforge.net:\n"
 
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.server.in.in.h:1
-#: ../../po/../src/gnome-ddcc-applet/ddcc-applet.c:184
-msgid "Monitor Profile Switcher"
-msgstr "Cambiador de Perfíl de Monitor"
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.server.in.in.h:2
-msgid "Quickly switch monitor profiles created with gddccontrol"
-msgstr "Rapidamente cambie perfiles de monitor creado con gddccontrol"
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.xml.h:1
-msgid "_About..."
-msgstr "_Acerca de..."
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.xml.h:2
-msgid "_Properties..."
-msgstr "_Propiedades..."
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.xml.h:3
-msgid "_Run gddccontrol..."
-msgstr "_Ejecutar gddccontrol..."
-
-#: ../../po/../src/gnome-ddcc-applet/ddcc-applet.c:189
-msgid ""
-"An applet for quick switching of monitor profiles.\n"
-"Based on libddccontrol and part of the ddccontrol project.\n"
-"(http://ddccontrol.sourceforge.net)"
-msgstr ""
-"Un subprograma para rapidamente cambiar perfiles de monitor.\n"
-"Basado en libddccontrol y parte del proyecto ddccontrol.\n"
-"(http://ddccontrol.sourceforge.net)"
-
-#: ../../po/../src/gnome-ddcc-applet/ddcc-applet.c:386
-msgid "Unable to initialize ddcci library"
-msgstr "No se pudo inicializar la biblioteca ddcci."
-
-#: ../../po/../src/gnome-ddcc-applet/ddcc-applet.c:390
-msgid "No monitor configuration found. Please run gddccontrol first"
-msgstr "No se encontró configuración de monitor.  Por favor ejecute gddccontrol primero"
-
-#: ../../po/../src/gnome-ddcc-applet/ddcc-applet.c:395
-msgid "An error occurred while opening the monitor device"
-msgstr "Ocurrió un error abriendo el dispositivo del monitor"
-
-#: ../../po/../src/gnome-ddcc-applet/ddcc-applet.c:400
-msgid "Can't find any profiles"
-msgstr "No se pudo encontrar ningunos perfiles"
-
-#. only reached, if init was not finished
-#: ../../po/../src/gnome-ddcc-applet/ddcc-applet.c:416
-msgid "error"
-msgstr "error"
-
-#: ../../po/../src/gnome-ddcc-applet/ddcc-applet.c:440
-msgid "Monitor:"
-msgstr "Monitor:"
-
-#: ../../po/../src/gnome-ddcc-applet/ddcc-applet.c:443
-msgid "Monitor Profile Switcher Properties"
-msgstr "Propiedades del Cambiador de Perfiles de Monitor"
-
-#: ../../po/../src/lib/conf.c:61 ../../po/../src/lib/conf.c:258
-#: ../../po/../src/lib/conf.c:308 ../../po/../src/lib/ddcci.c:1202
+#: ../src/lib/conf.c:63 ../src/lib/conf.c:260 ../src/lib/conf.c:310
+#: ../src/lib/ddcci.c:1306
 msgid "Cannot create filename (buffer too small)\n"
 msgstr "No se pudo crear nombre de fichero (memoria intermedia muy pequeño)\n"
 
-#: ../../po/../src/lib/conf.c:86 ../../po/../src/lib/conf.c:363
-#: ../../po/../src/lib/monitor_db.c:350 ../../po/../src/lib/monitor_db.c:714
+#: ../src/lib/conf.c:88 ../src/lib/conf.c:367 ../src/lib/monitor_db.c:353
+#: ../src/lib/monitor_db.c:726
 #, c-format
 msgid "Document not parsed successfully.\n"
 msgstr "Análisis sintáctico del documento falló.\n"
 
-#: ../../po/../src/lib/conf.c:93 ../../po/../src/lib/conf.c:370
+#: ../src/lib/conf.c:95 ../src/lib/conf.c:375
 #, c-format
 msgid "empty profile file\n"
 msgstr "fichero de perfíl vacio\n"
 
-#: ../../po/../src/lib/conf.c:99 ../../po/../src/lib/conf.c:376
+#: ../src/lib/conf.c:101 ../src/lib/conf.c:382
 #, c-format
 msgid "profile of the wrong type, root node %s != profile"
 msgstr "perfíl del tipo incorrecto, nódulo raíz %s != perfíl"
 
-#: ../../po/../src/lib/conf.c:105
+#: ../src/lib/conf.c:107
 msgid "Can't find ddccontrolversion property."
 msgstr "No se encuentra propiedad 'ddccontrolversion'"
 
-#: ../../po/../src/lib/conf.c:107
+#: ../src/lib/conf.c:109
 #, c-format
 msgid "ddccontrol has been upgraded since monitorlist was saved (%s vs %s).\n"
-msgstr "ddccontrol ha sido actualizado desde que se guardó monitorlist (%s vs %s).\n"
+msgstr ""
+"ddccontrol ha sido actualizado desde que se guardó monitorlist (%s vs %s).\n"
 
-#: ../../po/../src/lib/conf.c:124
+#: ../src/lib/conf.c:126
 msgid "Can't find filename property."
 msgstr "No se encuentra propiedad 'filename'"
 
-#: ../../po/../src/lib/conf.c:130
+#: ../src/lib/conf.c:132
 msgid "Can't find supported property."
 msgstr "No se encuentra propiedad 'supported'"
 
-#: ../../po/../src/lib/conf.c:133
+#: ../src/lib/conf.c:135
 msgid "Can't convert supported property to int."
 msgstr "So se puede convertir propiedad 'supported' a número entero"
 
-#: ../../po/../src/lib/conf.c:138 ../../po/../src/lib/conf.c:385
-#: ../../po/../src/lib/monitor_db.c:90 ../../po/../src/lib/monitor_db.c:194
-#: ../../po/../src/lib/monitor_db.c:370 ../../po/../src/lib/monitor_db.c:426
-#: ../../po/../src/lib/monitor_db.c:447
+#: ../src/lib/conf.c:140 ../src/lib/conf.c:392 ../src/lib/monitor_db.c:92
+#: ../src/lib/monitor_db.c:196 ../src/lib/monitor_db.c:373
+#: ../src/lib/monitor_db.c:429 ../src/lib/monitor_db.c:450
 msgid "Can't find name property."
 msgstr "No se encuentra propiedad 'name'"
 
-#: ../../po/../src/lib/conf.c:144
+#: ../src/lib/conf.c:146
 msgid "Can't find digital property."
 msgstr "No se encuentra propiedad 'digital'"
 
-#: ../../po/../src/lib/conf.c:147
+#: ../src/lib/conf.c:149
 msgid "Can't convert digital property to int."
 msgstr "So se puede convertir propiedad 'digital' a número entero"
 
-#: ../../po/../src/lib/conf.c:175 ../../po/../src/lib/conf.c:439
+#: ../src/lib/conf.c:177 ../src/lib/conf.c:447
 msgid "Cannot create the xml writer\n"
 msgstr "No se pueded crear el escribidor xml\n"
 
-#: ../../po/../src/lib/conf.c:239
+#: ../src/lib/conf.c:241
 msgid "Cannot read control value\n"
 msgstr "No se puede leer el valor del control\n"
 
-#: ../../po/../src/lib/conf.c:276
+#: ../src/lib/conf.c:278
 msgid "Cannot write control value\n"
 msgstr "No se puede escribir el valor del control\n"
 
-#: ../../po/../src/lib/conf.c:313
+#: ../src/lib/conf.c:315
 msgid "Error while opening ddccontrol home directory."
 msgstr "Error abriendo directorio casero de ddccontrol"
 
-#: ../../po/../src/lib/conf.c:337
+#: ../src/lib/conf.c:340
 msgid "Error while reading ddccontrol home directory."
 msgstr "Error leendo el directorio casero de ddccontrol"
 
-#: ../../po/../src/lib/conf.c:382
+#: ../src/lib/conf.c:389
 msgid "Can't find pnpid property."
 msgstr "No se encuentra la propiedad 'pnpid'"
 
-#: ../../po/../src/lib/conf.c:388 ../../po/../src/lib/conf.c:391
+#: ../src/lib/conf.c:395 ../src/lib/conf.c:398
 msgid "Can't find version property."
 msgstr "No se encuentra propiedad 'version'"
 
-#: ../../po/../src/lib/conf.c:390 ../../po/../src/lib/monitor_db.c:752
+#: ../src/lib/conf.c:397 ../src/lib/monitor_db.c:764
 msgid "Can't convert version to int."
 msgstr "So se puede convertir propiedad 'version' a número entero"
 
-#: ../../po/../src/lib/conf.c:393
+#: ../src/lib/conf.c:400
 #, c-format
 msgid "profile version (%d) is not supported (should be %d).\n"
 msgstr "versión de perfíl (%d) no es soportado (debe ser %d).\n"
 
-#: ../../po/../src/lib/conf.c:407 ../../po/../src/lib/monitor_db.c:229
+#: ../src/lib/conf.c:415 ../src/lib/monitor_db.c:233
 msgid "Can't find address property."
 msgstr "No se encuentra propiedad 'address'"
 
-#: ../../po/../src/lib/conf.c:409 ../../po/../src/lib/monitor_db.c:231
+#: ../src/lib/conf.c:417 ../src/lib/monitor_db.c:235
 msgid "Can't convert address to int."
 msgstr "So se puede convertir propiedad 'address' a número entero"
 
-#: ../../po/../src/lib/conf.c:413 ../../po/../src/lib/monitor_db.c:112
+#: ../src/lib/conf.c:421 ../src/lib/monitor_db.c:114
 msgid "Can't find value property."
 msgstr "No se encuentra propiedad 'value'"
 
-#: ../../po/../src/lib/conf.c:415 ../../po/../src/lib/monitor_db.c:114
+#: ../src/lib/conf.c:423 ../src/lib/monitor_db.c:116
 msgid "Can't convert value to int."
 msgstr "So se puede convertir propiedad 'value' a número entero"
 
-#: ../../po/../src/lib/conf.c:499
+#: ../src/lib/conf.c:507
 msgid "ddcci_delete_profile: Error, cannot delete profile.\n"
 msgstr "ddcci_delete_profile: Error, no se puede borrar perfíl.\n"
 
-#: ../../po/../src/lib/conf.c:519
+#: ../src/lib/conf.c:527
 #, c-format
 msgid "ddcci_delete_profile: Error, could not find the profile to delete.\n"
 msgstr "ddcci_delete_profile: Error, no so encontró el perfíl para borrar.\n"
 
-#: ../../po/../src/lib/ddcci.c:146
+#: ../src/lib/ddcci.c:148
 msgid "Error while initialisating the message queue"
 msgstr "Error inicializando la cola de mensajes"
 
-#: ../../po/../src/lib/ddcci.c:175
+#: ../src/lib/ddcci.c:177
 msgid "Error while sending quit message"
 msgstr "Error mandando el mensaje de abandonar"
 
-#: ../../po/../src/lib/ddcci.c:221
+#: ../src/lib/ddcci.c:223
 msgid "Error while sending heartbeat message"
 msgstr "Error mandando el mansaje 'heartbeat'"
 
-#: ../../po/../src/lib/ddcci.c:239
+#: ../src/lib/ddcci.c:241
 #, c-format
 msgid "Failed to initialize ddccontrol database...\n"
 msgstr "Falló inicialización de base de datos ddccontrol...\n"
 
-#: ../../po/../src/lib/ddcci.c:275 ../../po/../src/lib/ddcci.c:350
+#: ../src/lib/ddcci.c:247
+#, fuzzy, c-format
+msgid "Failed to initialize ADL...\n"
+msgstr "Falló inicialización de base de datos ddccontrol...\n"
+
+#: ../src/lib/ddcci.c:292 ../src/lib/ddcci.c:383
 #, c-format
 msgid "ioctl returned %d\n"
 msgstr "ioctl devolvió %d\n"
 
-#: ../../po/../src/lib/ddcci.c:300
+#: ../src/lib/ddcci.c:321
 msgid "Error while sending write message"
 msgstr "Error mandando mensaje de escribir"
 
-#: ../../po/../src/lib/ddcci.c:309
+#: ../src/lib/ddcci.c:330
 msgid "Error while reading write message answer"
 msgstr "Error leendo respuesta del mensaje de escribir"
 
-#: ../../po/../src/lib/ddcci.c:376
+#: ../src/lib/ddcci.c:413
 msgid "Error while sending read message"
 msgstr "Error mandando el mensaje de lectura"
 
-#: ../../po/../src/lib/ddcci.c:385
+#: ../src/lib/ddcci.c:422
 msgid "Error while reading read message answer"
 msgstr "Error leendo respuesta del mensaje de lectura"
 
-#: ../../po/../src/lib/ddcci.c:475
+#: ../src/lib/ddcci.c:518
 #, c-format
 msgid "Invalid response, first byte is 0x%02x, should be 0x%02x\n"
 msgstr "Respuesta inválido, primer byte es 0x%02x, debe ser 0x%02x\n"
 
-#: ../../po/../src/lib/ddcci.c:485
+#: ../src/lib/ddcci.c:528
 #, c-format
 msgid "Non-fatal error: Invalid response, magic is 0x%02x\n"
 msgstr "Error no fatal: Respuesta inválido, magia es 0x%02x\n"
 
-#: ../../po/../src/lib/ddcci.c:492
+#: ../src/lib/ddcci.c:535
 #, c-format
 msgid "Invalid response, length is %d, should be %d at most\n"
 msgstr "Respuesta inválido, largo es %d, debe ser %d a lo más\n"
 
-#: ../../po/../src/lib/ddcci.c:505
+#: ../src/lib/ddcci.c:548
 #, c-format
 msgid "Invalid response, corrupted data - xor is 0x%02x, length 0x%02x\n"
 msgstr "Respuesta inválido, datos corruptos - xor es 0x%02x, largo 0x%02x\n"
 
-#: ../../po/../src/lib/ddcci.c:658 ../../po/../src/lib/ddcci.c:680
+#: ../src/lib/ddcci.c:709 ../src/lib/ddcci.c:731
 #, c-format
 msgid "Can't convert value to int, invalid CAPS (buf=%s, pos=%d).\n"
-msgstr "No se puede convertir valor a número entero, CAPS inválido (buf=%s, pos=%s).\n"
+msgstr ""
+"No se puede convertir valor a número entero, CAPS inválido (buf=%s, "
+"pos=%d).\n"
 
-#: ../../po/../src/lib/ddcci.c:763
+#: ../src/lib/ddcci.c:814
 #, c-format
 msgid "Invalid sequence in caps.\n"
 msgstr "Secuencia inválida en 'caps'.\n"
 
-#: ../../po/../src/lib/ddcci.c:841
+#: ../src/lib/ddcci.c:892
 #, c-format
 msgid "Corrupted EDID at 0x%02x.\n"
 msgstr "EDID corrupto en 0x%02x.\n"
 
-#: ../../po/../src/lib/ddcci.c:853
+#: ../src/lib/ddcci.c:904
 #, c-format
 msgid "Serial number: %d\n"
 msgstr "Número de seria: %d\n"
 
-#: ../../po/../src/lib/ddcci.c:856
+#: ../src/lib/ddcci.c:907
 #, c-format
 msgid "Manufactured: Week %d, %d\n"
 msgstr "Fabricado: Semana %d, %d\n"
 
-#: ../../po/../src/lib/ddcci.c:859
+#: ../src/lib/ddcci.c:910
 #, c-format
 msgid "EDID version: %d.%d\n"
 msgstr "Versión EDID: %d.%d\n"
 
-#: ../../po/../src/lib/ddcci.c:862
+#: ../src/lib/ddcci.c:913
 #, c-format
 msgid "Maximum size: %d x %d (cm)\n"
 msgstr "Tamaño máximo: %d x %d (cm)\n"
 
-#: ../../po/../src/lib/ddcci.c:873
+#: ../src/lib/ddcci.c:924
 #, c-format
 msgid "Reading EDID 0x%02x failed.\n"
 msgstr "Lectura de EDID 0x%02x falló.\n"
 
-#: ../../po/../src/lib/ddcci.c:903
+#: ../src/lib/ddcci.c:954
 #, c-format
 msgid "Device: %s\n"
 msgstr "Dispositivo: %s\n"
 
-#: ../../po/../src/lib/ddcci.c:917
+#: ../src/lib/ddcci.c:968
 msgid "Error while sending open message"
 msgstr "Error mandando mensaje para abrir"
 
-#: ../../po/../src/lib/ddcci.c:925
+#: ../src/lib/ddcci.c:976
 msgid "Error while reading open message answer"
 msgstr "Error leendo respuesta del mensaje para abrir"
 
-#: ../../po/../src/lib/ddcci.c:933
+#: ../src/lib/ddcci.c:988 ../src/lib/ddcci.c:1001
 #, c-format
 msgid "Invalid filename (%s).\n"
 msgstr "Nombre de fichero inválido (%s).\n"
 
-#: ../../po/../src/lib/ddcci.c:1049
+#: ../src/lib/ddcci.c:993
+#, c-format
+msgid "ADL display not found (%s).\n"
+msgstr ""
+
+#: ../src/lib/ddcci.c:1125
 #, c-format
 msgid "ddcci_open returned %d\n"
 msgstr "ddcci_open devolvió %d\n"
 
-#: ../../po/../src/lib/ddcci.c:1062
+#: ../src/lib/ddcci.c:1138
 #, c-format
 msgid "Unknown monitor (%s)"
 msgstr "Monitor desconocido (%s)"
 
-#: ../../po/../src/lib/ddcci.c:1083
+#: ../src/lib/ddcci.c:1159
 #, c-format
 msgid "Probing for available monitors"
 msgstr "Investigando monitores disponibles"
 
-#: ../../po/../src/lib/ddcci.c:1097
+#: ../src/lib/ddcci.c:1173
 msgid "Error while sending list message"
 msgstr "Error mandando mensaje para hacer lista"
 
-#: ../../po/../src/lib/ddcci.c:1106
+#: ../src/lib/ddcci.c:1182
 msgid "Error while reading list entry"
 msgstr "Error leendo entrada del mensaje de hacer lista"
 
-#: ../../po/../src/lib/ddcci.c:1123
+#: ../src/lib/ddcci.c:1199
 #, c-format
 msgid "Found PCI device (%s)\n"
 msgstr "Se encontró dispositivo PCI (%s)\n"
 
-#: ../../po/../src/lib/ddcci.c:1157
+#: ../src/lib/ddcci.c:1239
 #, c-format
 msgid "Found I2C device (%s)\n"
 msgstr "Se encontró dispositivo I2C (%s)\n"
 
-#: ../../po/../src/lib/ddcci.c:1206
+#: ../src/lib/ddcci.c:1264
+#, fuzzy, c-format
+msgid "Found ADL display (%s)\n"
+msgstr "Se encontró dispositivo PCI (%s)\n"
+
+#: ../src/lib/ddcci.c:1310
 msgid "Error while getting information about ddccontrol home directory."
 msgstr "Error obteniendo información sobre el directorio casero de ddccontrol."
 
-#: ../../po/../src/lib/ddcci.c:1211
+#: ../src/lib/ddcci.c:1316
 msgid "Error while creating ddccontrol home directory."
 msgstr "Error creando el directorio casero de ddccontrol."
 
-#: ../../po/../src/lib/ddcci.c:1216
+#: ../src/lib/ddcci.c:1322
 msgid ""
 "Error while getting information about ddccontrol home directory after "
 "creating it."
@@ -1136,154 +1173,209 @@ msgstr ""
 "Error obteniendo información sobre el directorio casero de ddccontrol "
 "despues de crearlo."
 
-#: ../../po/../src/lib/ddcci.c:1223
+#: ../src/lib/ddcci.c:1330
 msgid "Error: '.ddccontrol' in your home directory is not a directory."
 msgstr "Error: '.ddccontro' en tu directorio casero no es un directorio."
 
-#: ../../po/../src/lib/ddcci.c:1231
+#: ../src/lib/ddcci.c:1339
 msgid "Error while getting information about ddccontrol profile directory."
-msgstr "Error obteniendo información sobre el directorio de perfíl de ddccontrol."
+msgstr ""
+"Error obteniendo información sobre el directorio de perfíl de ddccontrol."
 
-#: ../../po/../src/lib/ddcci.c:1236
+#: ../src/lib/ddcci.c:1345
 msgid "Error while creating ddccontrol profile directory."
 msgstr "Error creando el directorio de perfíl de ddccontrol."
 
-#: ../../po/../src/lib/ddcci.c:1241
+#: ../src/lib/ddcci.c:1351
 msgid ""
 "Error while getting information about ddccontrol profile directory after "
 "creating it."
 msgstr ""
-"Error obteniendo información sobre el directorio de perfíl de ddccontrol"
-"despues de crearlo."
+"Error obteniendo información sobre el directorio de perfíl de "
+"ddccontroldespues de crearlo."
 
-#: ../../po/../src/lib/ddcci.c:1248
+#: ../src/lib/ddcci.c:1359
 msgid ""
 "Error: '.ddccontrol/profiles' in your home directory is not a directory."
 msgstr ""
 "Error: '.ddccontrol/profiles' en tu directorio casero no es un directorio."
 
-#: ../../po/../src/lib/monitor_db.c:82 ../../po/../src/lib/monitor_db.c:192
+#: ../src/lib/monitor_db.c:84 ../src/lib/monitor_db.c:194
 msgid "Can't find id property."
 msgstr "No se encuentra propiedad 'id'."
 
-#: ../../po/../src/lib/monitor_db.c:151 ../../po/../src/lib/monitor_db.c:546
+#: ../src/lib/monitor_db.c:153 ../src/lib/monitor_db.c:549
 #, c-format
 msgid "Element %s (id=%s) has not been found (line %ld).\n"
 msgstr "Elemento %s (identificación=%s) no se ha encontrado (linea %ld).\n"
 
-#: ../../po/../src/lib/monitor_db.c:205
+#: ../src/lib/monitor_db.c:207
 msgid "Invalid refresh type (!= none, != all)."
 msgstr "Tipo de actualización inválido (!= ninguno, != todo)."
 
-#: ../../po/../src/lib/monitor_db.c:238
+#: ../src/lib/monitor_db.c:242
 #, c-format
 msgid "Control %s has been discarded by the caps string.\n"
 msgstr "Control %s ha sido descartado por la cadena 'caps'.\n"
 
-#: ../../po/../src/lib/monitor_db.c:246
+#: ../src/lib/monitor_db.c:250
 #, c-format
 msgid "Control %s (0x%02x) has already been defined.\n"
 msgstr "Control %s (0x%02x) ya ha sido definido.\n"
 
-#: ../../po/../src/lib/monitor_db.c:259
+#: ../src/lib/monitor_db.c:263
 msgid "Can't convert delay to int."
 msgstr "So se puede convertir demora a número entero"
 
-#: ../../po/../src/lib/monitor_db.c:267
+#: ../src/lib/monitor_db.c:271
 msgid "Can't find type property."
 msgstr "No se encuentra propiedad 'type'."
 
-#: ../../po/../src/lib/monitor_db.c:292 ../../po/../src/lib/monitor_db.c:381
+#: ../src/lib/monitor_db.c:296 ../src/lib/monitor_db.c:384
 msgid "Invalid type."
 msgstr "Tipo inválido."
 
-#: ../../po/../src/lib/monitor_db.c:343
+#: ../src/lib/monitor_db.c:346
 #, c-format
 msgid "Database must be inited before reading a monitor file.\n"
-msgstr "Base de datos tiene que ser incializado antes de leer un fichero de monitor.\n"
+msgstr ""
+"Base de datos tiene que ser incializado antes de leer un fichero de "
+"monitor.\n"
 
-#: ../../po/../src/lib/monitor_db.c:357
+#: ../src/lib/monitor_db.c:360
 #, c-format
 msgid "empty monitor/%s.xml\n"
 msgstr "monitor/%s.xml vacio\n"
 
-#: ../../po/../src/lib/monitor_db.c:363
+#: ../src/lib/monitor_db.c:366
 #, c-format
 msgid "monitor/%s.xml of the wrong type, root node %s != monitor"
 msgstr "monitor/%s.xml del tipo incorrecto, nódulo raíz %s != monitor"
 
-#: ../../po/../src/lib/monitor_db.c:464
+#: ../src/lib/monitor_db.c:467
 msgid "Can't find add or remove property in caps."
 msgstr "No se encuentra propiedad 'add or remove' en caps."
 
-#: ../../po/../src/lib/monitor_db.c:466
+#: ../src/lib/monitor_db.c:469
 msgid "Invalid remove caps."
 msgstr "'remove' caps inválido."
 
-#: ../../po/../src/lib/monitor_db.c:468
+#: ../src/lib/monitor_db.c:471
 msgid "Invalid add caps."
 msgstr "'add' caps inválido."
 
-#: ../../po/../src/lib/monitor_db.c:473
+#: ../src/lib/monitor_db.c:476
 #, c-format
 msgid "Error, include recursion level > 15 (file: %s).\n"
 msgstr "Error, nivel de repetición > 15 (fichero: %s).\n"
 
-#: ../../po/../src/lib/monitor_db.c:479
+#: ../src/lib/monitor_db.c:482
 msgid "Can't find file property."
 msgstr "No se encuentra propiedad 'file'."
 
-#: ../../po/../src/lib/monitor_db.c:487
+#: ../src/lib/monitor_db.c:490
 msgid "Two controls part in XML file."
 msgstr "Dos partes de controles en fichero XML."
 
-#: ../../po/../src/lib/monitor_db.c:534
+#: ../src/lib/monitor_db.c:537
 msgid "Error enumerating controls in subgroup."
 msgstr "Error enumerando controles en subgrupo."
 
-#: ../../po/../src/lib/monitor_db.c:589
+#: ../src/lib/monitor_db.c:601
 #, c-format
 msgid "document of the wrong type, can't find controls or include.\n"
-msgstr "document del tipo incorrecto, no se encuentra 'controls' o 'include'.\n"
+msgstr ""
+"document del tipo incorrecto, no se encuentra 'controls' o 'include'.\n"
 
-#: ../../po/../src/lib/monitor_db.c:721
+#: ../src/lib/monitor_db.c:733
 #, c-format
 msgid "empty options.xml\n"
 msgstr "options.xml vacio\n"
 
-#: ../../po/../src/lib/monitor_db.c:728
+#: ../src/lib/monitor_db.c:740
 #, c-format
 msgid "options.xml of the wrong type, root node %s != options"
 msgstr "options.xml del tipo incorrecto, nódulo raíz %s != options"
 
-#: ../../po/../src/lib/monitor_db.c:738
+#: ../src/lib/monitor_db.c:750
 #, c-format
 msgid "options.xml dbversion attribute missing, please update your database.\n"
-msgstr "options.xml atributo dbversion falta, por favor actualize tu base de datos.\n"
+msgstr ""
+"options.xml atributo dbversion falta, por favor actualize tu base de datos.\n"
 
-#: ../../po/../src/lib/monitor_db.c:745
+#: ../src/lib/monitor_db.c:757
 #, c-format
 msgid "options.xml date attribute missing, please update your database.\n"
-msgstr "options.xml atributo date falta, por favor actualize to base deo datos.\n"
+msgstr ""
+"options.xml atributo date falta, por favor actualize to base deo datos.\n"
 
-#: ../../po/../src/lib/monitor_db.c:755
+#: ../src/lib/monitor_db.c:767
 #, c-format
 msgid ""
 "options.xml dbversion (%d) is greater than the supported version (%d).\n"
 msgstr ""
 "options.xml dbversion (%d) es más grande de la versión soportado (%d).\n"
 
-#: ../../po/../src/lib/monitor_db.c:756
+#: ../src/lib/monitor_db.c:768
 #, c-format
 msgid "Please update ddccontrol program.\n"
 msgstr "Por favor actualize el programa ddccontrol.\n"
 
-#: ../../po/../src/lib/monitor_db.c:763
+#: ../src/lib/monitor_db.c:775
 #, c-format
 msgid "options.xml dbversion (%d) is less than the supported version (%d).\n"
-msgstr "options.xml dbversion (%d) es más pequeño de la versión soportado (%d).\n"
+msgstr ""
+"options.xml dbversion (%d) es más pequeño de la versión soportado (%d).\n"
 
-#: ../../po/../src/lib/monitor_db.c:764
+#: ../src/lib/monitor_db.c:776
 #, c-format
 msgid "Please update ddccontrol database.\n"
 msgstr "Por favor actualize el base de datos de ddccontrol.\n"
+
+#, c-format
+#~ msgid "Monitor Profile Switcher"
+#~ msgstr "Cambiador de Perfíl de Monitor"
+
+#~ msgid "Quickly switch monitor profiles created with gddccontrol"
+#~ msgstr "Rapidamente cambie perfiles de monitor creado con gddccontrol"
+
+#~ msgid "_About..."
+#~ msgstr "_Acerca de..."
+
+#~ msgid "_Properties..."
+#~ msgstr "_Propiedades..."
+
+#~ msgid "_Run gddccontrol..."
+#~ msgstr "_Ejecutar gddccontrol..."
+
+#~ msgid ""
+#~ "An applet for quick switching of monitor profiles.\n"
+#~ "Based on libddccontrol and part of the ddccontrol project.\n"
+#~ "(http://ddccontrol.sourceforge.net)"
+#~ msgstr ""
+#~ "Un subprograma para rapidamente cambiar perfiles de monitor.\n"
+#~ "Basado en libddccontrol y parte del proyecto ddccontrol.\n"
+#~ "(http://ddccontrol.sourceforge.net)"
+
+#~ msgid "Unable to initialize ddcci library"
+#~ msgstr "No se pudo inicializar la biblioteca ddcci."
+
+#~ msgid "No monitor configuration found. Please run gddccontrol first"
+#~ msgstr ""
+#~ "No se encontró configuración de monitor.  Por favor ejecute gddccontrol "
+#~ "primero"
+
+#~ msgid "An error occurred while opening the monitor device"
+#~ msgstr "Ocurrió un error abriendo el dispositivo del monitor"
+
+#~ msgid "Can't find any profiles"
+#~ msgstr "No se pudo encontrar ningunos perfiles"
+
+#~ msgid "error"
+#~ msgstr "error"
+
+#~ msgid "Monitor:"
+#~ msgstr "Monitor:"
+
+#~ msgid "Monitor Profile Switcher Properties"
+#~ msgstr "Propiedades del Cambiador de Perfiles de Monitor"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,36 +7,35 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DDC/CI control tool 0.1\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2006-08-29 19:01+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/ddccontrol/ddccontrol/issues/\n"
+"POT-Creation-Date: 2026-05-13 15:12+0200\n"
 "PO-Revision-Date: 2006-07-30 19:43+0100\n"
 "Last-Translator: Nicolas Boichat <nicolas@boichat.ch>\n"
 "Language-Team: French <traduc@traduc.org>\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=ISO-8859-1\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: ../src/ddccontrol/main.c:83 ../src/ddccontrol/main.c:87
-#: ../src/ddccontrol/main.c:91
-msgid "Control"
-msgstr "Contrôle"
-
-#: ../src/ddccontrol/main.c:132
-#, c-format
+#: ../src/ddccontrol/main.c:85
+#, fuzzy, c-format
 msgid ""
 "Usage:\n"
-"%s [-b datadir] [-v] [-c] [-d] [-f] [-s] [-r ctrl [-w value]] [-p | dev]\n"
+"%s [-b datadir] [-v] [-c] [-d] [-f] [-s] [-r ctrl [-w value]] [-l (profile "
+"path)] [-p | dev]\n"
 "\tdev: device, e.g. dev:/dev/i2c-0\n"
 "\t-p : probe I2C devices to find monitor buses\n"
 "\t-c : query capability\n"
 "\t-d : query ctrls 0 - 255\n"
 "\t-r : query ctrl\n"
 "\t-w : value to write to ctrl\n"
+"\t-W : relatively change ctrl value (+/-)\n"
 "\t-f : force (avoid validity checks)\n"
 "\t-s : save settings\n"
 "\t-v : verbosity (specify more to increase)\n"
 "\t-b : ddccontrol-db directory (if other than %s)\n"
+"\t-l : load values from XML profile file\n"
 msgstr ""
 "Usage:\n"
 "%s [-b datadir] [-v] [-c] [-d] [-f] [-s] [-r ctrl [-w value]] [-p | dev]\n"
@@ -51,22 +50,22 @@ msgstr ""
 "\t-v : verbosité (utiliser ce paramètre plusieurs fois l'augmente)\n"
 "\t-b : répertoire contenant ddccontrol-db (si autre que %s)\n"
 
-#: ../src/ddccontrol/main.c:150 ../src/ddccontrol/main.c:172
+#: ../src/ddccontrol/main.c:106 ../src/ddccontrol/main.c:128
 #, c-format
 msgid "Checking %s integrity...\n"
 msgstr "Vérification de l'intégrité de %s...\n"
 
-#: ../src/ddccontrol/main.c:152 ../src/ddccontrol/main.c:174
+#: ../src/ddccontrol/main.c:108 ../src/ddccontrol/main.c:130
 #, c-format
 msgid "[ FAILED ]\n"
 msgstr "[ ÉCHEC ]\n"
 
-#: ../src/ddccontrol/main.c:156 ../src/ddccontrol/main.c:179
+#: ../src/ddccontrol/main.c:112 ../src/ddccontrol/main.c:135
 #, c-format
 msgid "[ OK ]\n"
 msgstr "[ OK ]\n"
 
-#: ../src/ddccontrol/main.c:217
+#: ../src/ddccontrol/main.c:194
 #, c-format
 msgid ""
 "ddccontrol version %s\n"
@@ -85,73 +84,88 @@ msgstr ""
 "licence générale publique de GNU (GNU General Public License).\n"
 "\n"
 
-#: ../src/ddccontrol/main.c:236
+#: ../src/ddccontrol/main.c:211
 #, c-format
 msgid "'%s' does not seem to be a valid register name\n"
 msgstr "'%s' ne semble pas être un nom de contrôle valide\n"
 
-#: ../src/ddccontrol/main.c:242
+#: ../src/ddccontrol/main.c:217
 #, c-format
 msgid "You cannot use -w parameter without -r.\n"
 msgstr "Vous ne pouvez pas utiliser le paramètre -w sans -r.\n"
 
-#: ../src/ddccontrol/main.c:247
+#: ../src/ddccontrol/main.c:221 ../src/ddccontrol/main.c:231
 #, c-format
 msgid "'%s' does not seem to be a valid value.\n"
 msgstr "'%s' ne semble pas être une valeur valide\n"
 
-#: ../src/ddccontrol/main.c:292 ../src/gddccontrol/main.c:414
+#: ../src/ddccontrol/main.c:227
+#, fuzzy, c-format
+msgid "You cannot use -W parameter without -r.\n"
+msgstr "Vous ne pouvez pas utiliser le paramètre -w sans -r.\n"
+
+#: ../src/ddccontrol/main.c:282 ../src/gddccontrol/main.c:432
 #, c-format
 msgid "Unable to initialize ddcci library.\n"
 msgstr "Impossible d'initialiser la librairie ddcci.\n"
 
-#: ../src/ddccontrol/main.c:304
+#: ../src/ddccontrol/main.c:288
+#, fuzzy, c-format
+msgid "Unable to initialize ddcci db library.\n"
+msgstr "Impossible d'initialiser la librairie ddcci.\n"
+
+#: ../src/ddccontrol/main.c:293
+#, c-format
+msgid "Failed to open D-Bus proxy, try with DDCCONTROL_NO_DAEMON=1.\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:310
 #, c-format
 msgid "Detected monitors :\n"
 msgstr "Moniteurs détectés :\n"
 
-#: ../src/ddccontrol/main.c:309
+#: ../src/ddccontrol/main.c:314
 #, c-format
 msgid " - Device: %s\n"
 msgstr " - Périphérique : %s\n"
 
-#: ../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 #, c-format
 msgid "   DDC/CI supported: %s\n"
 msgstr "   DDC/CI supporté : %s\n"
 
-#: ../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 msgid "Yes"
 msgstr "Oui"
 
-#: ../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 msgid "No"
 msgstr "Non"
 
-#: ../src/ddccontrol/main.c:311
+#: ../src/ddccontrol/main.c:316
 #, c-format
 msgid "   Monitor Name: %s\n"
 msgstr "   Nom du moniteur : %s\n"
 
-#: ../src/ddccontrol/main.c:312
+#: ../src/ddccontrol/main.c:317
 #, c-format
 msgid "   Input type: %s\n"
 msgstr "   Type d'entrée : %s\n"
 
-#: ../src/ddccontrol/main.c:312 ../src/ddccontrol/main.c:350
+#: ../src/ddccontrol/main.c:317 ../src/ddccontrol/main.c:364
 msgid "Digital"
 msgstr "digitale"
 
-#: ../src/ddccontrol/main.c:312 ../src/ddccontrol/main.c:350
+#: ../src/ddccontrol/main.c:317 ../src/ddccontrol/main.c:364
 msgid "Analog"
 msgstr "analogique"
 
-#: ../src/ddccontrol/main.c:316
+#: ../src/ddccontrol/main.c:321
 #, c-format
 msgid "  (Automatically selected)\n"
 msgstr "  (Choisi automatiquement)\n"
 
-#: ../src/ddccontrol/main.c:326
+#: ../src/ddccontrol/main.c:333
 #, c-format
 msgid ""
 "No monitor supporting DDC/CI available.\n"
@@ -162,12 +176,12 @@ msgstr ""
 "Vérifiez que les modules du noyau sont chargés (i2c-dev, et votre driver de "
 "\"framebuffer\"), si votre carte graphique en a besoin.\n"
 
-#: ../src/ddccontrol/main.c:339
+#: ../src/ddccontrol/main.c:346
 #, c-format
 msgid "Reading EDID and initializing DDC/CI at bus %s...\n"
 msgstr "Lecture de l'EDID et initialisation du DDC/CI sur le bus %s...\n"
 
-#: ../src/ddccontrol/main.c:343
+#: ../src/ddccontrol/main.c:357
 #, c-format
 msgid ""
 "\n"
@@ -180,7 +194,7 @@ msgstr ""
 "Vérifiez que les modules du noyau sont chargés (i2c-dev, et votre driver de "
 "\"framebuffer\"), si votre carte graphique en a besoin.\n"
 
-#: ../src/ddccontrol/main.c:347
+#: ../src/ddccontrol/main.c:361
 #, c-format
 msgid ""
 "\n"
@@ -189,23 +203,157 @@ msgstr ""
 "\n"
 "Lectures EDID :\n"
 
-#: ../src/ddccontrol/main.c:348
+#: ../src/ddccontrol/main.c:362
 #, c-format
 msgid "\tPlug and Play ID: %s [%s]\n"
 msgstr "\tID Plug and Play: %s [%s]\n"
 
-#: ../src/ddccontrol/main.c:350
+#: ../src/ddccontrol/main.c:364
 #, c-format
 msgid "\tInput type: %s\n"
 msgstr "\tType d'entrée : %s\n"
 
+#: ../src/ddccontrol/main.c:370
+#, c-format
+msgid ""
+"\n"
+"Capabilities:\n"
+msgstr ""
+"\n"
+"Capacités:\n"
+
+#: ../src/ddccontrol/main.c:374
+#, c-format
+msgid "Raw output: %s\n"
+msgstr "Sortie brute : %s\n"
+
+#: ../src/ddccontrol/main.c:376
+#, c-format
+msgid "Parsed output: \n"
+msgstr "Sortie analysée : \n"
+
+#: ../src/ddccontrol/main.c:385
+#, c-format
+msgid "\tType: "
+msgstr "\tType :"
+
+#: ../src/ddccontrol/main.c:388
+#, c-format
+msgid "LCD"
+msgstr "LCD"
+
+#: ../src/ddccontrol/main.c:391
+#, c-format
+msgid "CRT"
+msgstr "CRT"
+
+#: ../src/ddccontrol/main.c:394
+#, c-format
+msgid "Unknown"
+msgstr "Inconnu"
+
+#: ../src/ddccontrol/main.c:403
+#, c-format
+msgid "Capabilities read fail.\n"
+msgstr "Échec lors de la lecture des capacités.\n"
+
+#: ../src/ddccontrol/main.c:417
+#, c-format
+msgid "Value cannot be lower than zero! %d -> %d\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:420
+#, c-format
+msgid "Value cannot be higher than maximum! %d / %d\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:428
+#, c-format
+msgid ""
+"\n"
+"Writing 0x%02x, 0x%02x(%d) (%dms delay)...\n"
+msgstr ""
+"\n"
+"Écriture 0x%02x, 0x%02x(%d) (délai de %dms)...\n"
+
+#: ../src/ddccontrol/main.c:431
+#, c-format
+msgid ""
+"\n"
+"Writing 0x%02x, 0x%02x(%d)...\n"
+msgstr ""
+"\n"
+"Écriture 0x%02x, 0x%02x(%d)...\n"
+
+#: ../src/ddccontrol/main.c:436
+#, c-format
+msgid ""
+"\n"
+"Reading 0x%02x...\n"
+msgstr ""
+"\n"
+"Lecture 0x%02x...\n"
+
+#: ../src/ddccontrol/main.c:445
+#, fuzzy, c-format
+msgid "Applied profile: %s\n"
+msgstr "Appliquer le profil"
+
+#: ../src/ddccontrol/main.c:447
+#, c-format
+msgid "Failed to apply profile: %s\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:451
+#, c-format
+msgid ""
+"\n"
+"Controls (valid/current/max) [Description - Value name]:\n"
+msgstr ""
+"\n"
+"Contrôles (valide/actuel/maximum) [Description - Nom de la valeur]:\n"
+
+#: ../src/ddccontrol/main.c:473
+#, c-format
+msgid "\t\t> id=%s, name=%s, address=%#x, delay=%dms, type=%d\n"
+msgstr "\t\t> id=%s, nom=%s, adresse=%#x, délai=%dms, type=%d\n"
+
+#: ../src/ddccontrol/main.c:478
+#, c-format
+msgid "\t\t  Possible values:\n"
+msgstr "\t\t  Valeurs autorisées:\n"
+
+#: ../src/ddccontrol/main.c:482
+#, c-format
+msgid "\t\t\t> id=%s - name=%s, value=%d\n"
+msgstr "\t\t\t> id=%s - name=%s, value=%d\n"
+
+#: ../src/ddccontrol/main.c:492
+#, c-format
+msgid "\t\t  supported, value=%d, maximum=%d\n"
+msgstr "\t\t  supporté, valeur=%d, maximum=%d\n"
+
+#: ../src/ddccontrol/main.c:493
+#, c-format
+msgid "\t\t  not supported, value=%d, maximum=%d\n"
+msgstr "\t\t  non supporté, valeur=%d, maximum=%d\n"
+
+#: ../src/ddccontrol/main.c:504
+#, c-format
+msgid ""
+"\n"
+"Saving settings...\n"
+msgstr ""
+"\n"
+"Sauvegarde des paramètres...\n"
+
 #. Put a big warning (in red if we are writing to a terminal).
-#: ../src/ddccontrol/main.c:354 ../src/ddccontrol/main.c:373
+#: ../src/ddccontrol/main.c:516 ../src/ddccontrol/main.c:537
 msgid "=============================== WARNING ==============================="
 msgstr ""
 "=============================== ATTENTION ==============================="
 
-#: ../src/ddccontrol/main.c:357
+#: ../src/ddccontrol/main.c:519
 #, c-format
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is\n"
@@ -217,7 +365,7 @@ msgstr ""
 "de votre moniteur. Quelques contrôles peuvent éventuellement\n"
 "ne pas être supportés, ou ne pas fonctionner correctement.\n"
 
-#: ../src/ddccontrol/main.c:363
+#: ../src/ddccontrol/main.c:524
 #, c-format
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is\n"
@@ -229,135 +377,24 @@ msgstr ""
 "Quelques contrôles peuvent éventuellement ne pas être\n"
 "supportés, ou ne pas fonctionner correctement.\n"
 
-#: ../src/ddccontrol/main.c:368
+#: ../src/ddccontrol/main.c:529
 #, c-format
 msgid ""
+"Unsupported monitor detected.\n"
+"\n"
 "Please update ddccontrol-db, or, if you are already using the latest\n"
-"version, please send the output of the following command to\n"
-"ddccontrol-users@lists.sourceforge.net:\n"
+"version, please open this pre-filled GitHub issue:\n"
 msgstr ""
-"Veuillez mettre à jour ddccontrol-db, ou, si vous utilisez déjà la\n"
-"dernière version, veuillez envoyez la sortie de la commande suivanteà "
-"ddccontrol-users@lists.sourceforge.net :\n"
 
-#: ../src/ddccontrol/main.c:372 ../src/gddccontrol/notebook.c:695
+#: ../src/ddccontrol/main.c:534
+#, c-format
+msgid "Then attach the resulting report file of the following command:\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:536 ../src/gddccontrol/notebook.c:715
 #, c-format
 msgid "Thank you.\n"
 msgstr "Merci.\n"
-
-#: ../src/ddccontrol/main.c:377
-#, c-format
-msgid ""
-"\n"
-"Capabilities:\n"
-msgstr ""
-"\n"
-"Capacités:\n"
-
-#: ../src/ddccontrol/main.c:381
-#, c-format
-msgid "Raw output: %s\n"
-msgstr "Sortie brute : %s\n"
-
-#: ../src/ddccontrol/main.c:383
-#, c-format
-msgid "Parsed output: \n"
-msgstr "Sortie analysée : \n"
-
-#: ../src/ddccontrol/main.c:392
-#, c-format
-msgid "\tType: "
-msgstr "\tType :"
-
-#: ../src/ddccontrol/main.c:395
-#, c-format
-msgid "LCD"
-msgstr "LCD"
-
-#: ../src/ddccontrol/main.c:398
-#, c-format
-msgid "CRT"
-msgstr "CRT"
-
-#: ../src/ddccontrol/main.c:401
-#, c-format
-msgid "Unknown"
-msgstr "Inconnu"
-
-#: ../src/ddccontrol/main.c:410
-#, c-format
-msgid "Capabilities read fail.\n"
-msgstr "Échec lors de la lecture des capacités.\n"
-
-#: ../src/ddccontrol/main.c:418
-#, c-format
-msgid ""
-"\n"
-"Writing 0x%02x, 0x%02x(%d) (%dms delay)...\n"
-msgstr ""
-"\n"
-"Écriture 0x%02x, 0x%02x(%d) (délai de %dms)...\n"
-
-#: ../src/ddccontrol/main.c:422
-#, c-format
-msgid ""
-"\n"
-"Writing 0x%02x, 0x%02x(%d)...\n"
-msgstr ""
-"\n"
-"Écriture 0x%02x, 0x%02x(%d)...\n"
-
-#: ../src/ddccontrol/main.c:427
-#, c-format
-msgid ""
-"\n"
-"Reading 0x%02x...\n"
-msgstr ""
-"\n"
-"Lecture 0x%02x...\n"
-
-#: ../src/ddccontrol/main.c:434
-#, c-format
-msgid ""
-"\n"
-"Controls (valid/current/max) [Description - Value name]:\n"
-msgstr ""
-"\n"
-"Contrôles (valide/actuel/maximum) [Description - Nom de la valeur]:\n"
-
-#: ../src/ddccontrol/main.c:458
-#, c-format
-msgid "\t\t> id=%s, name=%s, address=%#x, delay=%dms, type=%d\n"
-msgstr "\t\t> id=%s, nom=%s, adresse=%#x, délai=%dms, type=%d\n"
-
-#: ../src/ddccontrol/main.c:463
-#, c-format
-msgid "\t\t  Possible values:\n"
-msgstr "\t\t  Valeurs autorisées:\n"
-
-#: ../src/ddccontrol/main.c:467
-#, c-format
-msgid "\t\t\t> id=%s - name=%s, value=%d\n"
-msgstr "\t\t\t> id=%s - name=%s, value=%d\n"
-
-#: ../src/ddccontrol/main.c:477
-#, c-format
-msgid "\t\t  supported, value=%d, maximum=%d\n"
-msgstr "\t\t  supporté, valeur=%d, maximum=%d\n"
-
-#: ../src/ddccontrol/main.c:478
-#, c-format
-msgid "\t\t  not supported, value=%d, maximum=%d\n"
-msgstr "\t\t  non supporté, valeur=%d, maximum=%d\n"
-
-#: ../src/ddccontrol/main.c:489
-#, c-format
-msgid ""
-"\n"
-"Saving settings...\n"
-msgstr ""
-"\n"
-"Sauvegarde des paramètres...\n"
 
 #. arbitration or no acknowledge
 #: ../src/ddcpci/i2c-algo-bit.c:368
@@ -376,8 +413,9 @@ msgstr "i2c-algo-bit.o: readbytes: i2c_inb: temps dépassé.\n"
 msgid "i2c-algo-bit.o: readbytes: Timeout at ack\n"
 msgstr "i2c-algo-bit.o: readbytes: temps dépassé au moment du \"ack\".\n"
 
-#: ../src/ddcpci/intel740.c:103 ../src/ddcpci/intel810.c:161
+#: ../src/ddcpci/intel740.c:103 ../src/ddcpci/intel810.c:162
 #: ../src/ddcpci/nvidia.c:155 ../src/ddcpci/radeon.c:209
+#: ../src/ddcpci/sis.c:174 ../src/ddcpci/via.c:167
 #, c-format
 msgid "%s: Malloc error.\n"
 msgstr "%s: Erreur lors de malloc.\n"
@@ -397,61 +435,61 @@ msgstr "%s: Erreur: type de carte inconnu (%#x)\n"
 msgid "%s: Malloc error."
 msgstr "%s: Erreur lors de malloc."
 
-#: ../src/ddcpci/intel810.c:171
+#: ../src/ddcpci/intel810.c:172
 msgid "i810_open: cannot open /dev/mem"
 msgstr "i810_open: Ne peut ouvrir /dev/mem."
 
-#: ../src/ddcpci/intel810.c:206
+#: ../src/ddcpci/intel810.c:207
 #, c-format
 msgid "i810_open: Error: cannot find any valid MMIO PCI region.\n"
 msgstr "i810_open: Erreur: impossible de trouver une région MMIO PCI valide.\n"
 
-#: ../src/ddcpci/intel810.c:213
+#: ../src/ddcpci/intel810.c:214
 msgid "i810_open: mmap failed"
 msgstr "i810_open: Erreur lors de mmap."
 
-#: ../src/ddcpci/main.c:154
+#: ../src/ddcpci/main.c:160
 msgid "==>Error while sending open message"
 msgstr "==>Erreur lors de l'envoi du message d'ouverture"
 
-#: ../src/ddcpci/main.c:178 ../src/ddcpci/main.c:184 ../src/ddcpci/main.c:202
+#: ../src/ddcpci/main.c:184 ../src/ddcpci/main.c:190 ../src/ddcpci/main.c:208
 msgid "==>Error while sending data answer message"
 msgstr "==>Erreur lors de l'envoi de la réponse du message de donnée"
 
-#: ../src/ddcpci/main.c:251 ../src/ddcpci/main.c:266
+#: ../src/ddcpci/main.c:257 ../src/ddcpci/main.c:272
 msgid "==>Error while sending list message"
 msgstr "==>Erreur lors de l'envoi du message de type \"list\""
 
-#: ../src/ddcpci/main.c:284
+#: ../src/ddcpci/main.c:290
 #, c-format
 msgid "Invalid arguments.\n"
 msgstr "Arguments invalides.\n"
 
-#: ../src/ddcpci/main.c:290
+#: ../src/ddcpci/main.c:296
 #, c-format
 msgid "==>Can't read verbosity.\n"
 msgstr "==>Ne peut pas lire la \"verbosité\".\n"
 
-#: ../src/ddcpci/main.c:297
+#: ../src/ddcpci/main.c:303
 #, c-format
 msgid "==>Can't read key.\n"
 msgstr "==>Ne peut pas lire la clé.\n"
 
-#: ../src/ddcpci/main.c:302
+#: ../src/ddcpci/main.c:308
 #, c-format
 msgid "==>Can't open key %u\n"
 msgstr "==>Ne peut ouvrir la clé %u.\n"
 
-#: ../src/ddcpci/main.c:316
+#: ../src/ddcpci/main.c:322
 #, c-format
 msgid "==>No command received for %ld seconds, aborting.\n"
 msgstr "==>Pas de commande reçue pendant %ld secondes, on quitte.\n"
 
-#: ../src/ddcpci/main.c:324
+#: ../src/ddcpci/main.c:330
 msgid "==>Error while receiving query\n"
 msgstr "==>Erreur lors de la réception de la requête\n"
 
-#: ../src/ddcpci/main.c:359
+#: ../src/ddcpci/main.c:365
 #, c-format
 msgid "==>Invalid query...\n"
 msgstr "==>Requête invalide...\n"
@@ -482,7 +520,27 @@ msgstr "radeon_open: Ne peut ouvrir /dev/mem."
 msgid "radeon_open: mmap failed"
 msgstr "radeon_open: Erreur lors de mmap."
 
-#: ../src/gddccontrol/fspatterns.c:195
+#: ../src/ddcpci/sis.c:133
+#, fuzzy, c-format
+msgid "sis.c:init_i2c_bus: Malloc error."
+msgstr "nvidia.c:init_i2c_bus: Erreur lors de malloc."
+
+#: ../src/ddcpci/via.c:125
+#, fuzzy, c-format
+msgid "via.c:init_i2c_bus: Malloc error."
+msgstr "nvidia.c:init_i2c_bus: Erreur lors de malloc."
+
+#: ../src/ddcpci/via.c:177
+#, fuzzy
+msgid "via_open: cannot open /dev/mem"
+msgstr "nvidia_open: Ne peut ouvrir /dev/mem."
+
+#: ../src/ddcpci/via.c:186
+#, fuzzy
+msgid "via_open: mmap failed"
+msgstr "nvidia_open: Erreur lors de mmap."
+
+#: ../src/gddccontrol/fspatterns.c:137
 msgid ""
 "Adjust brightness and contrast following these rules:\n"
 " - Black must be as dark as possible.\n"
@@ -495,11 +553,11 @@ msgstr ""
 " - Chaque niveau de gris doit pouvoir être distingué (particulièrement les "
 "niveaux 0 et 12).\n"
 
-#: ../src/gddccontrol/fspatterns.c:211
+#: ../src/gddccontrol/fspatterns.c:259
 msgid "Try to make moire patterns disappear."
 msgstr "Essayez de faire disparaître les artefacts dus au moiré."
 
-#: ../src/gddccontrol/fspatterns.c:215
+#: ../src/gddccontrol/fspatterns.c:263
 msgid ""
 "Adjust Image Lock Coarse to make the vertical band disappear.\n"
 "Adjust Image Lock Fine to minimize movement on the screen."
@@ -507,34 +565,50 @@ msgstr ""
 "Ajustez l'horloge pour faire disparaître les bandes verticales.\n"
 "Ajustez la phase d'horloge pour diminuer les mouvements sur l'écran."
 
-#: ../src/gddccontrol/fspatterns.c:254
+#: ../src/gddccontrol/fspatterns.c:273
 #, c-format
 msgid "Unknown fullscreen pattern name: %s"
 msgstr "Motif plein écran inconnu : %s"
 
-#: ../src/gddccontrol/gprofile.c:53
+#: ../src/gddccontrol/gddccontrol.desktop.in.h:1
+#, fuzzy
+msgid "DDC Control"
+msgstr "Contrôle"
+
+#: ../src/gddccontrol/gddccontrol.desktop.in.h:2
+#, fuzzy
+msgid "Monitor Settings"
+msgstr "Paramètres du moniteur"
+
+#: ../src/gddccontrol/gddccontrol.desktop.in.h:3
+msgid ""
+"Set your monitor preferences (contrast, brightness,...) and manage your "
+"profiles"
+msgstr ""
+
+#: ../src/gddccontrol/gprofile.c:54
 msgid "You must select at least one control to be saved in the profile."
 msgstr ""
 "Au moins un contrôle doit être sélectionné pour être sauver dans le profil."
 
-#: ../src/gddccontrol/gprofile.c:61
+#: ../src/gddccontrol/gprofile.c:62
 msgid "Creating profile..."
 msgstr "Création du profil..."
 
-#: ../src/gddccontrol/gprofile.c:76
+#: ../src/gddccontrol/gprofile.c:77
 msgid "Error while creating profile."
 msgstr "Erreur lors de la création du profil."
 
-#: ../src/gddccontrol/gprofile.c:93
+#: ../src/gddccontrol/gprofile.c:94
 msgid "Applying profile..."
 msgstr "Application du profil..."
 
-#: ../src/gddccontrol/gprofile.c:116
+#: ../src/gddccontrol/gprofile.c:117
 #, c-format
 msgid "Are you sure you want to delete the profile '%s'?"
 msgstr "Êtes-vous sûr de vouloir supprimer le profil '%s' ?"
 
-#: ../src/gddccontrol/gprofile.c:142
+#: ../src/gddccontrol/gprofile.c:143
 msgid ""
 "Please select the controls you want to save in the profile using the "
 "checkboxes to the left of each control."
@@ -542,78 +616,78 @@ msgstr ""
 "Veuillez sélectionner les contrôles que vous souhaitez sauver dans le "
 "profile en utilisant les cases à cocher à gauche de chaque contrôle."
 
-#: ../src/gddccontrol/gprofile.c:174
+#: ../src/gddccontrol/gprofile.c:175
 msgid "Profile Manager"
 msgstr "Gérer les profils"
 
-#: ../src/gddccontrol/gprofile.c:193
+#: ../src/gddccontrol/gprofile.c:199
 msgid "Apply profile"
 msgstr "Appliquer le profil"
 
-#: ../src/gddccontrol/gprofile.c:198
+#: ../src/gddccontrol/gprofile.c:208
 msgid "Show profile details / Rename profile"
 msgstr "Voir les détails / Renommer"
 
-#: ../src/gddccontrol/gprofile.c:203
+#: ../src/gddccontrol/gprofile.c:217
 msgid "Delete profile"
 msgstr "Supprimer le profil"
 
-#: ../src/gddccontrol/gprofile.c:229
+#: ../src/gddccontrol/gprofile.c:253
 msgid "Create profile"
 msgstr "Créer un profil"
 
-#: ../src/gddccontrol/gprofile.c:235
+#: ../src/gddccontrol/gprofile.c:259
 msgid "Close profile manager"
 msgstr "Fermer"
 
-#: ../src/gddccontrol/gprofile.c:299
+#: ../src/gddccontrol/gprofile.c:321
 msgid "Control name"
 msgstr "Nom du contrôle"
 
-#: ../src/gddccontrol/gprofile.c:310
+#: ../src/gddccontrol/gprofile.c:332
 msgid "Value"
 msgstr "Valeur"
 
-#: ../src/gddccontrol/gprofile.c:313
+#: ../src/gddccontrol/gprofile.c:335
 msgid "Address"
 msgstr "Adresse"
 
-#: ../src/gddccontrol/gprofile.c:316
+#: ../src/gddccontrol/gprofile.c:338
 msgid "Raw value"
 msgstr "Valeur brute"
 
-#: ../src/gddccontrol/gprofile.c:434 ../src/gddccontrol/gprofile.c:454
+#: ../src/gddccontrol/gprofile.c:456 ../src/gddccontrol/gprofile.c:476
 msgid "Profile information:"
 msgstr "Informations au sujet du profile :"
 
-#: ../src/gddccontrol/gprofile.c:463
+#: ../src/gddccontrol/gprofile.c:485
 #, c-format
 msgid "File name: %s"
 msgstr "Nom du fichier : %s"
 
-#: ../src/gddccontrol/gprofile.c:474
+#: ../src/gddccontrol/gprofile.c:496
 msgid "Profile name:"
 msgstr "Nom du profile :"
 
 #. Save
-#: ../src/gddccontrol/gprofile.c:496
+#: ../src/gddccontrol/gprofile.c:518
 msgid "Saving profile..."
 msgstr "Sauvegarde du profil..."
 
-#: ../src/gddccontrol/gprofile.c:505
+#: ../src/gddccontrol/gprofile.c:527
 msgid "Error while saving profile."
 msgstr "Erreur lors de la sauvegarde du profil."
 
-#: ../src/gddccontrol/main.c:177
+#: ../src/gddccontrol/main.c:204
 #, c-format
 msgid "Monitor changed (%d %d).\n"
 msgstr "Moniteur changé (%d %d).\n"
 
-#: ../src/gddccontrol/main.c:329
+#: ../src/gddccontrol/main.c:356
 msgid "Probing for available monitors..."
 msgstr "Recherche des moniteurs disponibles..."
 
-#: ../src/gddccontrol/main.c:368
+#: ../src/gddccontrol/main.c:385
 msgid ""
 "No monitor supporting DDC/CI available.\n"
 "\n"
@@ -625,49 +699,49 @@ msgstr ""
 "Vérifiez que les modules du noyau sont chargés (i2c-dev, et votre driver de "
 "\"framebuffer\"), si votre carte graphique en a besoin."
 
-#: ../src/gddccontrol/main.c:420
+#: ../src/gddccontrol/main.c:438
 msgid "Unable to initialize ddcci library, see console for more details.\n"
 msgstr ""
 "Impossible d'initialiser la librairie ddcci, voir la console pour plus de "
 "détails.\n"
 
-#: ../src/gddccontrol/main.c:430
+#: ../src/gddccontrol/main.c:450
 msgid "Monitor settings"
 msgstr "Paramètres du moniteur"
 
-#: ../src/gddccontrol/main.c:454
+#: ../src/gddccontrol/main.c:474
 msgid "Current monitor: "
 msgstr "Moniteur actuel :"
 
-#: ../src/gddccontrol/main.c:464
+#: ../src/gddccontrol/main.c:484
 msgid "Refresh monitor list"
 msgstr "Rafraîchir la liste de moniteurs"
 
-#: ../src/gddccontrol/main.c:481
+#: ../src/gddccontrol/main.c:507
 msgid "Profile manager"
 msgstr "Gestion des profils"
 
-#: ../src/gddccontrol/main.c:488
+#: ../src/gddccontrol/main.c:514
 msgid "Save profile"
 msgstr "Sauver le profil"
 
-#: ../src/gddccontrol/main.c:494
+#: ../src/gddccontrol/main.c:520
 msgid "Cancel profile creation"
 msgstr "Annuler la création du profil"
 
-#: ../src/gddccontrol/main.c:518
+#: ../src/gddccontrol/main.c:549
 msgid "OK"
 msgstr "OK"
 
-#: ../src/gddccontrol/main.c:546
+#: ../src/gddccontrol/main.c:585
 msgid "Refresh"
 msgstr "Rafraîchir"
 
-#: ../src/gddccontrol/main.c:546
+#: ../src/gddccontrol/main.c:585
 msgid "Refresh all controls"
 msgstr "Rafraîchir tous les contrôles"
 
-#: ../src/gddccontrol/main.c:553
+#: ../src/gddccontrol/main.c:592
 msgid "Close"
 msgstr "Fermer"
 
@@ -675,33 +749,33 @@ msgstr "Fermer"
 #. gtk_misc_set_alignment(GTK_MISC(moninfo), 0, 0);
 #.
 #. gtk_table_attach(GTK_TABLE(table), moninfo, 0, 1, 1, 2, GTK_FILL_EXPAND, 0, 5, 5);
-#: ../src/gddccontrol/main.c:592
+#: ../src/gddccontrol/main.c:634
 #, c-format
 msgid "Welcome to gddccontrol %s."
 msgstr "Bienvenue dans gddccontrol %s."
 
-#: ../src/gddccontrol/notebook.c:81
+#: ../src/gddccontrol/notebook.c:83
 msgid "Error while getting value"
 msgstr "Erreur lors de la lecture de la valeur"
 
-#: ../src/gddccontrol/notebook.c:116 ../src/gddccontrol/notebook.c:128
+#: ../src/gddccontrol/notebook.c:118 ../src/gddccontrol/notebook.c:130
 #, c-format
 msgid "Refreshing controls values (%d%%)..."
 msgstr "Rafraîchissement de la valeur des contrôles (%d%%)..."
 
-#: ../src/gddccontrol/notebook.c:133
+#: ../src/gddccontrol/notebook.c:135
 msgid "Could not get the control_db struct related to a control."
 msgstr "Impossible d'obtenir la structure control_db associée au contrôle."
 
-#: ../src/gddccontrol/notebook.c:493
+#: ../src/gddccontrol/notebook.c:495
 msgid "Show fullscreen patterns"
 msgstr "Voir le motif plein écran"
 
-#: ../src/gddccontrol/notebook.c:525
+#: ../src/gddccontrol/notebook.c:527
 msgid "Section"
 msgstr "Section"
 
-#: ../src/gddccontrol/notebook.c:572
+#: ../src/gddccontrol/notebook.c:574
 msgid ""
 "The current monitor is in the database but does not support DDC/CI.\n"
 "\n"
@@ -722,7 +796,7 @@ msgstr ""
 "l'autre entrée, puis cliquer sur le bouton Rafraîchir à côté de la liste des "
 "moniteurs."
 
-#: ../src/gddccontrol/notebook.c:583
+#: ../src/gddccontrol/notebook.c:585
 #, c-format
 msgid "Opening the monitor device (%s)..."
 msgstr "Ouverture du périphérique du moniteur (%s)..."
@@ -740,29 +814,29 @@ msgstr ""
 #: ../src/gddccontrol/notebook.c:600
 #, c-format
 msgid ""
-"The current monitor is not supported, please run\n"
-"%s\n"
-"and send the output to ddccontrol-users@lists.sourceforge.net.\n"
-"Thanks."
+"Unsupported monitor detected.\n"
+"\n"
+"Please update ddccontrol-db, or, if you are already using the latest\n"
+"version, please open a github issue:\n"
+"https://github.com/ddccontrol/ddccontrol-db/issues/new?template=unsupported-"
+"monitor.yml\n"
+"Then attach the resulting report file of the following command:"
 msgstr ""
-"Le moniteur actuel n'est pas supporté. Veuillez exécuter :%s\n"
-"et envoyer la sortie à ddccontrol-users@lists.sourceforge.net.\n"
-"Merci."
 
-#: ../src/gddccontrol/notebook.c:620
+#: ../src/gddccontrol/notebook.c:622
 msgid "Please click on a group name."
 msgstr "Veuillez cliquer sur un nom de groupe."
 
-#: ../src/gddccontrol/notebook.c:639 ../src/gddccontrol/notebook.c:650
+#: ../src/gddccontrol/notebook.c:647 ../src/gddccontrol/notebook.c:658
 #, c-format
 msgid "Getting controls values (%d%%)..."
 msgstr "Lecture des valeurs des contrôles (%d%%)..."
 
-#: ../src/gddccontrol/notebook.c:664
+#: ../src/gddccontrol/notebook.c:683
 msgid "Loading profiles..."
 msgstr "Chargement des profils..."
 
-#: ../src/gddccontrol/notebook.c:677
+#: ../src/gddccontrol/notebook.c:696
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is "
 "using a generic profile for your monitor's manufacturer. Some controls may "
@@ -773,7 +847,7 @@ msgstr ""
 "Quelques contrôles peuvent éventuellement ne pas être supportés, ou ne pas "
 "fonctionner correctement.\n"
 
-#: ../src/gddccontrol/notebook.c:683
+#: ../src/gddccontrol/notebook.c:702
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is "
 "using a basic generic profile. Many controls will not be supported, and some "
@@ -783,374 +857,328 @@ msgstr ""
 "ddccontrol utilise un profil générique de base. Quelques contrôles peuvent "
 "éventuellement ne pas être supportés, ou ne pas fonctionner correctement.\n"
 
-#: ../src/gddccontrol/notebook.c:688
+#: ../src/gddccontrol/notebook.c:707
 msgid "Warning!"
 msgstr "Attention !"
 
-#: ../src/gddccontrol/notebook.c:690
+#: ../src/gddccontrol/notebook.c:709
 msgid ""
-"Please update ddccontrol-db, or, if you are already using the latest "
-"version, please send the output of the following command to ddccontrol-"
-"users@lists.sourceforge.net:\n"
+"Unsupported monitor detected.\n"
+"\n"
+"Please update ddccontrol-db, or, if you are already using the latest\n"
+"version, please open a github issue:\n"
+"https://github.com/ddccontrol/ddccontrol-db/issues/new?template=unsupported-"
+"monitor.yml\n"
+"Then attach the resulting report file of the following command:\n"
 msgstr ""
-"Veuillez mettre à jour ddccontrol-db, ou, si vous utilisez déjà la dernière "
-"version, veuillez envoyez la sortie de la commande suivanteà ddccontrol-"
-"users@lists.sourceforge.net :\n"
 
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.server.in.in.h:1
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:184
-msgid "Monitor Profile Switcher"
-msgstr "Manager de profils d'affichage"
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.server.in.in.h:2
-msgid "Quickly switch monitor profiles created with gddccontrol"
-msgstr "Choisit rapidement entre les profils moniteur créés avec gddccontrol."
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.xml.h:1
-msgid "_About..."
-msgstr "_A propos de..."
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.xml.h:2
-msgid "_Properties..."
-msgstr "_Propriétés"
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.xml.h:3
-msgid "_Run gddccontrol..."
-msgstr "_Lancer gddccontrol..."
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:189
-msgid ""
-"An applet for quick switching of monitor profiles.\n"
-"Based on libddccontrol and part of the ddccontrol project.\n"
-"(http://ddccontrol.sourceforge.net)"
-msgstr ""
-"Un applet pour changer rapidement de profiles de moniteurs.\n"
-"Basé sur libddccontrol et inclu dans le projet ddccontrol.\n"
-"(http://ddccontrol.sourceforge.net)"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:386
-msgid "Unable to initialize ddcci library"
-msgstr "Impossible d'initialiser la librairie ddcci"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:390
-msgid "No monitor configuration found. Please run gddccontrol first"
-msgstr ""
-"Aucune configuration de moniteurs trouvée, veuillez lancer gddccontrol "
-"d'abord."
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:395
-msgid "An error occurred while opening the monitor device"
-msgstr "Erreur lors de l'ouverture du périphérique du moniteur."
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:400
-msgid "Can't find any profiles"
-msgstr "Aucun profil trouvé."
-
-#. only reached, if init was not finished
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:416
-msgid "error"
-msgstr "erreur"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:440
-msgid "Monitor:"
-msgstr "Moniteur :"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:443
-msgid "Monitor Profile Switcher Properties"
-msgstr "Propriétés du manager de profils d'affichage."
-
-#: ../src/lib/conf.c:61 ../src/lib/conf.c:258 ../src/lib/conf.c:308
-#: ../src/lib/ddcci.c:1202
+#: ../src/lib/conf.c:63 ../src/lib/conf.c:260 ../src/lib/conf.c:310
+#: ../src/lib/ddcci.c:1306
 msgid "Cannot create filename (buffer too small)\n"
 msgstr "Ne peut créer le nom du fichier (tampon trop petit)\n"
 
-#: ../src/lib/conf.c:86 ../src/lib/conf.c:363 ../src/lib/monitor_db.c:350
-#: ../src/lib/monitor_db.c:714
+#: ../src/lib/conf.c:88 ../src/lib/conf.c:367 ../src/lib/monitor_db.c:353
+#: ../src/lib/monitor_db.c:726
 #, c-format
 msgid "Document not parsed successfully.\n"
 msgstr "Le document n'a pas été traité avec succès.\n"
 
-#: ../src/lib/conf.c:93 ../src/lib/conf.c:370
+#: ../src/lib/conf.c:95 ../src/lib/conf.c:375
 #, c-format
 msgid "empty profile file\n"
 msgstr "fichier de profil vide\n"
 
-#: ../src/lib/conf.c:99 ../src/lib/conf.c:376
+#: ../src/lib/conf.c:101 ../src/lib/conf.c:382
 #, c-format
 msgid "profile of the wrong type, root node %s != profile"
 msgstr "profil de mauvais type, élement racine %s != profile"
 
-#: ../src/lib/conf.c:105
+#: ../src/lib/conf.c:107
 msgid "Can't find ddccontrolversion property."
 msgstr "Ne peut trouver la propriété ddccontrolversion."
 
-#: ../src/lib/conf.c:107
+#: ../src/lib/conf.c:109
 #, c-format
 msgid "ddccontrol has been upgraded since monitorlist was saved (%s vs %s).\n"
 msgstr ""
-"ddccontrol a été mis à jour depuis que la liste des moniteurs a été sauvé (%"
-"s contre %s).\n"
+"ddccontrol a été mis à jour depuis que la liste des moniteurs a été sauvé "
+"(%s contre %s).\n"
 
-#: ../src/lib/conf.c:124
+#: ../src/lib/conf.c:126
 msgid "Can't find filename property."
 msgstr "Ne peut trouver la propriété filename."
 
-#: ../src/lib/conf.c:130
+#: ../src/lib/conf.c:132
 msgid "Can't find supported property."
 msgstr "Ne peut trouver la propriété supported."
 
-#: ../src/lib/conf.c:133
+#: ../src/lib/conf.c:135
 msgid "Can't convert supported property to int."
 msgstr "Ne peut convertir la propriété supported en entier."
 
-#: ../src/lib/conf.c:138 ../src/lib/conf.c:385 ../src/lib/monitor_db.c:90
-#: ../src/lib/monitor_db.c:194 ../src/lib/monitor_db.c:370
-#: ../src/lib/monitor_db.c:426 ../src/lib/monitor_db.c:447
+#: ../src/lib/conf.c:140 ../src/lib/conf.c:392 ../src/lib/monitor_db.c:92
+#: ../src/lib/monitor_db.c:196 ../src/lib/monitor_db.c:373
+#: ../src/lib/monitor_db.c:429 ../src/lib/monitor_db.c:450
 msgid "Can't find name property."
 msgstr "Ne peut trouver la propriété name."
 
-#: ../src/lib/conf.c:144
+#: ../src/lib/conf.c:146
 msgid "Can't find digital property."
 msgstr "Ne peut trouver la propriété digital."
 
-#: ../src/lib/conf.c:147
+#: ../src/lib/conf.c:149
 msgid "Can't convert digital property to int."
 msgstr "Ne peut convertir la propriété digital en entier."
 
-#: ../src/lib/conf.c:175 ../src/lib/conf.c:439
+#: ../src/lib/conf.c:177 ../src/lib/conf.c:447
 msgid "Cannot create the xml writer\n"
 msgstr "Ne peut créer la structure écrivant les fichiers xml.\n"
 
-#: ../src/lib/conf.c:239
+#: ../src/lib/conf.c:241
 msgid "Cannot read control value\n"
 msgstr "Impossible de lire la valeur du contrôle\n"
 
-#: ../src/lib/conf.c:276
+#: ../src/lib/conf.c:278
 msgid "Cannot write control value\n"
 msgstr "Impossible d'écrire la valeur du contrôle\n"
 
-#: ../src/lib/conf.c:313
+#: ../src/lib/conf.c:315
 msgid "Error while opening ddccontrol home directory."
 msgstr ""
 "Erreur lors de l'ouverture du dossier de ddccontrol dans le répertoire "
 "personnel."
 
-#: ../src/lib/conf.c:337
+#: ../src/lib/conf.c:340
 msgid "Error while reading ddccontrol home directory."
 msgstr ""
 "Erreur lors de la lecture du dossier de ddccontrol dans le répertoire "
 "personnel."
 
-#: ../src/lib/conf.c:382
+#: ../src/lib/conf.c:389
 msgid "Can't find pnpid property."
 msgstr "Ne peut trouver la propriété pnpid."
 
-#: ../src/lib/conf.c:388 ../src/lib/conf.c:391
+#: ../src/lib/conf.c:395 ../src/lib/conf.c:398
 msgid "Can't find version property."
 msgstr "Ne peut trouver la propriété version."
 
-#: ../src/lib/conf.c:390 ../src/lib/monitor_db.c:752
+#: ../src/lib/conf.c:397 ../src/lib/monitor_db.c:764
 msgid "Can't convert version to int."
 msgstr "Ne peut convertir la version en entier."
 
-#: ../src/lib/conf.c:393
+#: ../src/lib/conf.c:400
 #, c-format
 msgid "profile version (%d) is not supported (should be %d).\n"
 msgstr "La version du profile (%d) n'est pas supportée (devrait être %d).\n"
 
-#: ../src/lib/conf.c:407 ../src/lib/monitor_db.c:229
+#: ../src/lib/conf.c:415 ../src/lib/monitor_db.c:233
 msgid "Can't find address property."
 msgstr "Ne peut trouver la propriété address."
 
-#: ../src/lib/conf.c:409 ../src/lib/monitor_db.c:231
+#: ../src/lib/conf.c:417 ../src/lib/monitor_db.c:235
 msgid "Can't convert address to int."
 msgstr "Ne peut convertir l'adresse en entier."
 
-#: ../src/lib/conf.c:413 ../src/lib/monitor_db.c:112
+#: ../src/lib/conf.c:421 ../src/lib/monitor_db.c:114
 msgid "Can't find value property."
 msgstr "Ne peut trouver la propriété value."
 
-#: ../src/lib/conf.c:415 ../src/lib/monitor_db.c:114
+#: ../src/lib/conf.c:423 ../src/lib/monitor_db.c:116
 msgid "Can't convert value to int."
 msgstr "Ne peut convertir la valeur en entier."
 
-#: ../src/lib/conf.c:499
+#: ../src/lib/conf.c:507
 msgid "ddcci_delete_profile: Error, cannot delete profile.\n"
 msgstr "ddcci_delete_profile: Erreur, impossible de supprimer le profil.\n"
 
-#: ../src/lib/conf.c:519
+#: ../src/lib/conf.c:527
 #, c-format
 msgid "ddcci_delete_profile: Error, could not find the profile to delete.\n"
 msgstr ""
 "ddcci_delete_profile: Erreur, ne peut trouver le profile à supprimer.\n"
 
-#: ../src/lib/ddcci.c:146
+#: ../src/lib/ddcci.c:148
 msgid "Error while initialisating the message queue"
 msgstr "Erreur lors de l'initialisation de la file d'attente des messages."
 
-#: ../src/lib/ddcci.c:175
+#: ../src/lib/ddcci.c:177
 msgid "Error while sending quit message"
 msgstr "Erreur lors de l'envoi du message de type \"quit\"."
 
-#: ../src/lib/ddcci.c:221
+#: ../src/lib/ddcci.c:223
 msgid "Error while sending heartbeat message"
 msgstr "Erreur lors de l'envoi du message de type \"heartbeat\"."
 
-#: ../src/lib/ddcci.c:239
+#: ../src/lib/ddcci.c:241
 #, c-format
 msgid "Failed to initialize ddccontrol database...\n"
 msgstr "Impossible d'initialiser la base de donnée ddccontrol.\n"
 
-#: ../src/lib/ddcci.c:275 ../src/lib/ddcci.c:350
+#: ../src/lib/ddcci.c:247
+#, fuzzy, c-format
+msgid "Failed to initialize ADL...\n"
+msgstr "Impossible d'initialiser la base de donnée ddccontrol.\n"
+
+#: ../src/lib/ddcci.c:292 ../src/lib/ddcci.c:383
 #, c-format
 msgid "ioctl returned %d\n"
 msgstr "ioctl a renvoyé %d\n"
 
-#: ../src/lib/ddcci.c:300
+#: ../src/lib/ddcci.c:321
 msgid "Error while sending write message"
 msgstr "Erreur lors de l'envoi du message d'écriture."
 
-#: ../src/lib/ddcci.c:309
+#: ../src/lib/ddcci.c:330
 msgid "Error while reading write message answer"
 msgstr "Erreur lors de la lecture de la réponse du message d'écriture."
 
-#: ../src/lib/ddcci.c:376
+#: ../src/lib/ddcci.c:413
 msgid "Error while sending read message"
 msgstr "Erreur lors de l'envoi du message de lecture."
 
-#: ../src/lib/ddcci.c:385
+#: ../src/lib/ddcci.c:422
 msgid "Error while reading read message answer"
 msgstr "Erreur lors de la lecture de la réponse du message de lecture."
 
-#: ../src/lib/ddcci.c:475
+#: ../src/lib/ddcci.c:518
 #, c-format
 msgid "Invalid response, first byte is 0x%02x, should be 0x%02x\n"
 msgstr ""
 "Réponse invalide, le premier caractère est 0x%02x, mais devrait être 0x%02x\n"
 
-#: ../src/lib/ddcci.c:485
+#: ../src/lib/ddcci.c:528
 #, c-format
 msgid "Non-fatal error: Invalid response, magic is 0x%02x\n"
 msgstr ""
 "Erreur non-fatale : Réponse invalide, le nombre \"magique\" est 0x%02x\n"
 
-#: ../src/lib/ddcci.c:492
+#: ../src/lib/ddcci.c:535
 #, c-format
 msgid "Invalid response, length is %d, should be %d at most\n"
 msgstr "Réponse invalide, la longueur est %d, et devrait être de %d au moins\n"
 
-#: ../src/lib/ddcci.c:505
+#: ../src/lib/ddcci.c:548
 #, c-format
 msgid "Invalid response, corrupted data - xor is 0x%02x, length 0x%02x\n"
 msgstr ""
-"Réponse invalide, données corrompues - le xor est 0x%02x, la longueur 0x%"
-"02x\n"
+"Réponse invalide, données corrompues - le xor est 0x%02x, la longueur "
+"0x%02x\n"
 
-#: ../src/lib/ddcci.c:658 ../src/lib/ddcci.c:680
+#: ../src/lib/ddcci.c:709 ../src/lib/ddcci.c:731
 #, c-format
 msgid "Can't convert value to int, invalid CAPS (buf=%s, pos=%d).\n"
 msgstr ""
 "Ne peut convertir la valeur en entier, CAPS invalide (buf=%s, pos=%d).\n"
 
-#: ../src/lib/ddcci.c:763
+#: ../src/lib/ddcci.c:814
 #, c-format
 msgid "Invalid sequence in caps.\n"
 msgstr "Séquence invalide dans la chaîne de capacité.\n"
 
-#: ../src/lib/ddcci.c:841
+#: ../src/lib/ddcci.c:892
 #, c-format
 msgid "Corrupted EDID at 0x%02x.\n"
 msgstr "EDID corrompu à 0x%02x.\n"
 
-#: ../src/lib/ddcci.c:853
+#: ../src/lib/ddcci.c:904
 #, c-format
 msgid "Serial number: %d\n"
 msgstr "Numéro de série : %d\n"
 
-#: ../src/lib/ddcci.c:856
+#: ../src/lib/ddcci.c:907
 #, c-format
 msgid "Manufactured: Week %d, %d\n"
 msgstr "Manufacturé : Semaine %d, %d\n"
 
-#: ../src/lib/ddcci.c:859
+#: ../src/lib/ddcci.c:910
 #, c-format
 msgid "EDID version: %d.%d\n"
 msgstr "Version de l'EDID : %d.%d\n"
 
-#: ../src/lib/ddcci.c:862
+#: ../src/lib/ddcci.c:913
 #, c-format
 msgid "Maximum size: %d x %d (cm)\n"
 msgstr "Taille maximale : %d x %d (cm)\n"
 
-#: ../src/lib/ddcci.c:873
+#: ../src/lib/ddcci.c:924
 #, c-format
 msgid "Reading EDID 0x%02x failed.\n"
 msgstr "Echec de lecture de l'EDID 0x%02x.\n"
 
-#: ../src/lib/ddcci.c:903
+#: ../src/lib/ddcci.c:954
 #, c-format
 msgid "Device: %s\n"
 msgstr "Périphérique : %s\n"
 
-#: ../src/lib/ddcci.c:917
+#: ../src/lib/ddcci.c:968
 msgid "Error while sending open message"
 msgstr "Erreur lors de l'envoi du message de l'ouverture."
 
-#: ../src/lib/ddcci.c:925
+#: ../src/lib/ddcci.c:976
 msgid "Error while reading open message answer"
 msgstr "Erreur lors de la lecture de la réponse du message d'ouverture."
 
-#: ../src/lib/ddcci.c:933
+#: ../src/lib/ddcci.c:988 ../src/lib/ddcci.c:1001
 #, c-format
 msgid "Invalid filename (%s).\n"
 msgstr "Nom de fichier invalide (%s).\n"
 
-#: ../src/lib/ddcci.c:1049
+#: ../src/lib/ddcci.c:993
+#, c-format
+msgid "ADL display not found (%s).\n"
+msgstr ""
+
+#: ../src/lib/ddcci.c:1125
 #, c-format
 msgid "ddcci_open returned %d\n"
 msgstr "ddcci_open a renvoyé %d\n"
 
-#: ../src/lib/ddcci.c:1062
+#: ../src/lib/ddcci.c:1138
 #, c-format
 msgid "Unknown monitor (%s)"
 msgstr "Moniteur inconnu (%s)"
 
-#: ../src/lib/ddcci.c:1083
+#: ../src/lib/ddcci.c:1159
 #, c-format
 msgid "Probing for available monitors"
 msgstr "Recherche des moniteurs disponibles"
 
-#: ../src/lib/ddcci.c:1097
+#: ../src/lib/ddcci.c:1173
 msgid "Error while sending list message"
 msgstr "Erreur lors de l'envoi du message de type \"list\"."
 
-#: ../src/lib/ddcci.c:1106
+#: ../src/lib/ddcci.c:1182
 msgid "Error while reading list entry"
 msgstr "Erreur lors de la lecture d'une entrée de la liste."
 
-#: ../src/lib/ddcci.c:1123
+#: ../src/lib/ddcci.c:1199
 #, c-format
 msgid "Found PCI device (%s)\n"
 msgstr "Périphérique PCI trouvé (%s)\n"
 
-#: ../src/lib/ddcci.c:1157
+#: ../src/lib/ddcci.c:1239
 #, c-format
 msgid "Found I2C device (%s)\n"
 msgstr "Périphérique I2C trouvé (%s)\n"
 
-#: ../src/lib/ddcci.c:1206
+#: ../src/lib/ddcci.c:1264
+#, fuzzy, c-format
+msgid "Found ADL display (%s)\n"
+msgstr "Périphérique PCI trouvé (%s)\n"
+
+#: ../src/lib/ddcci.c:1310
 msgid "Error while getting information about ddccontrol home directory."
 msgstr ""
 "Erreur lors de l'obtention d'informations au sujet du dossier de ddccontrol "
 "dans le répertoire personnel."
 
-#: ../src/lib/ddcci.c:1211
+#: ../src/lib/ddcci.c:1316
 msgid "Error while creating ddccontrol home directory."
 msgstr ""
 "Erreur lors de la création du dossier de ddccontrol dans le répertoire "
 "personnel."
 
-#: ../src/lib/ddcci.c:1216
+#: ../src/lib/ddcci.c:1322
 msgid ""
 "Error while getting information about ddccontrol home directory after "
 "creating it."
@@ -1158,25 +1186,25 @@ msgstr ""
 "Erreur lors de l'obtention d'informations au sujet du dossier de ddccontrol "
 "dans le répertoire personnel après l'avoir créé."
 
-#: ../src/lib/ddcci.c:1223
+#: ../src/lib/ddcci.c:1330
 msgid "Error: '.ddccontrol' in your home directory is not a directory."
 msgstr ""
 "Erreur : '.ddccontrol' dans votre répertoire personnel n'est pas un "
 "répertoire."
 
-#: ../src/lib/ddcci.c:1231
+#: ../src/lib/ddcci.c:1339
 msgid "Error while getting information about ddccontrol profile directory."
 msgstr ""
 "Erreur lors de l'obtention d'informations au sujet du dossier des profils "
 "dans le répertoire personnel."
 
-#: ../src/lib/ddcci.c:1236
+#: ../src/lib/ddcci.c:1345
 msgid "Error while creating ddccontrol profile directory."
 msgstr ""
 "Erreur lors de la création du dossier des profiles dans le répertoire "
 "personnel."
 
-#: ../src/lib/ddcci.c:1241
+#: ../src/lib/ddcci.c:1351
 msgid ""
 "Error while getting information about ddccontrol profile directory after "
 "creating it."
@@ -1184,147 +1212,196 @@ msgstr ""
 "Erreur lors de l'obtention d'informations au sujet du dossier des profils "
 "dans le répertoire personnel après l'avoir créé."
 
-#: ../src/lib/ddcci.c:1248
+#: ../src/lib/ddcci.c:1359
 msgid ""
 "Error: '.ddccontrol/profiles' in your home directory is not a directory."
 msgstr ""
 "Erreur : '.ddccontrol/profiles' dans votre répertoire personnel n'est pas un "
 "répertoire."
 
-#: ../src/lib/monitor_db.c:82 ../src/lib/monitor_db.c:192
+#: ../src/lib/monitor_db.c:84 ../src/lib/monitor_db.c:194
 msgid "Can't find id property."
 msgstr "Ne peut trouver la propriété id."
 
-#: ../src/lib/monitor_db.c:151 ../src/lib/monitor_db.c:546
+#: ../src/lib/monitor_db.c:153 ../src/lib/monitor_db.c:549
 #, c-format
 msgid "Element %s (id=%s) has not been found (line %ld).\n"
 msgstr "L'élement %s (id=%s) n'a pas été trouvé (ligne %ld).\n"
 
-#: ../src/lib/monitor_db.c:205
+#: ../src/lib/monitor_db.c:207
 msgid "Invalid refresh type (!= none, != all)."
 msgstr "Type de refresh invalide (!= none, != all)."
 
-#: ../src/lib/monitor_db.c:238
+#: ../src/lib/monitor_db.c:242
 #, c-format
 msgid "Control %s has been discarded by the caps string.\n"
 msgstr "Le contrôle %s a été désactivé à cause de la chaîne de capacité.\n"
 
-#: ../src/lib/monitor_db.c:246
+#: ../src/lib/monitor_db.c:250
 #, c-format
 msgid "Control %s (0x%02x) has already been defined.\n"
 msgstr "Le contrôle %s (0x%02x) a déjà été défini.\n"
 
-#: ../src/lib/monitor_db.c:259
+#: ../src/lib/monitor_db.c:263
 msgid "Can't convert delay to int."
 msgstr "Ne peut convertir le délai en entier."
 
-#: ../src/lib/monitor_db.c:267
+#: ../src/lib/monitor_db.c:271
 msgid "Can't find type property."
 msgstr "Ne peut trouver la propriété type."
 
-#: ../src/lib/monitor_db.c:292 ../src/lib/monitor_db.c:381
+#: ../src/lib/monitor_db.c:296 ../src/lib/monitor_db.c:384
 msgid "Invalid type."
 msgstr "Type invalide."
 
-#: ../src/lib/monitor_db.c:343
+#: ../src/lib/monitor_db.c:346
 #, c-format
 msgid "Database must be inited before reading a monitor file.\n"
 msgstr ""
 "La base de donnée doit être initialisée avant de lire un fichier moniteur.\n"
 
-#: ../src/lib/monitor_db.c:357
+#: ../src/lib/monitor_db.c:360
 #, c-format
 msgid "empty monitor/%s.xml\n"
 msgstr "monitor/%s.xml vide\n"
 
-#: ../src/lib/monitor_db.c:363
+#: ../src/lib/monitor_db.c:366
 #, c-format
 msgid "monitor/%s.xml of the wrong type, root node %s != monitor"
 msgstr "monitor/%s.xml de mauvais type, élement racine %s != monitor"
 
-#: ../src/lib/monitor_db.c:464
+#: ../src/lib/monitor_db.c:467
 msgid "Can't find add or remove property in caps."
 msgstr "Ne peut trouver la propriété add ou remove dans caps."
 
-#: ../src/lib/monitor_db.c:466
+#: ../src/lib/monitor_db.c:469
 msgid "Invalid remove caps."
 msgstr "Séquence invalide dans la chaîne de capacité \"remove\"."
 
-#: ../src/lib/monitor_db.c:468
+#: ../src/lib/monitor_db.c:471
 msgid "Invalid add caps."
 msgstr "Séquence invalide dans la chaîne de capacité \"add\"."
 
-#: ../src/lib/monitor_db.c:473
+#: ../src/lib/monitor_db.c:476
 #, c-format
 msgid "Error, include recursion level > 15 (file: %s).\n"
 msgstr "Erreur, niveau de récursion > 15 (file: %s).\n"
 
-#: ../src/lib/monitor_db.c:479
+#: ../src/lib/monitor_db.c:482
 msgid "Can't find file property."
 msgstr "Ne peut trouver la propriété file."
 
-#: ../src/lib/monitor_db.c:487
+#: ../src/lib/monitor_db.c:490
 msgid "Two controls part in XML file."
 msgstr "Deux parties controls dans le fichier XML."
 
-#: ../src/lib/monitor_db.c:534
+#: ../src/lib/monitor_db.c:537
 msgid "Error enumerating controls in subgroup."
 msgstr "Erreur lors de l'énumération des contrôles dans d'un sous-groupe."
 
-#: ../src/lib/monitor_db.c:589
+#: ../src/lib/monitor_db.c:601
 #, c-format
 msgid "document of the wrong type, can't find controls or include.\n"
 msgstr ""
 "document de mauvais type, ne peut trouver les contrôles ou une inclusion.\n"
 
-#: ../src/lib/monitor_db.c:721
+#: ../src/lib/monitor_db.c:733
 #, c-format
 msgid "empty options.xml\n"
 msgstr "options.xml vide\n"
 
-#: ../src/lib/monitor_db.c:728
+#: ../src/lib/monitor_db.c:740
 #, c-format
 msgid "options.xml of the wrong type, root node %s != options"
 msgstr "options.xml de mauvais type, élement racine %s != monitor"
 
-#: ../src/lib/monitor_db.c:738
+#: ../src/lib/monitor_db.c:750
 #, c-format
 msgid "options.xml dbversion attribute missing, please update your database.\n"
 msgstr ""
 "L'attribut dbversion dans options.xml est absent, veuillez mettre à jour "
 "votre base de données.\n"
 
-#: ../src/lib/monitor_db.c:745
+#: ../src/lib/monitor_db.c:757
 #, c-format
 msgid "options.xml date attribute missing, please update your database.\n"
 msgstr ""
 "L'attribut date dans options.xml est absent, veuillez mettre à jour votre "
 "base de données.\n"
 
-#: ../src/lib/monitor_db.c:755
+#: ../src/lib/monitor_db.c:767
 #, c-format
 msgid ""
 "options.xml dbversion (%d) is greater than the supported version (%d).\n"
 msgstr ""
-"La version de options.xml (%d) est plus grande que la version supportée (%"
-"d).\n"
+"La version de options.xml (%d) est plus grande que la version supportée "
+"(%d).\n"
 
-#: ../src/lib/monitor_db.c:756
+#: ../src/lib/monitor_db.c:768
 #, c-format
 msgid "Please update ddccontrol program.\n"
 msgstr "Veuillez mettre à jour le programme ddccontrol.\n"
 
-#: ../src/lib/monitor_db.c:763
+#: ../src/lib/monitor_db.c:775
 #, c-format
 msgid "options.xml dbversion (%d) is less than the supported version (%d).\n"
 msgstr ""
-"La version de options.xml (%d) est plus petite que la version supportée (%"
-"d).\n"
+"La version de options.xml (%d) est plus petite que la version supportée "
+"(%d).\n"
 
-#: ../src/lib/monitor_db.c:764
+#: ../src/lib/monitor_db.c:776
 #, c-format
 msgid "Please update ddccontrol database.\n"
 msgstr "Veuillez mettre à jour la base de données ddccontrol.\n"
+
+#, c-format
+#~ msgid "Monitor Profile Switcher"
+#~ msgstr "Manager de profils d'affichage"
+
+#~ msgid "Quickly switch monitor profiles created with gddccontrol"
+#~ msgstr ""
+#~ "Choisit rapidement entre les profils moniteur créés avec gddccontrol."
+
+#~ msgid "_About..."
+#~ msgstr "_A propos de..."
+
+#~ msgid "_Properties..."
+#~ msgstr "_Propriétés"
+
+#~ msgid "_Run gddccontrol..."
+#~ msgstr "_Lancer gddccontrol..."
+
+#~ msgid ""
+#~ "An applet for quick switching of monitor profiles.\n"
+#~ "Based on libddccontrol and part of the ddccontrol project.\n"
+#~ "(http://ddccontrol.sourceforge.net)"
+#~ msgstr ""
+#~ "Un applet pour changer rapidement de profiles de moniteurs.\n"
+#~ "Basé sur libddccontrol et inclu dans le projet ddccontrol.\n"
+#~ "(http://ddccontrol.sourceforge.net)"
+
+#~ msgid "Unable to initialize ddcci library"
+#~ msgstr "Impossible d'initialiser la librairie ddcci"
+
+#~ msgid "No monitor configuration found. Please run gddccontrol first"
+#~ msgstr ""
+#~ "Aucune configuration de moniteurs trouvée, veuillez lancer gddccontrol "
+#~ "d'abord."
+
+#~ msgid "An error occurred while opening the monitor device"
+#~ msgstr "Erreur lors de l'ouverture du périphérique du moniteur."
+
+#~ msgid "Can't find any profiles"
+#~ msgstr "Aucun profil trouvé."
+
+#~ msgid "error"
+#~ msgstr "erreur"
+
+#~ msgid "Monitor:"
+#~ msgstr "Moniteur :"
+
+#~ msgid "Monitor Profile Switcher Properties"
+#~ msgstr "Propriétés du manager de profils d'affichage."
 
 #~ msgid "Buffer too small to contain caps.\n"
 #~ msgstr "Tampon trop petit pour contenir la chaîne de capacité.\n"

--- a/po/ka.po
+++ b/po/ka.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: ddcontrol\n"
-"Report-Msgid-Bugs-To: ddccontrol-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2024-01-29 22:16+0100\n"
+"Report-Msgid-Bugs-To: https://github.com/ddccontrol/ddccontrol/issues/\n"
+"POT-Creation-Date: 2026-05-13 15:12+0200\n"
 "PO-Revision-Date: 2026-03-24 17:19+0100\n"
 "Last-Translator: Ekaterine Papava <papava.e@gtu.ge>\n"
 "Language-Team: Georgian <(nothing)>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.9\n"
 
-#: ../src/ddccontrol/main.c:84
+#: ../src/ddccontrol/main.c:85
 #, c-format
 msgid ""
 "Usage:\n"
@@ -53,22 +53,22 @@ msgstr ""
 "\t-b : ddccontrol-db საქაღალდე (თუ განსხვავდება მნიშვნელობისგან %s)\n"
 "\t-l : მნიშვნელობების წაკითხვა XML პროფილის ფაილიდან\n"
 
-#: ../src/ddccontrol/main.c:105 ../src/ddccontrol/main.c:127
+#: ../src/ddccontrol/main.c:106 ../src/ddccontrol/main.c:128
 #, c-format
 msgid "Checking %s integrity...\n"
 msgstr "%s-ის მთლიანობის შემოწმება...\n"
 
-#: ../src/ddccontrol/main.c:107 ../src/ddccontrol/main.c:129
+#: ../src/ddccontrol/main.c:108 ../src/ddccontrol/main.c:130
 #, c-format
 msgid "[ FAILED ]\n"
 msgstr "[ ჩავარდა ]\n"
 
-#: ../src/ddccontrol/main.c:111 ../src/ddccontrol/main.c:134
+#: ../src/ddccontrol/main.c:112 ../src/ddccontrol/main.c:135
 #, c-format
 msgid "[ OK ]\n"
 msgstr "[ კარგია ]\n"
 
-#: ../src/ddccontrol/main.c:189
+#: ../src/ddccontrol/main.c:194
 #, c-format
 msgid ""
 "ddccontrol version %s\n"
@@ -87,90 +87,90 @@ msgstr ""
 "General Public License.\n"
 "\n"
 
-#: ../src/ddccontrol/main.c:206
+#: ../src/ddccontrol/main.c:211
 #, c-format
 msgid "'%s' does not seem to be a valid register name\n"
 msgstr "'%s' რეგისტრის სწორ სახელს არ წააგავს\n"
 
-#: ../src/ddccontrol/main.c:212
+#: ../src/ddccontrol/main.c:217
 #, c-format
 msgid "You cannot use -w parameter without -r.\n"
 msgstr "პარამეტრს -w ვერ გამოიყენებთ პარამეტრის -r გარეშე.\n"
 
-#: ../src/ddccontrol/main.c:216 ../src/ddccontrol/main.c:226
+#: ../src/ddccontrol/main.c:221 ../src/ddccontrol/main.c:231
 #, c-format
 msgid "'%s' does not seem to be a valid value.\n"
 msgstr "'%s' სწორ მნიშვნელობას არ წააგავს.\n"
 
-#: ../src/ddccontrol/main.c:222
+#: ../src/ddccontrol/main.c:227
 #, c-format
 msgid "You cannot use -W parameter without -r.\n"
 msgstr "პარამეტრს -W ვერ გამოიყენებთ პარამეტრის -r გარეშე.\n"
 
-#: ../src/ddccontrol/main.c:277 ../src/gddccontrol/main.c:421
+#: ../src/ddccontrol/main.c:282 ../src/gddccontrol/main.c:432
 #, c-format
 msgid "Unable to initialize ddcci library.\n"
 msgstr "ბიბლიოთეკის ddcci ინიციალიზაცია შეუძლებელია.\n"
 
-#: ../src/ddccontrol/main.c:283
+#: ../src/ddccontrol/main.c:288
 #, c-format
 msgid "Unable to initialize ddcci db library.\n"
 msgstr "ddcci-ის მონაცემთა ბაზის ბიბლიოთეკის ინიციალიზაცია შეუძლებელია.\n"
 
-#: ../src/ddccontrol/main.c:288
+#: ../src/ddccontrol/main.c:293
 #, c-format
 msgid "Failed to open D-Bus proxy, try with DDCCONTROL_NO_DAEMON=1.\n"
 msgstr ""
 "D-Bus-ის პროქსის გახსნა ჩავარდა. სცადეთ გარემოს ცვლადით "
 "DDCCONTROL_NO_DAEMON=1.\n"
 
-#: ../src/ddccontrol/main.c:305
+#: ../src/ddccontrol/main.c:310
 #, c-format
 msgid "Detected monitors :\n"
 msgstr "აღმოჩენილი ეკრანები:\n"
 
-#: ../src/ddccontrol/main.c:309
+#: ../src/ddccontrol/main.c:314
 #, c-format
 msgid " - Device: %s\n"
 msgstr " - მოწყობილობა: %s\n"
 
-#: ../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 #, c-format
 msgid "   DDC/CI supported: %s\n"
 msgstr "   DDC/CI მხარდაჭერილია: %s\n"
 
-#: ../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 msgid "Yes"
 msgstr "დიახ"
 
-#: ../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 msgid "No"
 msgstr "არა"
 
-#: ../src/ddccontrol/main.c:311
+#: ../src/ddccontrol/main.c:316
 #, c-format
 msgid "   Monitor Name: %s\n"
 msgstr "   ეკრანის სახელი: %s\n"
 
-#: ../src/ddccontrol/main.c:312
+#: ../src/ddccontrol/main.c:317
 #, c-format
 msgid "   Input type: %s\n"
 msgstr "   შეყვანის ტიპი: %s\n"
 
-#: ../src/ddccontrol/main.c:312 ../src/ddccontrol/main.c:355
+#: ../src/ddccontrol/main.c:317 ../src/ddccontrol/main.c:364
 msgid "Digital"
 msgstr "ციფრული"
 
-#: ../src/ddccontrol/main.c:312 ../src/ddccontrol/main.c:355
+#: ../src/ddccontrol/main.c:317 ../src/ddccontrol/main.c:364
 msgid "Analog"
 msgstr "ანალოგური"
 
-#: ../src/ddccontrol/main.c:315
+#: ../src/ddccontrol/main.c:321
 #, c-format
 msgid "  (Automatically selected)\n"
 msgstr "  (ავტომატურად არჩეული)\n"
 
-#: ../src/ddccontrol/main.c:325
+#: ../src/ddccontrol/main.c:333
 #, c-format
 msgid ""
 "No monitor supporting DDC/CI available.\n"
@@ -181,12 +181,12 @@ msgstr ""
 "თუ თქვენს გრაფიკულ ბარათს ეს სჭირდება, შეამოწმეთ, ჩატვირთულია, თუ არა ყველა "
 "საჭირო ბირთვის მოდული (i2c-dev და თქვენი framebuffer-ის დრაივერი).\n"
 
-#: ../src/ddccontrol/main.c:337
+#: ../src/ddccontrol/main.c:346
 #, c-format
 msgid "Reading EDID and initializing DDC/CI at bus %s...\n"
 msgstr "EDID-ის წაკითხვა და DDC/CI-ის ინიციალიზაცია სალტესთან %s...\n"
 
-#: ../src/ddccontrol/main.c:348
+#: ../src/ddccontrol/main.c:357
 #, c-format
 msgid ""
 "\n"
@@ -199,7 +199,7 @@ msgstr ""
 "თუ თქვენს გრაფიკულ ბარათს ეს სჭირდება, შეამოწმეთ, ჩატვირთულია, თუ არა ყველა "
 "საჭირო ბირთვის მოდული (i2c-dev და თქვენი framebuffer-ის დრაივერი).\n"
 
-#: ../src/ddccontrol/main.c:352
+#: ../src/ddccontrol/main.c:361
 #, c-format
 msgid ""
 "\n"
@@ -208,23 +208,157 @@ msgstr ""
 "\n"
 "EDID-ის მნიშვნელობები:\n"
 
-#: ../src/ddccontrol/main.c:353
+#: ../src/ddccontrol/main.c:362
 #, c-format
 msgid "\tPlug and Play ID: %s [%s]\n"
 msgstr "\tPlug and Play ID: %s [%s]\n"
 
-#: ../src/ddccontrol/main.c:355
+#: ../src/ddccontrol/main.c:364
 #, c-format
 msgid "\tInput type: %s\n"
 msgstr "\tშეყვანის ტიპი: %s\n"
 
+#: ../src/ddccontrol/main.c:370
+#, c-format
+msgid ""
+"\n"
+"Capabilities:\n"
+msgstr ""
+"\n"
+"შესაძლებლობები:\n"
+
+#: ../src/ddccontrol/main.c:374
+#, c-format
+msgid "Raw output: %s\n"
+msgstr "დაუმუშავებელი გამოტანა: %s\n"
+
+#: ../src/ddccontrol/main.c:376
+#, c-format
+msgid "Parsed output: \n"
+msgstr "დამუშავებული გამოტანა:\n"
+
+#: ../src/ddccontrol/main.c:385
+#, c-format
+msgid "\tType: "
+msgstr "\tტიპი: "
+
+#: ../src/ddccontrol/main.c:388
+#, c-format
+msgid "LCD"
+msgstr "LCD"
+
+#: ../src/ddccontrol/main.c:391
+#, c-format
+msgid "CRT"
+msgstr "CRT"
+
+#: ../src/ddccontrol/main.c:394
+#, c-format
+msgid "Unknown"
+msgstr "უცნობი"
+
+#: ../src/ddccontrol/main.c:403
+#, c-format
+msgid "Capabilities read fail.\n"
+msgstr "შესაძლებლობების წაკითხვა ჩავარდა.\n"
+
+#: ../src/ddccontrol/main.c:417
+#, c-format
+msgid "Value cannot be lower than zero! %d -> %d\n"
+msgstr "მნიშვნელობა ნულზე ნაკლები ვერ იქნება! %d -> %d\n"
+
+#: ../src/ddccontrol/main.c:420
+#, c-format
+msgid "Value cannot be higher than maximum! %d / %d\n"
+msgstr "მნიშვნელობა მაქსიმუმს ვერ გადააჭარბებს! %d / %d\n"
+
+#: ../src/ddccontrol/main.c:428
+#, c-format
+msgid ""
+"\n"
+"Writing 0x%02x, 0x%02x(%d) (%dms delay)...\n"
+msgstr ""
+"\n"
+"იწერება 0x%02x, 0x%02x(%d) (%dმწმ დაყოვნება)...\n"
+
+#: ../src/ddccontrol/main.c:431
+#, c-format
+msgid ""
+"\n"
+"Writing 0x%02x, 0x%02x(%d)...\n"
+msgstr ""
+"\n"
+"იწერება 0x%02x, 0x%02x(%d)...\n"
+
+#: ../src/ddccontrol/main.c:436
+#, c-format
+msgid ""
+"\n"
+"Reading 0x%02x...\n"
+msgstr ""
+"\n"
+"მიმდინარეობს კითხვა 0x%02x...\n"
+
+#: ../src/ddccontrol/main.c:445
+#, c-format
+msgid "Applied profile: %s\n"
+msgstr "გადატარებული პროფილი: %s\n"
+
+#: ../src/ddccontrol/main.c:447
+#, c-format
+msgid "Failed to apply profile: %s\n"
+msgstr "პროფილის გადატარება ჩავარდა: %s\n"
+
+#: ../src/ddccontrol/main.c:451
+#, c-format
+msgid ""
+"\n"
+"Controls (valid/current/max) [Description - Value name]:\n"
+msgstr ""
+"\n"
+"კონტროლის ელემენტები (სწორი/მიმდინარე/მას) [აღწერა - მნიშვნელობის სახელი]:\n"
+
+#: ../src/ddccontrol/main.c:473
+#, c-format
+msgid "\t\t> id=%s, name=%s, address=%#x, delay=%dms, type=%d\n"
+msgstr "\t\t> id=%s, სახელი=%s, მისამართი=%#x, დაყოვნება=%dმწმ, ტიპი=%d\n"
+
+#: ../src/ddccontrol/main.c:478
+#, c-format
+msgid "\t\t  Possible values:\n"
+msgstr "\t\t  შესაძლო მნიშვნელობები:\n"
+
+#: ../src/ddccontrol/main.c:482
+#, c-format
+msgid "\t\t\t> id=%s - name=%s, value=%d\n"
+msgstr "\t\t\t> id=%s - სახელი=%s, მნიშვნელობა=%d\n"
+
+#: ../src/ddccontrol/main.c:492
+#, c-format
+msgid "\t\t  supported, value=%d, maximum=%d\n"
+msgstr "\t\t  მხარდაჭერილია. მნიშვნელობა=%d, მაქსიმუმი=%d\n"
+
+#: ../src/ddccontrol/main.c:493
+#, c-format
+msgid "\t\t  not supported, value=%d, maximum=%d\n"
+msgstr "\t\t  მხარდაჭერილი არაა. მნიშვნელობა=%d, მაქსიმუმი=%d\n"
+
+#: ../src/ddccontrol/main.c:504
+#, c-format
+msgid ""
+"\n"
+"Saving settings...\n"
+msgstr ""
+"\n"
+"პარამეტრების შენახვა...\n"
+
 #. Put a big warning (in red if we are writing to a terminal).
-#: ../src/ddccontrol/main.c:359 ../src/ddccontrol/main.c:377
+#: ../src/ddccontrol/main.c:516 ../src/ddccontrol/main.c:537
 msgid "=============================== WARNING ==============================="
 msgstr ""
 "=============================== გაფრთხილება ==============================="
 
-#: ../src/ddccontrol/main.c:362
+#: ../src/ddccontrol/main.c:519
 #, c-format
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is\n"
@@ -237,7 +371,7 @@ msgstr ""
 "ელემენტი\n"
 "მხარდაჭერილი არ იყოს, ან არ იმუშაოს ისე, როგორც მოელით.\n"
 
-#: ../src/ddccontrol/main.c:367
+#: ../src/ddccontrol/main.c:524
 #, c-format
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is\n"
@@ -249,155 +383,24 @@ msgstr ""
 "საბაზისო ზოგად პროფილს თქვენი ეკრანის მწარმოებლისთვის. შეიძლება, ზოგიერთი\n"
 "კონტროლის ელემენტი მხარდაჭერილი არ იყოს, ან არ იმუშაოს ისე, როგორც მოელით.\n"
 
-#: ../src/ddccontrol/main.c:372
+#: ../src/ddccontrol/main.c:529
 #, c-format
 msgid ""
+"Unsupported monitor detected.\n"
+"\n"
 "Please update ddccontrol-db, or, if you are already using the latest\n"
-"version, please send the output of the following command to\n"
-"ddccontrol-users@lists.sourceforge.net:\n"
+"version, please open this pre-filled GitHub issue:\n"
 msgstr ""
-"განაახლეთ ddccontrol-db, ან, თუ უკვე იყენებთ უახლეს ვერსიას,\n"
-"გამოგვიგზავნეთ შემდეგი ბრძანების გამოტანილი ინფორმაცია ელფოსტაზე\n"
-"ddccontrol-users@lists.sourceforge.net:\n"
 
-#: ../src/ddccontrol/main.c:376 ../src/gddccontrol/notebook.c:695
+#: ../src/ddccontrol/main.c:534
+#, c-format
+msgid "Then attach the resulting report file of the following command:\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:536 ../src/gddccontrol/notebook.c:715
 #, c-format
 msgid "Thank you.\n"
 msgstr "მადლობა.\n"
-
-#: ../src/ddccontrol/main.c:381
-#, c-format
-msgid ""
-"\n"
-"Capabilities:\n"
-msgstr ""
-"\n"
-"შესაძლებლობები:\n"
-
-#: ../src/ddccontrol/main.c:385
-#, c-format
-msgid "Raw output: %s\n"
-msgstr "დაუმუშავებელი გამოტანა: %s\n"
-
-#: ../src/ddccontrol/main.c:387
-#, c-format
-msgid "Parsed output: \n"
-msgstr "დამუშავებული გამოტანა:\n"
-
-#: ../src/ddccontrol/main.c:396
-#, c-format
-msgid "\tType: "
-msgstr "\tტიპი: "
-
-#: ../src/ddccontrol/main.c:399
-#, c-format
-msgid "LCD"
-msgstr "LCD"
-
-#: ../src/ddccontrol/main.c:402
-#, c-format
-msgid "CRT"
-msgstr "CRT"
-
-#: ../src/ddccontrol/main.c:405
-#, c-format
-msgid "Unknown"
-msgstr "უცნობი"
-
-#: ../src/ddccontrol/main.c:414
-#, c-format
-msgid "Capabilities read fail.\n"
-msgstr "შესაძლებლობების წაკითხვა ჩავარდა.\n"
-
-#: ../src/ddccontrol/main.c:428
-#, c-format
-msgid "Value cannot be lower than zero! %d -> %d\n"
-msgstr "მნიშვნელობა ნულზე ნაკლები ვერ იქნება! %d -> %d\n"
-
-#: ../src/ddccontrol/main.c:431
-#, c-format
-msgid "Value cannot be higher than maximum! %d / %d\n"
-msgstr "მნიშვნელობა მაქსიმუმს ვერ გადააჭარბებს! %d / %d\n"
-
-#: ../src/ddccontrol/main.c:439
-#, c-format
-msgid ""
-"\n"
-"Writing 0x%02x, 0x%02x(%d) (%dms delay)...\n"
-msgstr ""
-"\n"
-"იწერება 0x%02x, 0x%02x(%d) (%dმწმ დაყოვნება)...\n"
-
-#: ../src/ddccontrol/main.c:442
-#, c-format
-msgid ""
-"\n"
-"Writing 0x%02x, 0x%02x(%d)...\n"
-msgstr ""
-"\n"
-"იწერება 0x%02x, 0x%02x(%d)...\n"
-
-#: ../src/ddccontrol/main.c:447
-#, c-format
-msgid ""
-"\n"
-"Reading 0x%02x...\n"
-msgstr ""
-"\n"
-"მიმდინარეობს კითხვა 0x%02x...\n"
-
-#: ../src/ddccontrol/main.c:456
-#, c-format
-msgid "Applied profile: %s\n"
-msgstr "გადატარებული პროფილი: %s\n"
-
-#: ../src/ddccontrol/main.c:458
-#, c-format
-msgid "Failed to apply profile: %s\n"
-msgstr "პროფილის გადატარება ჩავარდა: %s\n"
-
-#: ../src/ddccontrol/main.c:462
-#, c-format
-msgid ""
-"\n"
-"Controls (valid/current/max) [Description - Value name]:\n"
-msgstr ""
-"\n"
-"კონტროლის ელემენტები (სწორი/მიმდინარე/მას) [აღწერა - მნიშვნელობის სახელი]:\n"
-
-#: ../src/ddccontrol/main.c:484
-#, c-format
-msgid "\t\t> id=%s, name=%s, address=%#x, delay=%dms, type=%d\n"
-msgstr "\t\t> id=%s, სახელი=%s, მისამართი=%#x, დაყოვნება=%dმწმ, ტიპი=%d\n"
-
-#: ../src/ddccontrol/main.c:489
-#, c-format
-msgid "\t\t  Possible values:\n"
-msgstr "\t\t  შესაძლო მნიშვნელობები:\n"
-
-#: ../src/ddccontrol/main.c:493
-#, c-format
-msgid "\t\t\t> id=%s - name=%s, value=%d\n"
-msgstr "\t\t\t> id=%s - სახელი=%s, მნიშვნელობა=%d\n"
-
-#: ../src/ddccontrol/main.c:503
-#, c-format
-msgid "\t\t  supported, value=%d, maximum=%d\n"
-msgstr "\t\t  მხარდაჭერილია. მნიშვნელობა=%d, მაქსიმუმი=%d\n"
-
-#: ../src/ddccontrol/main.c:504
-#, c-format
-msgid "\t\t  not supported, value=%d, maximum=%d\n"
-msgstr "\t\t  მხარდაჭერილი არაა. მნიშვნელობა=%d, მაქსიმუმი=%d\n"
-
-#: ../src/ddccontrol/main.c:515
-#, c-format
-msgid ""
-"\n"
-"Saving settings...\n"
-msgstr ""
-"\n"
-"პარამეტრების შენახვა...\n"
 
 #. arbitration or no acknowledge
 #: ../src/ddcpci/i2c-algo-bit.c:368
@@ -541,7 +544,7 @@ msgstr "via_open: /dev/mem-ის გახსნა შეუძლებელ
 msgid "via_open: mmap failed"
 msgstr "via_open: mmap ცავარდა"
 
-#: ../src/gddccontrol/fspatterns.c:140
+#: ../src/gddccontrol/fspatterns.c:137
 msgid ""
 "Adjust brightness and contrast following these rules:\n"
 " - Black must be as dark as possible.\n"
@@ -554,11 +557,11 @@ msgstr ""
 " - უნდა შეგეძლოთ ნაცრისფრის ყველა დონის გარჩევა (უფრო ზუსტად, 0-ის და 12-"
 "ის).\n"
 
-#: ../src/gddccontrol/fspatterns.c:278
+#: ../src/gddccontrol/fspatterns.c:259
 msgid "Try to make moire patterns disappear."
 msgstr "სცადეთ, მუარის ნიმუშები გააქროთ."
 
-#: ../src/gddccontrol/fspatterns.c:282
+#: ../src/gddccontrol/fspatterns.c:263
 msgid ""
 "Adjust Image Lock Coarse to make the vertical band disappear.\n"
 "Adjust Image Lock Fine to minimize movement on the screen."
@@ -566,7 +569,7 @@ msgstr ""
 "მოირგეთ უხეშად გამოსახულება, თუ გნებავთ, ვერტიკალური ზოლები გაქრეს.\n"
 "მოირგეთ გამოსახულება ზუსტად ეკრანზე გადაადგილების შესამცირებლად."
 
-#: ../src/gddccontrol/fspatterns.c:293
+#: ../src/gddccontrol/fspatterns.c:273
 #, c-format
 msgid "Unknown fullscreen pattern name: %s"
 msgstr "უცნობი სრულეკრანიანი ნიმუშის სახელი: %s"
@@ -620,74 +623,74 @@ msgstr ""
 msgid "Profile Manager"
 msgstr "პროფილის მმართველი"
 
-#: ../src/gddccontrol/gprofile.c:194
+#: ../src/gddccontrol/gprofile.c:199
 msgid "Apply profile"
 msgstr "პროფილის გადატარება"
 
-#: ../src/gddccontrol/gprofile.c:199
+#: ../src/gddccontrol/gprofile.c:208
 msgid "Show profile details / Rename profile"
 msgstr "პროფილის დეტალების ჩვენება / პროფილის სახელის გადარქმევა"
 
-#: ../src/gddccontrol/gprofile.c:204
+#: ../src/gddccontrol/gprofile.c:217
 msgid "Delete profile"
 msgstr "პროფილის წაშლა"
 
-#: ../src/gddccontrol/gprofile.c:230
+#: ../src/gddccontrol/gprofile.c:253
 msgid "Create profile"
 msgstr "პროფილის შექმნა"
 
-#: ../src/gddccontrol/gprofile.c:236
+#: ../src/gddccontrol/gprofile.c:259
 msgid "Close profile manager"
 msgstr "პროფილების მმართველის დახურვა"
 
-#: ../src/gddccontrol/gprofile.c:300
+#: ../src/gddccontrol/gprofile.c:321
 msgid "Control name"
 msgstr "კონსტროლის ელემენტის სახელი"
 
-#: ../src/gddccontrol/gprofile.c:311
+#: ../src/gddccontrol/gprofile.c:332
 msgid "Value"
 msgstr "მნიშვნელობა"
 
-#: ../src/gddccontrol/gprofile.c:314
+#: ../src/gddccontrol/gprofile.c:335
 msgid "Address"
 msgstr "მისამართი"
 
-#: ../src/gddccontrol/gprofile.c:317
+#: ../src/gddccontrol/gprofile.c:338
 msgid "Raw value"
 msgstr "დაუმუშავებელი მნისვნელობა"
 
-#: ../src/gddccontrol/gprofile.c:435 ../src/gddccontrol/gprofile.c:455
+#: ../src/gddccontrol/gprofile.c:456 ../src/gddccontrol/gprofile.c:476
 msgid "Profile information:"
 msgstr "პროფილის ინფორმაცია:"
 
-#: ../src/gddccontrol/gprofile.c:464
+#: ../src/gddccontrol/gprofile.c:485
 #, c-format
 msgid "File name: %s"
 msgstr "ფაილის სახელი: %s"
 
-#: ../src/gddccontrol/gprofile.c:475
+#: ../src/gddccontrol/gprofile.c:496
 msgid "Profile name:"
 msgstr "პროფილის სახელი:"
 
 #. Save
-#: ../src/gddccontrol/gprofile.c:497
+#: ../src/gddccontrol/gprofile.c:518
 msgid "Saving profile..."
 msgstr "პროფილის შენახვა..."
 
-#: ../src/gddccontrol/gprofile.c:506
+#: ../src/gddccontrol/gprofile.c:527
 msgid "Error while saving profile."
 msgstr "პროფილის შენახვის შეცდომა."
 
-#: ../src/gddccontrol/main.c:192
+#: ../src/gddccontrol/main.c:204
 #, c-format
 msgid "Monitor changed (%d %d).\n"
 msgstr "ეკრანი შეიცვალა (%d %d).\n"
 
-#: ../src/gddccontrol/main.c:344
+#: ../src/gddccontrol/main.c:356
 msgid "Probing for available monitors..."
 msgstr "ხელმისაწვდომი ეკრანების აღმოჩენა..."
 
-#: ../src/gddccontrol/main.c:373
+#: ../src/gddccontrol/main.c:385
 msgid ""
 "No monitor supporting DDC/CI available.\n"
 "\n"
@@ -699,50 +702,50 @@ msgstr ""
 "თუ თქვენს გრაფიკულ ბარათს ეს სჭირდება, შეამოწმეთ, ჩატვირთულია, თუ არა ყველა "
 "საჭირო ბირთვის მოდული (i2c-dev და თქვენი framebuffer-ის დრაივერი)."
 
-#: ../src/gddccontrol/main.c:427
+#: ../src/gddccontrol/main.c:438
 msgid "Unable to initialize ddcci library, see console for more details.\n"
 msgstr ""
 "ddcci ბიბლიოთეკის ინიციალიზაცია შეუძლებელია. მეტი დეტალებისთვის იხილეთ "
 "კონსოლი.\n"
 "\n"
 
-#: ../src/gddccontrol/main.c:439
+#: ../src/gddccontrol/main.c:450
 msgid "Monitor settings"
 msgstr "ეკრანის მორგება"
 
-#: ../src/gddccontrol/main.c:463
+#: ../src/gddccontrol/main.c:474
 msgid "Current monitor: "
 msgstr "მიმდინარე ეკრანი: "
 
-#: ../src/gddccontrol/main.c:473
+#: ../src/gddccontrol/main.c:484
 msgid "Refresh monitor list"
 msgstr "ეკრანების სიის განახლება"
 
-#: ../src/gddccontrol/main.c:490
+#: ../src/gddccontrol/main.c:507
 msgid "Profile manager"
 msgstr "პროფილების მმართველი"
 
-#: ../src/gddccontrol/main.c:497
+#: ../src/gddccontrol/main.c:514
 msgid "Save profile"
 msgstr "პროფილის შენახვა"
 
-#: ../src/gddccontrol/main.c:503
+#: ../src/gddccontrol/main.c:520
 msgid "Cancel profile creation"
 msgstr "პროფილის შექმნის გაუმება"
 
-#: ../src/gddccontrol/main.c:527
+#: ../src/gddccontrol/main.c:549
 msgid "OK"
 msgstr "დიახ"
 
-#: ../src/gddccontrol/main.c:555
+#: ../src/gddccontrol/main.c:585
 msgid "Refresh"
 msgstr "განახლება"
 
-#: ../src/gddccontrol/main.c:555
+#: ../src/gddccontrol/main.c:585
 msgid "Refresh all controls"
 msgstr "ყველა კონტროლის ელემენტის განახლება"
 
-#: ../src/gddccontrol/main.c:562
+#: ../src/gddccontrol/main.c:592
 msgid "Close"
 msgstr "დახურვა"
 
@@ -750,7 +753,7 @@ msgstr "დახურვა"
 #. gtk_misc_set_alignment(GTK_MISC(moninfo), 0, 0);
 #.
 #. gtk_table_attach(GTK_TABLE(table), moninfo, 0, 1, 1, 2, GTK_FILL_EXPAND, 0, 5, 5);
-#: ../src/gddccontrol/main.c:601
+#: ../src/gddccontrol/main.c:634
 #, c-format
 msgid "Welcome to gddccontrol %s."
 msgstr "კეთილი იყოს თქვენი მობრძანება gddccontrol %s-ში."
@@ -816,31 +819,29 @@ msgstr ""
 #: ../src/gddccontrol/notebook.c:600
 #, c-format
 msgid ""
-"The current monitor is not supported, please run\n"
-"%s\n"
-"and send the output to ddccontrol-users@lists.sourceforge.net.\n"
-"Thanks."
+"Unsupported monitor detected.\n"
+"\n"
+"Please update ddccontrol-db, or, if you are already using the latest\n"
+"version, please open a github issue:\n"
+"https://github.com/ddccontrol/ddccontrol-db/issues/new?template=unsupported-"
+"monitor.yml\n"
+"Then attach the resulting report file of the following command:"
 msgstr ""
-"ეს ეკრანი მხარდაჭერილი არაა. გაუშვით ბრძანება\n"
-"%s\n"
-"და გამოაგზავნეთ გამოტანილი ინფორმაცია ელფოსტაზე ddccontrol-"
-"users@lists.sourceforge.net.\n"
-"მადლობა."
 
-#: ../src/gddccontrol/notebook.c:620
+#: ../src/gddccontrol/notebook.c:622
 msgid "Please click on a group name."
 msgstr "დააწკაპუნეთ ჯგუფის სახელზე."
 
-#: ../src/gddccontrol/notebook.c:639 ../src/gddccontrol/notebook.c:650
+#: ../src/gddccontrol/notebook.c:647 ../src/gddccontrol/notebook.c:658
 #, c-format
 msgid "Getting controls values (%d%%)..."
 msgstr "კონტროლის ელემენტის მნიშვნელობების მიღება (%d%%)..."
 
-#: ../src/gddccontrol/notebook.c:664
+#: ../src/gddccontrol/notebook.c:683
 msgid "Loading profiles..."
 msgstr "პროფილების ჩატვირთვა..."
 
-#: ../src/gddccontrol/notebook.c:677
+#: ../src/gddccontrol/notebook.c:696
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is "
 "using a generic profile for your monitor's manufacturer. Some controls may "
@@ -850,7 +851,7 @@ msgstr ""
 "იყენებს ზოგად პროფილს თქვენი ეკრანის მწარმოებლისთვის. შეიძლება, ზოგიერთი "
 "კონტროლის ელემენტი მხარდაჭერილი არ იყოს, ან არ იმუშაოს ისე, როგორც მოელით.\n"
 
-#: ../src/gddccontrol/notebook.c:683
+#: ../src/gddccontrol/notebook.c:702
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is "
 "using a basic generic profile. Many controls will not be supported, and some "
@@ -861,19 +862,20 @@ msgstr ""
 "ზოგიერთი კონტროლის ელემენტი მხარდაჭერილი არ იყოს, ან არ იმუშაოს ისე, როგორც "
 "მოელით.\n"
 
-#: ../src/gddccontrol/notebook.c:688
+#: ../src/gddccontrol/notebook.c:707
 msgid "Warning!"
 msgstr "გაფთხილება:!"
 
-#: ../src/gddccontrol/notebook.c:690
+#: ../src/gddccontrol/notebook.c:709
 msgid ""
-"Please update ddccontrol-db, or, if you are already using the latest "
-"version, please send the output of the following command to ddccontrol-"
-"users@lists.sourceforge.net:\n"
+"Unsupported monitor detected.\n"
+"\n"
+"Please update ddccontrol-db, or, if you are already using the latest\n"
+"version, please open a github issue:\n"
+"https://github.com/ddccontrol/ddccontrol-db/issues/new?template=unsupported-"
+"monitor.yml\n"
+"Then attach the resulting report file of the following command:\n"
 msgstr ""
-"განაახლეთ ddccontrol-db, ან, თუ უკვე იყენებთ უახლეს ვერსიას, გამოგვიგზავნეთ "
-"შემდეგი ბრძანების გამოტანილი ინფორმაცია ელფოსტაზე ddccontrol-"
-"users@lists.sourceforge.net:\n"
 
 #: ../src/lib/conf.c:63 ../src/lib/conf.c:260 ../src/lib/conf.c:310
 #: ../src/lib/ddcci.c:1306

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,37 +7,36 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: ddccontrol 0.4.3\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2006-08-29 19:01+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/ddccontrol/ddccontrol/issues/\n"
+"POT-Creation-Date: 2026-05-13 15:12+0200\n"
 "PO-Revision-Date: 2006-08-25 00:31+0200\n"
 "Last-Translator: Jakub Bogusz <qboosh@pld-linux.org>\n"
 "Language-Team: Polish <translation-team-pl@lists.sourceforge.net>\n"
+"Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=ISO-8859-2\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
 
-#: ../src/ddccontrol/main.c:83 ../src/ddccontrol/main.c:87
-#: ../src/ddccontrol/main.c:91
-msgid "Control"
-msgstr "Control"
-
-#: ../src/ddccontrol/main.c:132
-#, c-format
+#: ../src/ddccontrol/main.c:85
+#, fuzzy, c-format
 msgid ""
 "Usage:\n"
-"%s [-b datadir] [-v] [-c] [-d] [-f] [-s] [-r ctrl [-w value]] [-p | dev]\n"
+"%s [-b datadir] [-v] [-c] [-d] [-f] [-s] [-r ctrl [-w value]] [-l (profile "
+"path)] [-p | dev]\n"
 "\tdev: device, e.g. dev:/dev/i2c-0\n"
 "\t-p : probe I2C devices to find monitor buses\n"
 "\t-c : query capability\n"
 "\t-d : query ctrls 0 - 255\n"
 "\t-r : query ctrl\n"
 "\t-w : value to write to ctrl\n"
+"\t-W : relatively change ctrl value (+/-)\n"
 "\t-f : force (avoid validity checks)\n"
 "\t-s : save settings\n"
 "\t-v : verbosity (specify more to increase)\n"
 "\t-b : ddccontrol-db directory (if other than %s)\n"
+"\t-l : load values from XML profile file\n"
 msgstr ""
 "Opcje:\n"
 "%s [-b katalog_danych] [-v] [-c] [-d] [-f] [-s] [-r parametr [-w warto¶æ]] [-"
@@ -53,22 +52,22 @@ msgstr ""
 "\t-v : gadatliwy (wiêcj -v, bardziej gadatliwy)\n"
 "\t-b : katalog bazy monitorów ddccontrol-db (je¿eli inny ni¿ %s)\n"
 
-#: ../src/ddccontrol/main.c:150 ../src/ddccontrol/main.c:172
+#: ../src/ddccontrol/main.c:106 ../src/ddccontrol/main.c:128
 #, c-format
 msgid "Checking %s integrity...\n"
 msgstr "Sprawdznie integralno¶ci %s...\n"
 
-#: ../src/ddccontrol/main.c:152 ../src/ddccontrol/main.c:174
+#: ../src/ddccontrol/main.c:108 ../src/ddccontrol/main.c:130
 #, c-format
 msgid "[ FAILED ]\n"
 msgstr "[ B£¡D ]\n"
 
-#: ../src/ddccontrol/main.c:156 ../src/ddccontrol/main.c:179
+#: ../src/ddccontrol/main.c:112 ../src/ddccontrol/main.c:135
 #, c-format
 msgid "[ OK ]\n"
 msgstr "[ OK ]\n"
 
-#: ../src/ddccontrol/main.c:217
+#: ../src/ddccontrol/main.c:194
 #, c-format
 msgid ""
 "ddccontrol version %s\n"
@@ -87,73 +86,88 @@ msgstr ""
 "(General Public License).\n"
 "\n"
 
-#: ../src/ddccontrol/main.c:236
+#: ../src/ddccontrol/main.c:211
 #, c-format
 msgid "'%s' does not seem to be a valid register name\n"
 msgstr "'%s' nie jest zarejestrowan± nazw±\n"
 
-#: ../src/ddccontrol/main.c:242
+#: ../src/ddccontrol/main.c:217
 #, c-format
 msgid "You cannot use -w parameter without -r.\n"
 msgstr "Nie mo¿esz u¿yæ -w bez -r.\n"
 
-#: ../src/ddccontrol/main.c:247
+#: ../src/ddccontrol/main.c:221 ../src/ddccontrol/main.c:231
 #, c-format
 msgid "'%s' does not seem to be a valid value.\n"
 msgstr "%s' nie jest poprawn± warto¶ci±.\n"
 
-#: ../src/ddccontrol/main.c:292 ../src/gddccontrol/main.c:414
+#: ../src/ddccontrol/main.c:227
+#, fuzzy, c-format
+msgid "You cannot use -W parameter without -r.\n"
+msgstr "Nie mo¿esz u¿yæ -w bez -r.\n"
+
+#: ../src/ddccontrol/main.c:282 ../src/gddccontrol/main.c:432
 #, c-format
 msgid "Unable to initialize ddcci library.\n"
 msgstr "Biblioteka ddcci nie zosta³a zainicjalizowana.\n"
 
-#: ../src/ddccontrol/main.c:304
+#: ../src/ddccontrol/main.c:288
+#, fuzzy, c-format
+msgid "Unable to initialize ddcci db library.\n"
+msgstr "Biblioteka ddcci nie zosta³a zainicjalizowana.\n"
+
+#: ../src/ddccontrol/main.c:293
+#, c-format
+msgid "Failed to open D-Bus proxy, try with DDCCONTROL_NO_DAEMON=1.\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:310
 #, c-format
 msgid "Detected monitors :\n"
 msgstr "Wykryte monitory:\n"
 
-#: ../src/ddccontrol/main.c:309
+#: ../src/ddccontrol/main.c:314
 #, c-format
 msgid " - Device: %s\n"
 msgstr " - Urz±dzenie: %s\n"
 
-#: ../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 #, c-format
 msgid "   DDC/CI supported: %s\n"
 msgstr "   Obs³uguj±ce DDC/CI: %s\n"
 
-#: ../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 msgid "Yes"
 msgstr "Tak"
 
-#: ../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 msgid "No"
 msgstr "Nie"
 
-#: ../src/ddccontrol/main.c:311
+#: ../src/ddccontrol/main.c:316
 #, c-format
 msgid "   Monitor Name: %s\n"
 msgstr "   Nazwa monitora: %s\n"
 
-#: ../src/ddccontrol/main.c:312
+#: ../src/ddccontrol/main.c:317
 #, c-format
 msgid "   Input type: %s\n"
 msgstr "   Typ wej¶cia: %s\n"
 
-#: ../src/ddccontrol/main.c:312 ../src/ddccontrol/main.c:350
+#: ../src/ddccontrol/main.c:317 ../src/ddccontrol/main.c:364
 msgid "Digital"
 msgstr "Cyfrowe"
 
-#: ../src/ddccontrol/main.c:312 ../src/ddccontrol/main.c:350
+#: ../src/ddccontrol/main.c:317 ../src/ddccontrol/main.c:364
 msgid "Analog"
 msgstr "Analogowe"
 
-#: ../src/ddccontrol/main.c:316
+#: ../src/ddccontrol/main.c:321
 #, c-format
 msgid "  (Automatically selected)\n"
 msgstr "  (Zaznaczony automatycznie)\n"
 
-#: ../src/ddccontrol/main.c:326
+#: ../src/ddccontrol/main.c:333
 #, c-format
 msgid ""
 "No monitor supporting DDC/CI available.\n"
@@ -164,12 +178,12 @@ msgstr ""
 "Karta graficzna mo¿e wymagaæ dodatkowych modu³ów kernela (i2c-dev i "
 "framebuffer)\n"
 
-#: ../src/ddccontrol/main.c:339
+#: ../src/ddccontrol/main.c:346
 #, c-format
 msgid "Reading EDID and initializing DDC/CI at bus %s...\n"
 msgstr "Czyta EDID i inicjalizuje DDC/CI na magistrali %s...\n"
 
-#: ../src/ddccontrol/main.c:343
+#: ../src/ddccontrol/main.c:357
 #, c-format
 msgid ""
 "\n"
@@ -182,7 +196,7 @@ msgstr ""
 "Karta graficzna mo¿e wymagaæ dodatkowych modu³ów kernela (i2c-dev i "
 "framebuffer).\n"
 
-#: ../src/ddccontrol/main.c:347
+#: ../src/ddccontrol/main.c:361
 #, c-format
 msgid ""
 "\n"
@@ -191,23 +205,157 @@ msgstr ""
 "\n"
 "EDID zaczyta³:\n"
 
-#: ../src/ddccontrol/main.c:348
+#: ../src/ddccontrol/main.c:362
 #, c-format
 msgid "\tPlug and Play ID: %s [%s]\n"
 msgstr "\tPlug and Play ID: %s [%s]\n"
 
-#: ../src/ddccontrol/main.c:350
+#: ../src/ddccontrol/main.c:364
 #, c-format
 msgid "\tInput type: %s\n"
 msgstr "\tType wej¶cia: %s\n"
 
+#: ../src/ddccontrol/main.c:370
+#, c-format
+msgid ""
+"\n"
+"Capabilities:\n"
+msgstr ""
+"\n"
+"Mo¿liwo¶ci:\n"
+
+#: ../src/ddccontrol/main.c:374
+#, c-format
+msgid "Raw output: %s\n"
+msgstr "Wyj¶cie czyste: %s\n"
+
+#: ../src/ddccontrol/main.c:376
+#, c-format
+msgid "Parsed output: \n"
+msgstr "Wyj¶cie przetworzone: \n"
+
+#: ../src/ddccontrol/main.c:385
+#, c-format
+msgid "\tType: "
+msgstr "\tRodzaj: "
+
+#: ../src/ddccontrol/main.c:388
+#, c-format
+msgid "LCD"
+msgstr "LCD"
+
+#: ../src/ddccontrol/main.c:391
+#, c-format
+msgid "CRT"
+msgstr "CRT"
+
+#: ../src/ddccontrol/main.c:394
+#, c-format
+msgid "Unknown"
+msgstr "Nieznany"
+
+#: ../src/ddccontrol/main.c:403
+#, c-format
+msgid "Capabilities read fail.\n"
+msgstr "Odczyt mo¿liwo¶ci nie powiód³ siê.\n"
+
+#: ../src/ddccontrol/main.c:417
+#, c-format
+msgid "Value cannot be lower than zero! %d -> %d\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:420
+#, c-format
+msgid "Value cannot be higher than maximum! %d / %d\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:428
+#, c-format
+msgid ""
+"\n"
+"Writing 0x%02x, 0x%02x(%d) (%dms delay)...\n"
+msgstr ""
+"\n"
+"Zapis: 0x%02x, 0x%02x(%d) (opó¼nienie %dms)...\n"
+
+#: ../src/ddccontrol/main.c:431
+#, c-format
+msgid ""
+"\n"
+"Writing 0x%02x, 0x%02x(%d)...\n"
+msgstr ""
+"\n"
+"Zapis: 0x%02x, 0x%02x(%d)...\n"
+
+#: ../src/ddccontrol/main.c:436
+#, c-format
+msgid ""
+"\n"
+"Reading 0x%02x...\n"
+msgstr ""
+"\n"
+"Odczyt 0x%02x...\n"
+
+#: ../src/ddccontrol/main.c:445
+#, fuzzy, c-format
+msgid "Applied profile: %s\n"
+msgstr "Zastosuj profil"
+
+#: ../src/ddccontrol/main.c:447
+#, c-format
+msgid "Failed to apply profile: %s\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:451
+#, c-format
+msgid ""
+"\n"
+"Controls (valid/current/max) [Description - Value name]:\n"
+msgstr ""
+"\n"
+"Parametry (poprawny/aktualny/maksymalny) [Opis - nazwa warto¶ci]:\n"
+
+#: ../src/ddccontrol/main.c:473
+#, c-format
+msgid "\t\t> id=%s, name=%s, address=%#x, delay=%dms, type=%d\n"
+msgstr "\t\t> id=%s, nazwa=%s, adres=%#x, opó¼nienie=%dms, typ=%d\n"
+
+#: ../src/ddccontrol/main.c:478
+#, c-format
+msgid "\t\t  Possible values:\n"
+msgstr "\t\t  Mo¿liwe warto¶ci:\n"
+
+#: ../src/ddccontrol/main.c:482
+#, c-format
+msgid "\t\t\t> id=%s - name=%s, value=%d\n"
+msgstr "\t\t\t> id=%s - nazwa=%s, warto¶æ=%d\n"
+
+#: ../src/ddccontrol/main.c:492
+#, c-format
+msgid "\t\t  supported, value=%d, maximum=%d\n"
+msgstr "\t\t  suportowane, warto¶æ=%d, maksimum=%d\n"
+
+#: ../src/ddccontrol/main.c:493
+#, c-format
+msgid "\t\t  not supported, value=%d, maximum=%d\n"
+msgstr "\t\t  not supported, value=%d, maximum=%d\n"
+
+#: ../src/ddccontrol/main.c:504
+#, c-format
+msgid ""
+"\n"
+"Saving settings...\n"
+msgstr ""
+"\n"
+"Zapisywanie ustawieñ...\n"
+
 #. Put a big warning (in red if we are writing to a terminal).
-#: ../src/ddccontrol/main.c:354 ../src/ddccontrol/main.c:373
+#: ../src/ddccontrol/main.c:516 ../src/ddccontrol/main.c:537
 msgid "=============================== WARNING ==============================="
 msgstr ""
 "================================ UWAGA ================================"
 
-#: ../src/ddccontrol/main.c:357
+#: ../src/ddccontrol/main.c:519
 #, c-format
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is\n"
@@ -218,7 +366,7 @@ msgstr ""
 "profilu dla tego producenta monitorów. Niektóre parametry mog± nie byæ\n"
 "obs³ugiwane, lub mog± dzia³aæ inaczej ni¿ powinny.\n"
 
-#: ../src/ddccontrol/main.c:363
+#: ../src/ddccontrol/main.c:524
 #, c-format
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is\n"
@@ -229,135 +377,24 @@ msgstr ""
 "profilu. Wiele parametrów mo¿e nie byæ obs³ugiwanych, a niektóre mog±\n"
 "dzia³aæ inaczej ni¿ powinny.\n"
 
-#: ../src/ddccontrol/main.c:368
+#: ../src/ddccontrol/main.c:529
 #, c-format
 msgid ""
+"Unsupported monitor detected.\n"
+"\n"
 "Please update ddccontrol-db, or, if you are already using the latest\n"
-"version, please send the output of the following command to\n"
-"ddccontrol-users@lists.sourceforge.net:\n"
+"version, please open this pre-filled GitHub issue:\n"
 msgstr ""
-"Proszê uaktualniæ ddccontrol-db lub, je¶li to ju¿ jest najnowsza wersja,\n"
-"proszê wys³aæ wyj¶cie nastêpuj±cego polecenia na adres\n"
-"ddccontrol-users@lists.sourceforge.net:\n"
 
-#: ../src/ddccontrol/main.c:372 ../src/gddccontrol/notebook.c:695
+#: ../src/ddccontrol/main.c:534
+#, c-format
+msgid "Then attach the resulting report file of the following command:\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:536 ../src/gddccontrol/notebook.c:715
 #, c-format
 msgid "Thank you.\n"
 msgstr "Dziêkujê.\n"
-
-#: ../src/ddccontrol/main.c:377
-#, c-format
-msgid ""
-"\n"
-"Capabilities:\n"
-msgstr ""
-"\n"
-"Mo¿liwo¶ci:\n"
-
-#: ../src/ddccontrol/main.c:381
-#, c-format
-msgid "Raw output: %s\n"
-msgstr "Wyj¶cie czyste: %s\n"
-
-#: ../src/ddccontrol/main.c:383
-#, c-format
-msgid "Parsed output: \n"
-msgstr "Wyj¶cie przetworzone: \n"
-
-#: ../src/ddccontrol/main.c:392
-#, c-format
-msgid "\tType: "
-msgstr "\tRodzaj: "
-
-#: ../src/ddccontrol/main.c:395
-#, c-format
-msgid "LCD"
-msgstr "LCD"
-
-#: ../src/ddccontrol/main.c:398
-#, c-format
-msgid "CRT"
-msgstr "CRT"
-
-#: ../src/ddccontrol/main.c:401
-#, c-format
-msgid "Unknown"
-msgstr "Nieznany"
-
-#: ../src/ddccontrol/main.c:410
-#, c-format
-msgid "Capabilities read fail.\n"
-msgstr "Odczyt mo¿liwo¶ci nie powiód³ siê.\n"
-
-#: ../src/ddccontrol/main.c:418
-#, c-format
-msgid ""
-"\n"
-"Writing 0x%02x, 0x%02x(%d) (%dms delay)...\n"
-msgstr ""
-"\n"
-"Zapis: 0x%02x, 0x%02x(%d) (opó¼nienie %dms)...\n"
-
-#: ../src/ddccontrol/main.c:422
-#, c-format
-msgid ""
-"\n"
-"Writing 0x%02x, 0x%02x(%d)...\n"
-msgstr ""
-"\n"
-"Zapis: 0x%02x, 0x%02x(%d)...\n"
-
-#: ../src/ddccontrol/main.c:427
-#, c-format
-msgid ""
-"\n"
-"Reading 0x%02x...\n"
-msgstr ""
-"\n"
-"Odczyt 0x%02x...\n"
-
-#: ../src/ddccontrol/main.c:434
-#, c-format
-msgid ""
-"\n"
-"Controls (valid/current/max) [Description - Value name]:\n"
-msgstr ""
-"\n"
-"Parametry (poprawny/aktualny/maksymalny) [Opis - nazwa warto¶ci]:\n"
-
-#: ../src/ddccontrol/main.c:458
-#, c-format
-msgid "\t\t> id=%s, name=%s, address=%#x, delay=%dms, type=%d\n"
-msgstr "\t\t> id=%s, nazwa=%s, adres=%#x, opó¼nienie=%dms, typ=%d\n"
-
-#: ../src/ddccontrol/main.c:463
-#, c-format
-msgid "\t\t  Possible values:\n"
-msgstr "\t\t  Mo¿liwe warto¶ci:\n"
-
-#: ../src/ddccontrol/main.c:467
-#, c-format
-msgid "\t\t\t> id=%s - name=%s, value=%d\n"
-msgstr "\t\t\t> id=%s - nazwa=%s, warto¶æ=%d\n"
-
-#: ../src/ddccontrol/main.c:477
-#, c-format
-msgid "\t\t  supported, value=%d, maximum=%d\n"
-msgstr "\t\t  suportowane, warto¶æ=%d, maksimum=%d\n"
-
-#: ../src/ddccontrol/main.c:478
-#, c-format
-msgid "\t\t  not supported, value=%d, maximum=%d\n"
-msgstr "\t\t  not supported, value=%d, maximum=%d\n"
-
-#: ../src/ddccontrol/main.c:489
-#, c-format
-msgid ""
-"\n"
-"Saving settings...\n"
-msgstr ""
-"\n"
-"Zapisywanie ustawieñ...\n"
 
 #. arbitration or no acknowledge
 #: ../src/ddcpci/i2c-algo-bit.c:368
@@ -376,8 +413,9 @@ msgstr "i2c-algo-bit.o: readbytes: i2c_inb przekroczy³o limit czasu.\n"
 msgid "i2c-algo-bit.o: readbytes: Timeout at ack\n"
 msgstr "i2c-algo-bit.o: readbytes: Przekroczony limit czasu przy ack\n"
 
-#: ../src/ddcpci/intel740.c:103 ../src/ddcpci/intel810.c:161
+#: ../src/ddcpci/intel740.c:103 ../src/ddcpci/intel810.c:162
 #: ../src/ddcpci/nvidia.c:155 ../src/ddcpci/radeon.c:209
+#: ../src/ddcpci/sis.c:174 ../src/ddcpci/via.c:167
 #, c-format
 msgid "%s: Malloc error.\n"
 msgstr "%s: B³±d malloca.\n"
@@ -397,62 +435,62 @@ msgstr "%s: B³±d: nieznany typ karty (%#x)\n"
 msgid "%s: Malloc error."
 msgstr "%s: B³±d malloca."
 
-#: ../src/ddcpci/intel810.c:171
+#: ../src/ddcpci/intel810.c:172
 msgid "i810_open: cannot open /dev/mem"
 msgstr "i810_open: nie mo¿na otworzyæ /dev/mem"
 
-#: ../src/ddcpci/intel810.c:206
+#: ../src/ddcpci/intel810.c:207
 #, c-format
 msgid "i810_open: Error: cannot find any valid MMIO PCI region.\n"
 msgstr ""
 "i810_open: B³±d: nie mo¿na odnale¼æ ¿adnego poprawnego regionu PCI MMIO.\n"
 
-#: ../src/ddcpci/intel810.c:213
+#: ../src/ddcpci/intel810.c:214
 msgid "i810_open: mmap failed"
 msgstr "i810_open: mmap nie powiod³o siê"
 
-#: ../src/ddcpci/main.c:154
+#: ../src/ddcpci/main.c:160
 msgid "==>Error while sending open message"
 msgstr "==>B³±d podczas wysy³ania open message"
 
-#: ../src/ddcpci/main.c:178 ../src/ddcpci/main.c:184 ../src/ddcpci/main.c:202
+#: ../src/ddcpci/main.c:184 ../src/ddcpci/main.c:190 ../src/ddcpci/main.c:208
 msgid "==>Error while sending data answer message"
 msgstr "==>B³±d podczas wysy³ania data answer message"
 
-#: ../src/ddcpci/main.c:251 ../src/ddcpci/main.c:266
+#: ../src/ddcpci/main.c:257 ../src/ddcpci/main.c:272
 msgid "==>Error while sending list message"
 msgstr "==>B³±d podczas wysy³ania list message"
 
-#: ../src/ddcpci/main.c:284
+#: ../src/ddcpci/main.c:290
 #, c-format
 msgid "Invalid arguments.\n"
 msgstr "B³êdne argumenty.\n"
 
-#: ../src/ddcpci/main.c:290
+#: ../src/ddcpci/main.c:296
 #, c-format
 msgid "==>Can't read verbosity.\n"
 msgstr "==>Nie mo¿na odczytaæ gadatliwo¶ci.\n"
 
-#: ../src/ddcpci/main.c:297
+#: ../src/ddcpci/main.c:303
 #, c-format
 msgid "==>Can't read key.\n"
 msgstr "==>Nie mo¿na odczytaæ klucza.\n"
 
-#: ../src/ddcpci/main.c:302
+#: ../src/ddcpci/main.c:308
 #, c-format
 msgid "==>Can't open key %u\n"
 msgstr "==>Nie mo¿na otworzyæ klucza %u\n"
 
-#: ../src/ddcpci/main.c:316
+#: ../src/ddcpci/main.c:322
 #, c-format
 msgid "==>No command received for %ld seconds, aborting.\n"
 msgstr "==>Nie otrzymano polecenia przez %ld sekund, przerwano.\n"
 
-#: ../src/ddcpci/main.c:324
+#: ../src/ddcpci/main.c:330
 msgid "==>Error while receiving query\n"
 msgstr "==>B³±d podczas odbierania zapytania\n"
 
-#: ../src/ddcpci/main.c:359
+#: ../src/ddcpci/main.c:365
 #, c-format
 msgid "==>Invalid query...\n"
 msgstr "==>B³êdne zapytanie...\n"
@@ -483,7 +521,27 @@ msgstr "radeon_open: nie mo¿na otworzyæ /dev/mem"
 msgid "radeon_open: mmap failed"
 msgstr "radeon_open: mmap nie powiod³o siê"
 
-#: ../src/gddccontrol/fspatterns.c:195
+#: ../src/ddcpci/sis.c:133
+#, fuzzy, c-format
+msgid "sis.c:init_i2c_bus: Malloc error."
+msgstr "nvidia.c:init_i2c_bus: B³±d malloca."
+
+#: ../src/ddcpci/via.c:125
+#, fuzzy, c-format
+msgid "via.c:init_i2c_bus: Malloc error."
+msgstr "nvidia.c:init_i2c_bus: B³±d malloca."
+
+#: ../src/ddcpci/via.c:177
+#, fuzzy
+msgid "via_open: cannot open /dev/mem"
+msgstr "nvidia_open: nie mo¿na otworzyæ /dev/mem"
+
+#: ../src/ddcpci/via.c:186
+#, fuzzy
+msgid "via_open: mmap failed"
+msgstr "nvidia_open: mmap nie powiod³o siê"
+
+#: ../src/gddccontrol/fspatterns.c:137
 msgid ""
 "Adjust brightness and contrast following these rules:\n"
 " - Black must be as dark as possible.\n"
@@ -496,11 +554,11 @@ msgstr ""
 " - Musisz byæ w stanie rozró¿niæ ka¿dy stopieñ szaro¶ci (szczególnie 0 i "
 "12).\n"
 
-#: ../src/gddccontrol/fspatterns.c:211
+#: ../src/gddccontrol/fspatterns.c:259
 msgid "Try to make moire patterns disappear."
 msgstr "Spróbuj doprowadziæ do znikniêcia wzorów mory."
 
-#: ../src/gddccontrol/fspatterns.c:215
+#: ../src/gddccontrol/fspatterns.c:263
 msgid ""
 "Adjust Image Lock Coarse to make the vertical band disappear.\n"
 "Adjust Image Lock Fine to minimize movement on the screen."
@@ -508,34 +566,50 @@ msgstr ""
 "Wyreguluj zgrubn± blokadê obrazu, aby pionowy pasek znikn±³.\n"
 "Wyreguluj dok³adn± blokadê obrazu, aby zminimalizowaæ ruch na ekranie."
 
-#: ../src/gddccontrol/fspatterns.c:254
+#: ../src/gddccontrol/fspatterns.c:273
 #, c-format
 msgid "Unknown fullscreen pattern name: %s"
 msgstr "Nieznana nazwa wzoru ca³oekranowego: %s"
 
-#: ../src/gddccontrol/gprofile.c:53
+#: ../src/gddccontrol/gddccontrol.desktop.in.h:1
+#, fuzzy
+msgid "DDC Control"
+msgstr "Control"
+
+#: ../src/gddccontrol/gddccontrol.desktop.in.h:2
+#, fuzzy
+msgid "Monitor Settings"
+msgstr "Ustawienia monitora"
+
+#: ../src/gddccontrol/gddccontrol.desktop.in.h:3
+msgid ""
+"Set your monitor preferences (contrast, brightness,...) and manage your "
+"profiles"
+msgstr ""
+
+#: ../src/gddccontrol/gprofile.c:54
 msgid "You must select at least one control to be saved in the profile."
 msgstr ""
 "Zaznacz przynajmniej jeden parametr, który zostanie zapisany w profilu."
 
-#: ../src/gddccontrol/gprofile.c:61
+#: ../src/gddccontrol/gprofile.c:62
 msgid "Creating profile..."
 msgstr "Tworzenie profilu..."
 
-#: ../src/gddccontrol/gprofile.c:76
+#: ../src/gddccontrol/gprofile.c:77
 msgid "Error while creating profile."
 msgstr "B³±d podczas tworzenia profilu."
 
-#: ../src/gddccontrol/gprofile.c:93
+#: ../src/gddccontrol/gprofile.c:94
 msgid "Applying profile..."
 msgstr "Zastosowanie profilu..."
 
-#: ../src/gddccontrol/gprofile.c:116
+#: ../src/gddccontrol/gprofile.c:117
 #, c-format
 msgid "Are you sure you want to delete the profile '%s'?"
 msgstr "Czy skasowaæ profil '%s'?"
 
-#: ../src/gddccontrol/gprofile.c:142
+#: ../src/gddccontrol/gprofile.c:143
 msgid ""
 "Please select the controls you want to save in the profile using the "
 "checkboxes to the left of each control."
@@ -543,78 +617,78 @@ msgstr ""
 "Proszê wybraæ parametry do zapisu w profilu przy u¿yciu kontrolek z lewej "
 "strony ka¿dego parametru."
 
-#: ../src/gddccontrol/gprofile.c:174
+#: ../src/gddccontrol/gprofile.c:175
 msgid "Profile Manager"
 msgstr "Zarz±dzanie profilami"
 
-#: ../src/gddccontrol/gprofile.c:193
+#: ../src/gddccontrol/gprofile.c:199
 msgid "Apply profile"
 msgstr "Zastosuj profil"
 
-#: ../src/gddccontrol/gprofile.c:198
+#: ../src/gddccontrol/gprofile.c:208
 msgid "Show profile details / Rename profile"
 msgstr "Poka¿ szczegó³y profilu/Zmieñ profile"
 
-#: ../src/gddccontrol/gprofile.c:203
+#: ../src/gddccontrol/gprofile.c:217
 msgid "Delete profile"
 msgstr "Usuñ profil"
 
-#: ../src/gddccontrol/gprofile.c:229
+#: ../src/gddccontrol/gprofile.c:253
 msgid "Create profile"
 msgstr "Stwórz profil"
 
-#: ../src/gddccontrol/gprofile.c:235
+#: ../src/gddccontrol/gprofile.c:259
 msgid "Close profile manager"
 msgstr "Zamknij menad¿er profilu"
 
-#: ../src/gddccontrol/gprofile.c:299
+#: ../src/gddccontrol/gprofile.c:321
 msgid "Control name"
 msgstr "Nazwa parametru"
 
-#: ../src/gddccontrol/gprofile.c:310
+#: ../src/gddccontrol/gprofile.c:332
 msgid "Value"
 msgstr "Warto¶æ"
 
-#: ../src/gddccontrol/gprofile.c:313
+#: ../src/gddccontrol/gprofile.c:335
 msgid "Address"
 msgstr "Adres"
 
-#: ../src/gddccontrol/gprofile.c:316
+#: ../src/gddccontrol/gprofile.c:338
 msgid "Raw value"
 msgstr "Warto¶æ nieprzetworzona"
 
-#: ../src/gddccontrol/gprofile.c:434 ../src/gddccontrol/gprofile.c:454
+#: ../src/gddccontrol/gprofile.c:456 ../src/gddccontrol/gprofile.c:476
 msgid "Profile information:"
 msgstr "Informacje o profilu"
 
-#: ../src/gddccontrol/gprofile.c:463
+#: ../src/gddccontrol/gprofile.c:485
 #, c-format
 msgid "File name: %s"
 msgstr "Nazwa pliku: %s"
 
-#: ../src/gddccontrol/gprofile.c:474
+#: ../src/gddccontrol/gprofile.c:496
 msgid "Profile name:"
 msgstr "&Nazwa profilu:"
 
 #. Save
-#: ../src/gddccontrol/gprofile.c:496
+#: ../src/gddccontrol/gprofile.c:518
 msgid "Saving profile..."
 msgstr "Zapisz profil..."
 
-#: ../src/gddccontrol/gprofile.c:505
+#: ../src/gddccontrol/gprofile.c:527
 msgid "Error while saving profile."
 msgstr "B³±d podczas zapisywania profilu."
 
-#: ../src/gddccontrol/main.c:177
+#: ../src/gddccontrol/main.c:204
 #, c-format
 msgid "Monitor changed (%d %d).\n"
 msgstr "Monitor zmieni³ (%d %d).\n"
 
-#: ../src/gddccontrol/main.c:329
+#: ../src/gddccontrol/main.c:356
 msgid "Probing for available monitors..."
 msgstr "Skanowanie w poszukiwaniu monitorów..."
 
-#: ../src/gddccontrol/main.c:368
+#: ../src/gddccontrol/main.c:385
 msgid ""
 "No monitor supporting DDC/CI available.\n"
 "\n"
@@ -626,49 +700,49 @@ msgstr ""
 "Karta graficzna mo¿e wymagaæ dodatkowych modu³ów kernela (i2c-dev, i "
 "framebuffer)."
 
-#: ../src/gddccontrol/main.c:420
+#: ../src/gddccontrol/main.c:438
 msgid "Unable to initialize ddcci library, see console for more details.\n"
 msgstr ""
 "Brak mo¿liwo¶ci incjalizacji biblioteki ddcci, sprawd¼ komunikaty na "
 "konsoli.\n"
 
-#: ../src/gddccontrol/main.c:430
+#: ../src/gddccontrol/main.c:450
 msgid "Monitor settings"
 msgstr "Ustawienia monitora"
 
-#: ../src/gddccontrol/main.c:454
+#: ../src/gddccontrol/main.c:474
 msgid "Current monitor: "
 msgstr "Bie¿±cy monitor: "
 
-#: ../src/gddccontrol/main.c:464
+#: ../src/gddccontrol/main.c:484
 msgid "Refresh monitor list"
 msgstr "&Od¶wie¿ listê monitorów"
 
-#: ../src/gddccontrol/main.c:481
+#: ../src/gddccontrol/main.c:507
 msgid "Profile manager"
 msgstr "Zarz±dzanie profilami"
 
-#: ../src/gddccontrol/main.c:488
+#: ../src/gddccontrol/main.c:514
 msgid "Save profile"
 msgstr "Zapisz profil"
 
-#: ../src/gddccontrol/main.c:494
+#: ../src/gddccontrol/main.c:520
 msgid "Cancel profile creation"
 msgstr "Odwo³aj tworzenie profilu"
 
-#: ../src/gddccontrol/main.c:518
+#: ../src/gddccontrol/main.c:549
 msgid "OK"
 msgstr "OK"
 
-#: ../src/gddccontrol/main.c:546
+#: ../src/gddccontrol/main.c:585
 msgid "Refresh"
 msgstr "Od¶wie¿"
 
-#: ../src/gddccontrol/main.c:546
+#: ../src/gddccontrol/main.c:585
 msgid "Refresh all controls"
 msgstr "&Od¶wie¿ wszystkie parametry"
 
-#: ../src/gddccontrol/main.c:553
+#: ../src/gddccontrol/main.c:592
 msgid "Close"
 msgstr "Zamknij"
 
@@ -676,33 +750,33 @@ msgstr "Zamknij"
 #. gtk_misc_set_alignment(GTK_MISC(moninfo), 0, 0);
 #.
 #. gtk_table_attach(GTK_TABLE(table), moninfo, 0, 1, 1, 2, GTK_FILL_EXPAND, 0, 5, 5);
-#: ../src/gddccontrol/main.c:592
+#: ../src/gddccontrol/main.c:634
 #, c-format
 msgid "Welcome to gddccontrol %s."
 msgstr "Witaj w gddccontrol %s."
 
-#: ../src/gddccontrol/notebook.c:81
+#: ../src/gddccontrol/notebook.c:83
 msgid "Error while getting value"
 msgstr "B³±d przy pobieraniu warto¶ci"
 
-#: ../src/gddccontrol/notebook.c:116 ../src/gddccontrol/notebook.c:128
+#: ../src/gddccontrol/notebook.c:118 ../src/gddccontrol/notebook.c:130
 #, c-format
 msgid "Refreshing controls values (%d%%)..."
 msgstr "Od¶wie¿ wielko¶ci paramaetrów  (%d%%)..."
 
-#: ../src/gddccontrol/notebook.c:133
+#: ../src/gddccontrol/notebook.c:135
 msgid "Could not get the control_db struct related to a control."
 msgstr "Nie mo¿na znale¼æ struktury control_db odpowiadaj±cej parametrówi."
 
-#: ../src/gddccontrol/notebook.c:493
+#: ../src/gddccontrol/notebook.c:495
 msgid "Show fullscreen patterns"
 msgstr "Poka¿ wzory ca³oekranowe"
 
-#: ../src/gddccontrol/notebook.c:525
+#: ../src/gddccontrol/notebook.c:527
 msgid "Section"
 msgstr "Sekcja"
 
-#: ../src/gddccontrol/notebook.c:572
+#: ../src/gddccontrol/notebook.c:574
 msgid ""
 "The current monitor is in the database but does not support DDC/CI.\n"
 "\n"
@@ -720,7 +794,7 @@ msgstr ""
 "Je¶li monitor ma dwa wej¶cia, proszê spróbowaæ pod³±czyæ kabel do innego "
 "wej¶cia i klikn±æ na przycisku od¶wie¿enia blisko listy monitorów."
 
-#: ../src/gddccontrol/notebook.c:583
+#: ../src/gddccontrol/notebook.c:585
 #, c-format
 msgid "Opening the monitor device (%s)..."
 msgstr "Otwarcie urz±dzenia monitora (%s)..."
@@ -738,30 +812,29 @@ msgstr ""
 #: ../src/gddccontrol/notebook.c:600
 #, c-format
 msgid ""
-"The current monitor is not supported, please run\n"
-"%s\n"
-"and send the output to ddccontrol-users@lists.sourceforge.net.\n"
-"Thanks."
+"Unsupported monitor detected.\n"
+"\n"
+"Please update ddccontrol-db, or, if you are already using the latest\n"
+"version, please open a github issue:\n"
+"https://github.com/ddccontrol/ddccontrol-db/issues/new?template=unsupported-"
+"monitor.yml\n"
+"Then attach the resulting report file of the following command:"
 msgstr ""
-"Aktualny monitor nie jest obs³ugiwany, proszê uruchomiæ\n"
-"%s\n"
-"i wys³aæ wyj¶cie na ddccontrol-users@lists.sourceforge.net.\n"
-"Dziêkujê."
 
-#: ../src/gddccontrol/notebook.c:620
+#: ../src/gddccontrol/notebook.c:622
 msgid "Please click on a group name."
 msgstr "Wybierz nazwê grupy."
 
-#: ../src/gddccontrol/notebook.c:639 ../src/gddccontrol/notebook.c:650
+#: ../src/gddccontrol/notebook.c:647 ../src/gddccontrol/notebook.c:658
 #, c-format
 msgid "Getting controls values (%d%%)..."
 msgstr "Pobieranie warto¶ci parametrów (%d%%)..."
 
-#: ../src/gddccontrol/notebook.c:664
+#: ../src/gddccontrol/notebook.c:683
 msgid "Loading profiles..."
 msgstr "£adownie profili..."
 
-#: ../src/gddccontrol/notebook.c:677
+#: ../src/gddccontrol/notebook.c:696
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is "
 "using a generic profile for your monitor's manufacturer. Some controls may "
@@ -771,7 +844,7 @@ msgstr ""
 "profilu dla tego producenta monitorów. Niektóre parametry mog± nie byæ "
 "obs³ugiwane, lub mog± dzia³aæ inaczej ni¿ powinny.\n"
 
-#: ../src/gddccontrol/notebook.c:683
+#: ../src/gddccontrol/notebook.c:702
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is "
 "using a basic generic profile. Many controls will not be supported, and some "
@@ -781,361 +854,315 @@ msgstr ""
 "profilu. Wiele parametrów mo¿e nie byæ obs³ugiwanych, a niektóre mog± "
 "dzia³aæ inaczej ni¿ powinny.\n"
 
-#: ../src/gddccontrol/notebook.c:688
+#: ../src/gddccontrol/notebook.c:707
 msgid "Warning!"
 msgstr "Uwaga!"
 
-#: ../src/gddccontrol/notebook.c:690
+#: ../src/gddccontrol/notebook.c:709
 msgid ""
-"Please update ddccontrol-db, or, if you are already using the latest "
-"version, please send the output of the following command to ddccontrol-"
-"users@lists.sourceforge.net:\n"
+"Unsupported monitor detected.\n"
+"\n"
+"Please update ddccontrol-db, or, if you are already using the latest\n"
+"version, please open a github issue:\n"
+"https://github.com/ddccontrol/ddccontrol-db/issues/new?template=unsupported-"
+"monitor.yml\n"
+"Then attach the resulting report file of the following command:\n"
 msgstr ""
-"Proszê uaktualniæ ddccontrol-db lub, je¶li to ju¿ jest najnowsza wersja, "
-"proszê wys³aæ wyj¶cie nastêpuj±cego polecenia na adres ddccontrol-"
-"users@lists.sourceforge.net:\n"
 
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.server.in.in.h:1
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:184
-msgid "Monitor Profile Switcher"
-msgstr "Prze³±cznik profili monitora"
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.server.in.in.h:2
-msgid "Quickly switch monitor profiles created with gddccontrol"
-msgstr ""
-"Szybkie prze³±czanie profili monitora utworzonych przy u¿yciu gddccontrol"
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.xml.h:1
-msgid "_About..."
-msgstr "_O..."
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.xml.h:2
-msgid "_Properties..."
-msgstr "_W³a¶ciwo¶ci..."
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.xml.h:3
-msgid "_Run gddccontrol..."
-msgstr "_Uruchomienie gddccontrol..."
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:189
-msgid ""
-"An applet for quick switching of monitor profiles.\n"
-"Based on libddccontrol and part of the ddccontrol project.\n"
-"(http://ddccontrol.sourceforge.net)"
-msgstr ""
-"Aplet do szybkiego prze³±czania profili monitora.\n"
-"Oparty na libddccontrol i bêd±cy czê¶ci± projektu ddccontrol.\n"
-"(http://ddccontrol.sourceforge.net)"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:386
-msgid "Unable to initialize ddcci library"
-msgstr "Biblioteka ddcci nie zosta³a zainicjalizowana"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:390
-msgid "No monitor configuration found. Please run gddccontrol first"
-msgstr ""
-"Nie znaleziono konfiguracji monitora. Proszê najpierw uruchomiæ gddccontrol"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:395
-msgid "An error occurred while opening the monitor device"
-msgstr "Wyst±pi³ b³±d podczas otwierania urz±dzenia monitora"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:400
-msgid "Can't find any profiles"
-msgstr "Nie znaleziono ¿adnego profilu"
-
-#. only reached, if init was not finished
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:416
-msgid "error"
-msgstr "b³±d"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:440
-msgid "Monitor:"
-msgstr "Monitor:"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:443
-msgid "Monitor Profile Switcher Properties"
-msgstr "W³a¶ciwo¶ci prze³±czania profili monitora"
-
-#: ../src/lib/conf.c:61 ../src/lib/conf.c:258 ../src/lib/conf.c:308
-#: ../src/lib/ddcci.c:1202
+#: ../src/lib/conf.c:63 ../src/lib/conf.c:260 ../src/lib/conf.c:310
+#: ../src/lib/ddcci.c:1306
 msgid "Cannot create filename (buffer too small)\n"
 msgstr "Nie mo¿na utworzyæ nazwy pliku (bufor zbyt ma³y)\n"
 
-#: ../src/lib/conf.c:86 ../src/lib/conf.c:363 ../src/lib/monitor_db.c:350
-#: ../src/lib/monitor_db.c:714
+#: ../src/lib/conf.c:88 ../src/lib/conf.c:367 ../src/lib/monitor_db.c:353
+#: ../src/lib/monitor_db.c:726
 #, c-format
 msgid "Document not parsed successfully.\n"
 msgstr "Dokument nie zosta³ poprawnie przetworzony.\n"
 
-#: ../src/lib/conf.c:93 ../src/lib/conf.c:370
+#: ../src/lib/conf.c:95 ../src/lib/conf.c:375
 #, c-format
 msgid "empty profile file\n"
 msgstr "pusty plik profilu\n"
 
-#: ../src/lib/conf.c:99 ../src/lib/conf.c:376
+#: ../src/lib/conf.c:101 ../src/lib/conf.c:382
 #, c-format
 msgid "profile of the wrong type, root node %s != profile"
 msgstr "profil z³ego rodzaju, g³ówny wêze³ %s != profile"
 
-#: ../src/lib/conf.c:105
+#: ../src/lib/conf.c:107
 msgid "Can't find ddccontrolversion property."
 msgstr "Nie znaleziono w³a¶ciwo¶ci ddccontrolversion."
 
-#: ../src/lib/conf.c:107
+#: ../src/lib/conf.c:109
 #, c-format
 msgid "ddccontrol has been upgraded since monitorlist was saved (%s vs %s).\n"
 msgstr ""
 "ddccontrol zosta³ uaktualniony od zapisania listy monitorów (%s vs %s).\n"
 
-#: ../src/lib/conf.c:124
+#: ../src/lib/conf.c:126
 msgid "Can't find filename property."
 msgstr "Nie znaleziono w³a¶ciwo¶ci filename."
 
-#: ../src/lib/conf.c:130
+#: ../src/lib/conf.c:132
 msgid "Can't find supported property."
 msgstr "Nie znaleziono w³a¶ciwo¶ci supported."
 
-#: ../src/lib/conf.c:133
+#: ../src/lib/conf.c:135
 msgid "Can't convert supported property to int."
 msgstr "Nie mo¿na przekonwertowaæ w³a¶ciwo¶ci supported na int."
 
-#: ../src/lib/conf.c:138 ../src/lib/conf.c:385 ../src/lib/monitor_db.c:90
-#: ../src/lib/monitor_db.c:194 ../src/lib/monitor_db.c:370
-#: ../src/lib/monitor_db.c:426 ../src/lib/monitor_db.c:447
+#: ../src/lib/conf.c:140 ../src/lib/conf.c:392 ../src/lib/monitor_db.c:92
+#: ../src/lib/monitor_db.c:196 ../src/lib/monitor_db.c:373
+#: ../src/lib/monitor_db.c:429 ../src/lib/monitor_db.c:450
 msgid "Can't find name property."
 msgstr "Nie znaleziono w³a¶ciwo¶ci name."
 
-#: ../src/lib/conf.c:144
+#: ../src/lib/conf.c:146
 msgid "Can't find digital property."
 msgstr "Nie znaleziono w³a¶ciwo¶ci digital."
 
-#: ../src/lib/conf.c:147
+#: ../src/lib/conf.c:149
 msgid "Can't convert digital property to int."
 msgstr "Nie mo¿na przekonwertowaæ w³a¶ciwo¶ci digital na int."
 
-#: ../src/lib/conf.c:175 ../src/lib/conf.c:439
+#: ../src/lib/conf.c:177 ../src/lib/conf.c:447
 msgid "Cannot create the xml writer\n"
 msgstr "Nie mo¿na utworzyæ pisarza xml\n"
 
-#: ../src/lib/conf.c:239
+#: ../src/lib/conf.c:241
 msgid "Cannot read control value\n"
 msgstr "Nie mo¿na odczytaæ warto¶ci parametru\n"
 
-#: ../src/lib/conf.c:276
+#: ../src/lib/conf.c:278
 msgid "Cannot write control value\n"
 msgstr "Nie mo¿na zapisaæ warto¶ci parametru\n"
 
-#: ../src/lib/conf.c:313
+#: ../src/lib/conf.c:315
 msgid "Error while opening ddccontrol home directory."
 msgstr "B³±d podczas otwierania katalogu domowego ddccontrol."
 
-#: ../src/lib/conf.c:337
+#: ../src/lib/conf.c:340
 msgid "Error while reading ddccontrol home directory."
 msgstr "B³±d podczas odczytu katalogu domowego ddccontrol."
 
-#: ../src/lib/conf.c:382
+#: ../src/lib/conf.c:389
 msgid "Can't find pnpid property."
 msgstr "Nie znaleziono w³a¶ciwo¶ci pnpid."
 
-#: ../src/lib/conf.c:388 ../src/lib/conf.c:391
+#: ../src/lib/conf.c:395 ../src/lib/conf.c:398
 msgid "Can't find version property."
 msgstr "Nie znaleziono w³a¶ciwo¶ci version."
 
-#: ../src/lib/conf.c:390 ../src/lib/monitor_db.c:752
+#: ../src/lib/conf.c:397 ../src/lib/monitor_db.c:764
 msgid "Can't convert version to int."
 msgstr "Nie mo¿na przekonwertowaæ wersji na int."
 
-#: ../src/lib/conf.c:393
+#: ../src/lib/conf.c:400
 #, c-format
 msgid "profile version (%d) is not supported (should be %d).\n"
 msgstr "wersja profilu (%d) nie jest obs³ugiwana (powinna byæ %d).\n"
 
-#: ../src/lib/conf.c:407 ../src/lib/monitor_db.c:229
+#: ../src/lib/conf.c:415 ../src/lib/monitor_db.c:233
 msgid "Can't find address property."
 msgstr "Nie znaleziono w³a¶ciwo¶ci address."
 
-#: ../src/lib/conf.c:409 ../src/lib/monitor_db.c:231
+#: ../src/lib/conf.c:417 ../src/lib/monitor_db.c:235
 msgid "Can't convert address to int."
 msgstr "Nie mo¿na przekonwertowaæ adresu na int."
 
-#: ../src/lib/conf.c:413 ../src/lib/monitor_db.c:112
+#: ../src/lib/conf.c:421 ../src/lib/monitor_db.c:114
 msgid "Can't find value property."
 msgstr "Nie znaleziono w³a¶ciwo¶ci value."
 
-#: ../src/lib/conf.c:415 ../src/lib/monitor_db.c:114
+#: ../src/lib/conf.c:423 ../src/lib/monitor_db.c:116
 msgid "Can't convert value to int."
 msgstr "Nie mo¿na przekonwertowaæ warto¶ci na int."
 
-#: ../src/lib/conf.c:499
+#: ../src/lib/conf.c:507
 msgid "ddcci_delete_profile: Error, cannot delete profile.\n"
 msgstr "ddcci_delete_profile: B³±d, nie mo¿na usun±æ profilu.\n"
 
-#: ../src/lib/conf.c:519
+#: ../src/lib/conf.c:527
 #, c-format
 msgid "ddcci_delete_profile: Error, could not find the profile to delete.\n"
 msgstr "ddcci_delete_profile: B³±d, nie znaleziono profilu do usuniêcia.\n"
 
-#: ../src/lib/ddcci.c:146
+#: ../src/lib/ddcci.c:148
 msgid "Error while initialisating the message queue"
 msgstr "B³±d podczas inicjalizacji kolejki komunikatów"
 
-#: ../src/lib/ddcci.c:175
+#: ../src/lib/ddcci.c:177
 msgid "Error while sending quit message"
 msgstr "B³±d podczas wysy³ania komunikatu koñcz±cego"
 
-#: ../src/lib/ddcci.c:221
+#: ../src/lib/ddcci.c:223
 msgid "Error while sending heartbeat message"
 msgstr "B³±d podczas wysy³ania komunikatu znaku ¿ycia"
 
-#: ../src/lib/ddcci.c:239
+#: ../src/lib/ddcci.c:241
 #, c-format
 msgid "Failed to initialize ddccontrol database...\n"
 msgstr "Nie uda³o siê zainicjowaæ bazy danych ddccontrol...\n"
 
-#: ../src/lib/ddcci.c:275 ../src/lib/ddcci.c:350
+#: ../src/lib/ddcci.c:247
+#, fuzzy, c-format
+msgid "Failed to initialize ADL...\n"
+msgstr "Nie uda³o siê zainicjowaæ bazy danych ddccontrol...\n"
+
+#: ../src/lib/ddcci.c:292 ../src/lib/ddcci.c:383
 #, c-format
 msgid "ioctl returned %d\n"
 msgstr "ioctl zwróci³o %d\n"
 
-#: ../src/lib/ddcci.c:300
+#: ../src/lib/ddcci.c:321
 msgid "Error while sending write message"
 msgstr "B³±d podczas wysy³ania komunikatu zapisu"
 
-#: ../src/lib/ddcci.c:309
+#: ../src/lib/ddcci.c:330
 msgid "Error while reading write message answer"
 msgstr "B³±d podczas odczytu odpowiedzi na komunikat zapisu"
 
-#: ../src/lib/ddcci.c:376
+#: ../src/lib/ddcci.c:413
 msgid "Error while sending read message"
 msgstr "B³±d podczas wysy³ania komunikatu odczytu"
 
-#: ../src/lib/ddcci.c:385
+#: ../src/lib/ddcci.c:422
 msgid "Error while reading read message answer"
 msgstr "B³±d podczas odczytu odpowiedzi na komunikat odczytu"
 
-#: ../src/lib/ddcci.c:475
+#: ../src/lib/ddcci.c:518
 #, c-format
 msgid "Invalid response, first byte is 0x%02x, should be 0x%02x\n"
 msgstr "B³êdna odpowied¼, pierwszy bajt to 0x%02x, powinien byæ 0x%02x\n"
 
-#: ../src/lib/ddcci.c:485
+#: ../src/lib/ddcci.c:528
 #, c-format
 msgid "Non-fatal error: Invalid response, magic is 0x%02x\n"
 msgstr "B³±d niekrytyczny: B³êdna odpowied¼, liczba magiczna wynosi 0x%02x\n"
 
-#: ../src/lib/ddcci.c:492
+#: ../src/lib/ddcci.c:535
 #, c-format
 msgid "Invalid response, length is %d, should be %d at most\n"
 msgstr "B³êdna odpowied¼, d³ugo¶æ wynosi %d, powinna byæ najwy¿ej %d\n"
 
-#: ../src/lib/ddcci.c:505
+#: ../src/lib/ddcci.c:548
 #, c-format
 msgid "Invalid response, corrupted data - xor is 0x%02x, length 0x%02x\n"
 msgstr ""
 "B³êdna odpowied¼, uszkodzone dane - xor wynosi 0x%02x, d³ugo¶æ 0x%02x\n"
 
-#: ../src/lib/ddcci.c:658 ../src/lib/ddcci.c:680
+#: ../src/lib/ddcci.c:709 ../src/lib/ddcci.c:731
 #, c-format
 msgid "Can't convert value to int, invalid CAPS (buf=%s, pos=%d).\n"
 msgstr ""
 "Nie mo¿na przekonwertowaæ warto¶ci na int, b³êdne CAPS (buf=%s, pos=%d).\n"
 
-#: ../src/lib/ddcci.c:763
+#: ../src/lib/ddcci.c:814
 #, c-format
 msgid "Invalid sequence in caps.\n"
 msgstr "B³êdna sekwencja w mo¿liwo¶ciach.\n"
 
-#: ../src/lib/ddcci.c:841
+#: ../src/lib/ddcci.c:892
 #, c-format
 msgid "Corrupted EDID at 0x%02x.\n"
 msgstr "Uszkodzony EDID pod 0x%02x.\n"
 
-#: ../src/lib/ddcci.c:853
+#: ../src/lib/ddcci.c:904
 #, c-format
 msgid "Serial number: %d\n"
 msgstr "Numer seryjny: %d\n"
 
-#: ../src/lib/ddcci.c:856
+#: ../src/lib/ddcci.c:907
 #, c-format
 msgid "Manufactured: Week %d, %d\n"
 msgstr "Wyprodukowany: Tydzieñ %d, %d\n"
 
-#: ../src/lib/ddcci.c:859
+#: ../src/lib/ddcci.c:910
 #, c-format
 msgid "EDID version: %d.%d\n"
 msgstr "Wersja EDID: %d.%d\n"
 
-#: ../src/lib/ddcci.c:862
+#: ../src/lib/ddcci.c:913
 #, c-format
 msgid "Maximum size: %d x %d (cm)\n"
 msgstr "Maksymalny rozmiar: %d x %d (cm)\n"
 
-#: ../src/lib/ddcci.c:873
+#: ../src/lib/ddcci.c:924
 #, c-format
 msgid "Reading EDID 0x%02x failed.\n"
 msgstr "Odczyt EDID 0x%02x nie powiód³ siê.\n"
 
-#: ../src/lib/ddcci.c:903
+#: ../src/lib/ddcci.c:954
 #, c-format
 msgid "Device: %s\n"
 msgstr "Urz±dzenie: %s\n"
 
-#: ../src/lib/ddcci.c:917
+#: ../src/lib/ddcci.c:968
 msgid "Error while sending open message"
 msgstr "B³±d podczas wysy³ania open message"
 
-#: ../src/lib/ddcci.c:925
+#: ../src/lib/ddcci.c:976
 msgid "Error while reading open message answer"
 msgstr "B³±d podczas czytania data answer message"
 
-#: ../src/lib/ddcci.c:933
+#: ../src/lib/ddcci.c:988 ../src/lib/ddcci.c:1001
 #, c-format
 msgid "Invalid filename (%s).\n"
 msgstr "Niepoprawna nazwa pliku (%s).\n"
 
-#: ../src/lib/ddcci.c:1049
+#: ../src/lib/ddcci.c:993
+#, c-format
+msgid "ADL display not found (%s).\n"
+msgstr ""
+
+#: ../src/lib/ddcci.c:1125
 #, c-format
 msgid "ddcci_open returned %d\n"
 msgstr "ddcci_open zwróci³ warto¶æ %d\n"
 
-#: ../src/lib/ddcci.c:1062
+#: ../src/lib/ddcci.c:1138
 #, c-format
 msgid "Unknown monitor (%s)"
 msgstr "Nieznany monitor (%s)"
 
-#: ../src/lib/ddcci.c:1083
+#: ../src/lib/ddcci.c:1159
 #, c-format
 msgid "Probing for available monitors"
 msgstr "Skanowanie w poszukiwaniu znanych monitorów"
 
-#: ../src/lib/ddcci.c:1097
+#: ../src/lib/ddcci.c:1173
 msgid "Error while sending list message"
 msgstr "B³±d podczas wysy³ania list message"
 
-#: ../src/lib/ddcci.c:1106
+#: ../src/lib/ddcci.c:1182
 msgid "Error while reading list entry"
 msgstr "B³±d podczas odczytu wpisu listy"
 
-#: ../src/lib/ddcci.c:1123
+#: ../src/lib/ddcci.c:1199
 #, c-format
 msgid "Found PCI device (%s)\n"
 msgstr "Znaleziono urz±dznie PCI (%s)\n"
 
-#: ../src/lib/ddcci.c:1157
+#: ../src/lib/ddcci.c:1239
 #, c-format
 msgid "Found I2C device (%s)\n"
 msgstr "Znaleziono urz±dzenie I2C (%s)\n"
 
-#: ../src/lib/ddcci.c:1206
+#: ../src/lib/ddcci.c:1264
+#, fuzzy, c-format
+msgid "Found ADL display (%s)\n"
+msgstr "Znaleziono urz±dznie PCI (%s)\n"
+
+#: ../src/lib/ddcci.c:1310
 msgid "Error while getting information about ddccontrol home directory."
 msgstr "B³±d podczas pobierania informacji o katalogu domowym ddccontrol."
 
-#: ../src/lib/ddcci.c:1211
+#: ../src/lib/ddcci.c:1316
 msgid "Error while creating ddccontrol home directory."
 msgstr "B³±d podczas tworzenia katalogu domowego ddccontrol."
 
-#: ../src/lib/ddcci.c:1216
+#: ../src/lib/ddcci.c:1322
 msgid ""
 "Error while getting information about ddccontrol home directory after "
 "creating it."
@@ -1143,20 +1170,20 @@ msgstr ""
 "B³±d podczas pobierania informacji o katalogu domowym ddccontrol po "
 "utworzeniu go."
 
-#: ../src/lib/ddcci.c:1223
+#: ../src/lib/ddcci.c:1330
 msgid "Error: '.ddccontrol' in your home directory is not a directory."
 msgstr ""
 "B³±d: '.ddccontrol' w katalogu domowym u¿ytkownika nie jest katalogiem."
 
-#: ../src/lib/ddcci.c:1231
+#: ../src/lib/ddcci.c:1339
 msgid "Error while getting information about ddccontrol profile directory."
 msgstr "B³±d podczas pobierania informacji o katalogu profili ddccontrol."
 
-#: ../src/lib/ddcci.c:1236
+#: ../src/lib/ddcci.c:1345
 msgid "Error while creating ddccontrol profile directory."
 msgstr "B³±d podczas tworzenia katalogu profili ddccontrol."
 
-#: ../src/lib/ddcci.c:1241
+#: ../src/lib/ddcci.c:1351
 msgid ""
 "Error while getting information about ddccontrol profile directory after "
 "creating it."
@@ -1164,134 +1191,182 @@ msgstr ""
 "B³±d podczas pobierania informacji o katalogu profili ddccontrol po "
 "utworzeniu go."
 
-#: ../src/lib/ddcci.c:1248
+#: ../src/lib/ddcci.c:1359
 msgid ""
 "Error: '.ddccontrol/profiles' in your home directory is not a directory."
 msgstr ""
 "B³±d: '.ddccontrol/profiles' w katalogu domowym u¿ytkownika nie jest "
 "katalogiem."
 
-#: ../src/lib/monitor_db.c:82 ../src/lib/monitor_db.c:192
+#: ../src/lib/monitor_db.c:84 ../src/lib/monitor_db.c:194
 msgid "Can't find id property."
 msgstr "Nie znaleziono w³a¶ciwo¶ci id."
 
-#: ../src/lib/monitor_db.c:151 ../src/lib/monitor_db.c:546
+#: ../src/lib/monitor_db.c:153 ../src/lib/monitor_db.c:549
 #, c-format
 msgid "Element %s (id=%s) has not been found (line %ld).\n"
 msgstr "Element %s (id=%s) nie zosta³ odnaleziony (linia %ld).\n"
 
-#: ../src/lib/monitor_db.c:205
+#: ../src/lib/monitor_db.c:207
 msgid "Invalid refresh type (!= none, != all)."
 msgstr "B³êdny rodzaj od¶wie¿ania (!= none, != all)."
 
-#: ../src/lib/monitor_db.c:238
+#: ../src/lib/monitor_db.c:242
 #, c-format
 msgid "Control %s has been discarded by the caps string.\n"
 msgstr "Parametr %s zosta³ usuniêty przez ³añcuch mo¿liwo¶ci.\n"
 
-#: ../src/lib/monitor_db.c:246
+#: ../src/lib/monitor_db.c:250
 #, c-format
 msgid "Control %s (0x%02x) has already been defined.\n"
 msgstr "Parametr %s (0x%02x) ju¿ zosta³ zdefiniowany.\n"
 
-#: ../src/lib/monitor_db.c:259
+#: ../src/lib/monitor_db.c:263
 msgid "Can't convert delay to int."
 msgstr "Nie mo¿na przekonwertowaæ opó¼nienia na int."
 
-#: ../src/lib/monitor_db.c:267
+#: ../src/lib/monitor_db.c:271
 msgid "Can't find type property."
 msgstr "Nie znaleziono w³a¶ciwo¶ci type."
 
-#: ../src/lib/monitor_db.c:292 ../src/lib/monitor_db.c:381
+#: ../src/lib/monitor_db.c:296 ../src/lib/monitor_db.c:384
 msgid "Invalid type."
 msgstr "Niepoprawny typ."
 
-#: ../src/lib/monitor_db.c:343
+#: ../src/lib/monitor_db.c:346
 #, c-format
 msgid "Database must be inited before reading a monitor file.\n"
 msgstr "Baza danych musi byæ zainicjowana przed odczytem pliku monitora.\n"
 
-#: ../src/lib/monitor_db.c:357
+#: ../src/lib/monitor_db.c:360
 #, c-format
 msgid "empty monitor/%s.xml\n"
 msgstr "pusty monitor/%s.xml\n"
 
-#: ../src/lib/monitor_db.c:363
+#: ../src/lib/monitor_db.c:366
 #, c-format
 msgid "monitor/%s.xml of the wrong type, root node %s != monitor"
 msgstr "monitor/%s.xml jest z³ego typu, g³ówny wêze³ %s != monitor"
 
-#: ../src/lib/monitor_db.c:464
+#: ../src/lib/monitor_db.c:467
 msgid "Can't find add or remove property in caps."
 msgstr "Nie znaleziono w³a¶ciwo¶ci add ani remove w caps."
 
-#: ../src/lib/monitor_db.c:466
+#: ../src/lib/monitor_db.c:469
 msgid "Invalid remove caps."
 msgstr "B³êdne w³asno¶ci do usuniêcia."
 
-#: ../src/lib/monitor_db.c:468
+#: ../src/lib/monitor_db.c:471
 msgid "Invalid add caps."
 msgstr "B³êdne w³asno¶ci do dodania."
 
-#: ../src/lib/monitor_db.c:473
+#: ../src/lib/monitor_db.c:476
 #, c-format
 msgid "Error, include recursion level > 15 (file: %s).\n"
 msgstr "B³±d, poziom zag³êbienia do³±czania > 15 (plik: %s).\n"
 
-#: ../src/lib/monitor_db.c:479
+#: ../src/lib/monitor_db.c:482
 msgid "Can't find file property."
 msgstr "Nie znaleziono w³a¶ciwo¶ci plik."
 
-#: ../src/lib/monitor_db.c:487
+#: ../src/lib/monitor_db.c:490
 msgid "Two controls part in XML file."
 msgstr "Dwie czê¶ci controls w pliku XML."
 
-#: ../src/lib/monitor_db.c:534
+#: ../src/lib/monitor_db.c:537
 msgid "Error enumerating controls in subgroup."
 msgstr "B³±d podczas zliczania parametrów w podgrupie."
 
-#: ../src/lib/monitor_db.c:589
+#: ../src/lib/monitor_db.c:601
 #, c-format
 msgid "document of the wrong type, can't find controls or include.\n"
 msgstr "niepoprawny typ documentu, nie znaleziono parametru lub do³±czenia.\n"
 
-#: ../src/lib/monitor_db.c:721
+#: ../src/lib/monitor_db.c:733
 #, c-format
 msgid "empty options.xml\n"
 msgstr "pusty options.xml\n"
 
-#: ../src/lib/monitor_db.c:728
+#: ../src/lib/monitor_db.c:740
 #, c-format
 msgid "options.xml of the wrong type, root node %s != options"
 msgstr "options.xml z³ego typu, g³ówny wêze³ %s != options"
 
-#: ../src/lib/monitor_db.c:738
+#: ../src/lib/monitor_db.c:750
 #, c-format
 msgid "options.xml dbversion attribute missing, please update your database.\n"
 msgstr "options.xml atrybut dbversion nie znaleziony, od¶wie¿ bazê danych.\n"
 
-#: ../src/lib/monitor_db.c:745
+#: ../src/lib/monitor_db.c:757
 #, c-format
 msgid "options.xml date attribute missing, please update your database.\n"
 msgstr "options.xml atrubut date nie znaleziony, od¶wie¿ bazê danych.\n"
 
-#: ../src/lib/monitor_db.c:755
+#: ../src/lib/monitor_db.c:767
 #, c-format
 msgid ""
 "options.xml dbversion (%d) is greater than the supported version (%d).\n"
 msgstr "options.xml dbversion (%d) jest wy¿sze ni¿ suportowana wersja (%d).\n"
 
-#: ../src/lib/monitor_db.c:756
+#: ../src/lib/monitor_db.c:768
 #, c-format
 msgid "Please update ddccontrol program.\n"
 msgstr "Proszê uaktualniæ program ddccontrol.\n"
 
-#: ../src/lib/monitor_db.c:763
+#: ../src/lib/monitor_db.c:775
 #, c-format
 msgid "options.xml dbversion (%d) is less than the supported version (%d).\n"
 msgstr "dbversion options.xml (%d) jest mniejsza od obs³ugiwanej (%d).\n"
 
-#: ../src/lib/monitor_db.c:764
+#: ../src/lib/monitor_db.c:776
 #, c-format
 msgid "Please update ddccontrol database.\n"
 msgstr "Proszê uaktualniæ bazê danych ddccontrol.\n"
+
+#~ msgid "Monitor Profile Switcher"
+#~ msgstr "Prze³±cznik profili monitora"
+
+#~ msgid "Quickly switch monitor profiles created with gddccontrol"
+#~ msgstr ""
+#~ "Szybkie prze³±czanie profili monitora utworzonych przy u¿yciu gddccontrol"
+
+#~ msgid "_About..."
+#~ msgstr "_O..."
+
+#~ msgid "_Properties..."
+#~ msgstr "_W³a¶ciwo¶ci..."
+
+#~ msgid "_Run gddccontrol..."
+#~ msgstr "_Uruchomienie gddccontrol..."
+
+#~ msgid ""
+#~ "An applet for quick switching of monitor profiles.\n"
+#~ "Based on libddccontrol and part of the ddccontrol project.\n"
+#~ "(http://ddccontrol.sourceforge.net)"
+#~ msgstr ""
+#~ "Aplet do szybkiego prze³±czania profili monitora.\n"
+#~ "Oparty na libddccontrol i bêd±cy czê¶ci± projektu ddccontrol.\n"
+#~ "(http://ddccontrol.sourceforge.net)"
+
+#~ msgid "Unable to initialize ddcci library"
+#~ msgstr "Biblioteka ddcci nie zosta³a zainicjalizowana"
+
+#~ msgid "No monitor configuration found. Please run gddccontrol first"
+#~ msgstr ""
+#~ "Nie znaleziono konfiguracji monitora. Proszê najpierw uruchomiæ "
+#~ "gddccontrol"
+
+#~ msgid "An error occurred while opening the monitor device"
+#~ msgstr "Wyst±pi³ b³±d podczas otwierania urz±dzenia monitora"
+
+#~ msgid "Can't find any profiles"
+#~ msgstr "Nie znaleziono ¿adnego profilu"
+
+#~ msgid "error"
+#~ msgstr "b³±d"
+
+#~ msgid "Monitor:"
+#~ msgstr "Monitor:"
+
+#~ msgid "Monitor Profile Switcher Properties"
+#~ msgstr "W³a¶ciwo¶ci prze³±czania profili monitora"

--- a/po/ru.po
+++ b/po/ru.po
@@ -6,36 +6,34 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DDC/CI control tool 0.1\n"
-"Report-Msgid-Bugs-To: ddccontrol-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2009-03-10 03:54+0300\n"
+"Report-Msgid-Bugs-To: https://github.com/ddccontrol/ddccontrol/issues/\n"
+"POT-Creation-Date: 2026-05-13 15:12+0200\n"
 "PO-Revision-Date: 2009-03-10 04:50+0300\n"
 "Last-Translator: Alexandre Prokoudine <alexandre.prokoudine@gmail.com>\n"
 "Language-Team: Russian <LL@li.org>\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/ddccontrol/main.c:83
-#: ../src/ddccontrol/main.c:87
-#: ../src/ddccontrol/main.c:91
-msgid "Control"
-msgstr "Управление"
-
-#: ../src/ddccontrol/main.c:132
-#, c-format
+#: ../src/ddccontrol/main.c:85
+#, fuzzy, c-format
 msgid ""
 "Usage:\n"
-"%s [-b datadir] [-v] [-c] [-d] [-f] [-s] [-r ctrl [-w value]] [-p | dev]\n"
+"%s [-b datadir] [-v] [-c] [-d] [-f] [-s] [-r ctrl [-w value]] [-l (profile "
+"path)] [-p | dev]\n"
 "\tdev: device, e.g. dev:/dev/i2c-0\n"
 "\t-p : probe I2C devices to find monitor buses\n"
 "\t-c : query capability\n"
 "\t-d : query ctrls 0 - 255\n"
 "\t-r : query ctrl\n"
 "\t-w : value to write to ctrl\n"
+"\t-W : relatively change ctrl value (+/-)\n"
 "\t-f : force (avoid validity checks)\n"
 "\t-s : save settings\n"
 "\t-v : verbosity (specify more to increase)\n"
 "\t-b : ddccontrol-db directory (if other than %s)\n"
+"\t-l : load values from XML profile file\n"
 msgstr ""
 "Использование:\n"
 "%s [-b каталог] [-v] [-c] [-d] [-f] [-s] [-r ctrl [-w value]] [-p | dev]\n"
@@ -50,32 +48,30 @@ msgstr ""
 "\t-v : подробный вывод (введите для получения более подробной информации)\n"
 "\t-b : каталог ddccontrol-db (если отличается от %s)\n"
 
-#: ../src/ddccontrol/main.c:150
-#: ../src/ddccontrol/main.c:172
+#: ../src/ddccontrol/main.c:106 ../src/ddccontrol/main.c:128
 #, c-format
 msgid "Checking %s integrity...\n"
 msgstr "Проверка целостности %s...\n"
 
-#: ../src/ddccontrol/main.c:152
-#: ../src/ddccontrol/main.c:174
+#: ../src/ddccontrol/main.c:108 ../src/ddccontrol/main.c:130
 #, c-format
 msgid "[ FAILED ]\n"
 msgstr "[ ОШИБКА ]\n"
 
-#: ../src/ddccontrol/main.c:156
-#: ../src/ddccontrol/main.c:179
+#: ../src/ddccontrol/main.c:112 ../src/ddccontrol/main.c:135
 #, c-format
 msgid "[ OK ]\n"
 msgstr "[ OK ]\n"
 
-#: ../src/ddccontrol/main.c:217
+#: ../src/ddccontrol/main.c:194
 #, c-format
 msgid ""
 "ddccontrol version %s\n"
 "Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)\n"
 "Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)\n"
 "This program comes with ABSOLUTELY NO WARRANTY.\n"
-"You may redistribute copies of this program under the terms of the GNU General Public License.\n"
+"You may redistribute copies of this program under the terms of the GNU "
+"General Public License.\n"
 "\n"
 msgstr ""
 "ddccontrol версии %s\n"
@@ -85,101 +81,117 @@ msgstr ""
 "Вы можете распространять ее копии на условиях GNU General Public License.\n"
 "\n"
 
-#: ../src/ddccontrol/main.c:236
+#: ../src/ddccontrol/main.c:211
 #, c-format
 msgid "'%s' does not seem to be a valid register name\n"
 msgstr "'%s' не является правильным именем регистра\n"
 
-#: ../src/ddccontrol/main.c:242
+#: ../src/ddccontrol/main.c:217
 #, c-format
 msgid "You cannot use -w parameter without -r.\n"
 msgstr "Нельзя использовать параметр -w без -r.\n"
 
-#: ../src/ddccontrol/main.c:247
+#: ../src/ddccontrol/main.c:221 ../src/ddccontrol/main.c:231
 #, c-format
 msgid "'%s' does not seem to be a valid value.\n"
 msgstr "'%s' не является правильным значением.\n"
 
-#: ../src/ddccontrol/main.c:292
-#: ../src/gddccontrol/main.c:414
+#: ../src/ddccontrol/main.c:227
+#, fuzzy, c-format
+msgid "You cannot use -W parameter without -r.\n"
+msgstr "Нельзя использовать параметр -w без -r.\n"
+
+#: ../src/ddccontrol/main.c:282 ../src/gddccontrol/main.c:432
 #, c-format
 msgid "Unable to initialize ddcci library.\n"
 msgstr "Не удалось инициализировать библиотеку ddcci.\n"
 
-#: ../src/ddccontrol/main.c:304
+#: ../src/ddccontrol/main.c:288
+#, fuzzy, c-format
+msgid "Unable to initialize ddcci db library.\n"
+msgstr "Не удалось инициализировать библиотеку ddcci.\n"
+
+#: ../src/ddccontrol/main.c:293
+#, c-format
+msgid "Failed to open D-Bus proxy, try with DDCCONTROL_NO_DAEMON=1.\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:310
 #, c-format
 msgid "Detected monitors :\n"
 msgstr "Найдены мониторы :\n"
 
-#: ../src/ddccontrol/main.c:309
+#: ../src/ddccontrol/main.c:314
 #, c-format
 msgid " - Device: %s\n"
 msgstr " - Устройство: %s\n"
 
-#: ../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 #, c-format
 msgid "   DDC/CI supported: %s\n"
 msgstr "   Поддерживается DDC/CI: %s\n"
 
-#: ../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 msgid "Yes"
 msgstr "Да"
 
-#: ../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 msgid "No"
 msgstr "Нет"
 
-#: ../src/ddccontrol/main.c:311
+#: ../src/ddccontrol/main.c:316
 #, c-format
 msgid "   Monitor Name: %s\n"
 msgstr "   Имя монитора: %s\n"
 
-#: ../src/ddccontrol/main.c:312
+#: ../src/ddccontrol/main.c:317
 #, c-format
 msgid "   Input type: %s\n"
 msgstr "   Тип входа: %s\n"
 
-#: ../src/ddccontrol/main.c:312
-#: ../src/ddccontrol/main.c:350
+#: ../src/ddccontrol/main.c:317 ../src/ddccontrol/main.c:364
 msgid "Digital"
 msgstr "Цифровой"
 
-#: ../src/ddccontrol/main.c:312
-#: ../src/ddccontrol/main.c:350
+#: ../src/ddccontrol/main.c:317 ../src/ddccontrol/main.c:364
 msgid "Analog"
 msgstr "Аналоговый"
 
-#: ../src/ddccontrol/main.c:316
+#: ../src/ddccontrol/main.c:321
 #, c-format
 msgid "  (Automatically selected)\n"
 msgstr "  (Автоматический выбор)\n"
 
-#: ../src/ddccontrol/main.c:326
+#: ../src/ddccontrol/main.c:333
 #, c-format
 msgid ""
 "No monitor supporting DDC/CI available.\n"
-"If your graphics card need it, please check all the required kernel modules are loaded (i2c-dev, and your framebuffer driver).\n"
+"If your graphics card need it, please check all the required kernel modules "
+"are loaded (i2c-dev, and your framebuffer driver).\n"
 msgstr ""
 "Не обнаружены мониторы, поддерживающие DDC/CI.\n"
-"Если ваша видеокарта этого требует, проверьте загружены ли все требуемые модули ядра (i2c-dev и драйвер фреймбуфера).\n"
+"Если ваша видеокарта этого требует, проверьте загружены ли все требуемые "
+"модули ядра (i2c-dev и драйвер фреймбуфера).\n"
 
-#: ../src/ddccontrol/main.c:339
+#: ../src/ddccontrol/main.c:346
 #, c-format
 msgid "Reading EDID and initializing DDC/CI at bus %s...\n"
 msgstr "Чтение EDID и инициализация DDC/CI на шине %s...\n"
 
-#: ../src/ddccontrol/main.c:343
+#: ../src/ddccontrol/main.c:357
 #, c-format
 msgid ""
 "\n"
 "DDC/CI at %s is unusable (%d).\n"
-"If your graphics card need it, please check all the required kernel modules are loaded (i2c-dev, and your framebuffer driver).\n"
+"If your graphics card need it, please check all the required kernel modules "
+"are loaded (i2c-dev, and your framebuffer driver).\n"
 msgstr ""
 "\n"
 "DDC/CI на %s нерабочее (%d).\n"
-"Если ваша видеокарта этого требует, проверьте загружены ли все требуемые модули ядра (i2c-dev и драйвер фреймбуфера).\n"
+"Если ваша видеокарта этого требует, проверьте загружены ли все требуемые "
+"модули ядра (i2c-dev и драйвер фреймбуфера).\n"
 
-#: ../src/ddccontrol/main.c:347
+#: ../src/ddccontrol/main.c:361
 #, c-format
 msgid ""
 "\n"
@@ -188,53 +200,17 @@ msgstr ""
 "\n"
 "Чтение EDID:\n"
 
-#: ../src/ddccontrol/main.c:348
+#: ../src/ddccontrol/main.c:362
 #, c-format
 msgid "\tPlug and Play ID: %s [%s]\n"
 msgstr "\tPlug and Play ID: %s [%s]\n"
 
-#: ../src/ddccontrol/main.c:350
+#: ../src/ddccontrol/main.c:364
 #, c-format
 msgid "\tInput type: %s\n"
 msgstr "\tТип входа: %s\n"
 
-#. Put a big warning (in red if we are writing to a terminal).
-#: ../src/ddccontrol/main.c:354
-#: ../src/ddccontrol/main.c:373
-msgid "=============================== WARNING ==============================="
-msgstr "=============================== ПРЕДУПРЕЖДЕНИЕ ==============================="
-
-#: ../src/ddccontrol/main.c:357
-#, c-format
-msgid ""
-"There is no support for your monitor in the database, but ddccontrol is\n"
-"using a generic profile for your monitor's manufacturer. Some controls\n"
-"may not be supported, or may not work as expected.\n"
-msgstr ""
-
-#: ../src/ddccontrol/main.c:363
-#, c-format
-msgid ""
-"There is no support for your monitor in the database, but ddccontrol is\n"
-"using a basic generic profile. Many controls will not be supported, and\n"
-"some controls may not work as expected.\n"
-msgstr ""
-
-#: ../src/ddccontrol/main.c:368
-#, c-format
-msgid ""
-"Please update ddccontrol-db, or, if you are already using the latest\n"
-"version, please send the output of the following command to\n"
-"ddccontrol-users@lists.sourceforge.net:\n"
-msgstr ""
-
-#: ../src/ddccontrol/main.c:372
-#: ../src/gddccontrol/notebook.c:695
-#, c-format
-msgid "Thank you.\n"
-msgstr "Спасибо.\n"
-
-#: ../src/ddccontrol/main.c:377
+#: ../src/ddccontrol/main.c:370
 #, c-format
 msgid ""
 "\n"
@@ -243,42 +219,52 @@ msgstr ""
 "\n"
 "Возможности:\n"
 
-#: ../src/ddccontrol/main.c:381
+#: ../src/ddccontrol/main.c:374
 #, c-format
 msgid "Raw output: %s\n"
 msgstr "Вывод как есть: %s\n"
 
-#: ../src/ddccontrol/main.c:383
+#: ../src/ddccontrol/main.c:376
 #, c-format
 msgid "Parsed output: \n"
 msgstr "Разобранный вывод: \n"
 
-#: ../src/ddccontrol/main.c:392
+#: ../src/ddccontrol/main.c:385
 #, c-format
 msgid "\tType: "
 msgstr "\tТип: "
 
-#: ../src/ddccontrol/main.c:395
+#: ../src/ddccontrol/main.c:388
 #, c-format
 msgid "LCD"
 msgstr "ЖК"
 
-#: ../src/ddccontrol/main.c:398
+#: ../src/ddccontrol/main.c:391
 #, c-format
 msgid "CRT"
 msgstr "ЭЛТ"
 
-#: ../src/ddccontrol/main.c:401
+#: ../src/ddccontrol/main.c:394
 #, c-format
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#: ../src/ddccontrol/main.c:410
+#: ../src/ddccontrol/main.c:403
 #, c-format
 msgid "Capabilities read fail.\n"
 msgstr "Не удалось прочесть возможности.\n"
 
-#: ../src/ddccontrol/main.c:418
+#: ../src/ddccontrol/main.c:417
+#, c-format
+msgid "Value cannot be lower than zero! %d -> %d\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:420
+#, c-format
+msgid "Value cannot be higher than maximum! %d / %d\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:428
 #, c-format
 msgid ""
 "\n"
@@ -287,7 +273,7 @@ msgstr ""
 "\n"
 "Записывается 0x%02x, 0x%02x(%d) (задержка %d мс)...\n"
 
-#: ../src/ddccontrol/main.c:422
+#: ../src/ddccontrol/main.c:431
 #, c-format
 msgid ""
 "\n"
@@ -296,7 +282,7 @@ msgstr ""
 "\n"
 "Записывается 0x%02x, 0x%02x(%d)...\n"
 
-#: ../src/ddccontrol/main.c:427
+#: ../src/ddccontrol/main.c:436
 #, c-format
 msgid ""
 "\n"
@@ -305,7 +291,17 @@ msgstr ""
 "\n"
 "Читается 0x%02x...\n"
 
-#: ../src/ddccontrol/main.c:434
+#: ../src/ddccontrol/main.c:445
+#, fuzzy, c-format
+msgid "Applied profile: %s\n"
+msgstr "Применить профиль"
+
+#: ../src/ddccontrol/main.c:447
+#, c-format
+msgid "Failed to apply profile: %s\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:451
 #, c-format
 msgid ""
 "\n"
@@ -314,32 +310,32 @@ msgstr ""
 "\n"
 "Управление (разрешенное/текущее/максимальное) [Описание - Имя величины]:\n"
 
-#: ../src/ddccontrol/main.c:458
+#: ../src/ddccontrol/main.c:473
 #, c-format
 msgid "\t\t> id=%s, name=%s, address=%#x, delay=%dms, type=%d\n"
 msgstr "\t\t> id=%s, имя=%s, адрес=%#x, задержка=%dms, тип=%d\n"
 
-#: ../src/ddccontrol/main.c:463
+#: ../src/ddccontrol/main.c:478
 #, c-format
 msgid "\t\t  Possible values:\n"
 msgstr "\t\t  Возможные значения:\n"
 
-#: ../src/ddccontrol/main.c:467
+#: ../src/ddccontrol/main.c:482
 #, c-format
 msgid "\t\t\t> id=%s - name=%s, value=%d\n"
 msgstr "\t\t\t> id=%s - имя=%s, значение=%d\n"
 
-#: ../src/ddccontrol/main.c:477
+#: ../src/ddccontrol/main.c:492
 #, c-format
 msgid "\t\t  supported, value=%d, maximum=%d\n"
 msgstr "\t\t  поддерживается, значение=%d, максимум=%d\n"
 
-#: ../src/ddccontrol/main.c:478
+#: ../src/ddccontrol/main.c:493
 #, c-format
 msgid "\t\t  not supported, value=%d, maximum=%d\n"
 msgstr "\t\t  не поддерживается, значение=%d, максимум=%d\n"
 
-#: ../src/ddccontrol/main.c:489
+#: ../src/ddccontrol/main.c:504
 #, c-format
 msgid ""
 "\n"
@@ -347,6 +343,48 @@ msgid ""
 msgstr ""
 "\n"
 "Сохраняются значения...\n"
+
+#. Put a big warning (in red if we are writing to a terminal).
+#: ../src/ddccontrol/main.c:516 ../src/ddccontrol/main.c:537
+msgid "=============================== WARNING ==============================="
+msgstr ""
+"=============================== ПРЕДУПРЕЖДЕНИЕ "
+"==============================="
+
+#: ../src/ddccontrol/main.c:519
+#, c-format
+msgid ""
+"There is no support for your monitor in the database, but ddccontrol is\n"
+"using a generic profile for your monitor's manufacturer. Some controls\n"
+"may not be supported, or may not work as expected.\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:524
+#, c-format
+msgid ""
+"There is no support for your monitor in the database, but ddccontrol is\n"
+"using a basic generic profile. Many controls will not be supported, and\n"
+"some controls may not work as expected.\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:529
+#, c-format
+msgid ""
+"Unsupported monitor detected.\n"
+"\n"
+"Please update ddccontrol-db, or, if you are already using the latest\n"
+"version, please open this pre-filled GitHub issue:\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:534
+#, c-format
+msgid "Then attach the resulting report file of the following command:\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:536 ../src/gddccontrol/notebook.c:715
+#, c-format
+msgid "Thank you.\n"
+msgstr "Спасибо.\n"
 
 #. arbitration or no acknowledge
 #: ../src/ddcpci/i2c-algo-bit.c:368
@@ -365,10 +403,9 @@ msgstr "i2c-algo-bit.o: readbytes: тайм-аут i2c_inb .\n"
 msgid "i2c-algo-bit.o: readbytes: Timeout at ack\n"
 msgstr "i2c-algo-bit.o: readbytes: тайм-аут при подтверждении\n"
 
-#: ../src/ddcpci/intel740.c:103
-#: ../src/ddcpci/intel810.c:161
-#: ../src/ddcpci/nvidia.c:155
-#: ../src/ddcpci/radeon.c:209
+#: ../src/ddcpci/intel740.c:103 ../src/ddcpci/intel810.c:162
+#: ../src/ddcpci/nvidia.c:155 ../src/ddcpci/radeon.c:209
+#: ../src/ddcpci/sis.c:174 ../src/ddcpci/via.c:167
 #, c-format
 msgid "%s: Malloc error.\n"
 msgstr "%s: ошибка malloc.\n"
@@ -388,64 +425,62 @@ msgstr "%s: Ошибка: неизвестный тип карты (%#x)\n"
 msgid "%s: Malloc error."
 msgstr "%s: ошибка malloc."
 
-#: ../src/ddcpci/intel810.c:171
+#: ../src/ddcpci/intel810.c:172
 msgid "i810_open: cannot open /dev/mem"
 msgstr "i810_open: не удалось открыть /dev/mem"
 
-#: ../src/ddcpci/intel810.c:206
+#: ../src/ddcpci/intel810.c:207
 #, c-format
 msgid "i810_open: Error: cannot find any valid MMIO PCI region.\n"
-msgstr "i810_open: Ошибка: не удалось найти ни одной правильной области MMIO PCI.\n"
+msgstr ""
+"i810_open: Ошибка: не удалось найти ни одной правильной области MMIO PCI.\n"
 
-#: ../src/ddcpci/intel810.c:213
+#: ../src/ddcpci/intel810.c:214
 msgid "i810_open: mmap failed"
 msgstr "i810_open: Ошибка: mmap не выполнена"
 
-#: ../src/ddcpci/main.c:154
+#: ../src/ddcpci/main.c:160
 msgid "==>Error while sending open message"
 msgstr "==>Ошибка при отправке сообщения открытия"
 
-#: ../src/ddcpci/main.c:178
-#: ../src/ddcpci/main.c:184
-#: ../src/ddcpci/main.c:202
+#: ../src/ddcpci/main.c:184 ../src/ddcpci/main.c:190 ../src/ddcpci/main.c:208
 msgid "==>Error while sending data answer message"
 msgstr "==>Ошибка при отправке ответа на сообщение открытия"
 
-#: ../src/ddcpci/main.c:251
-#: ../src/ddcpci/main.c:266
+#: ../src/ddcpci/main.c:257 ../src/ddcpci/main.c:272
 msgid "==>Error while sending list message"
 msgstr "==>Ошибка при отправке сообщения списка"
 
-#: ../src/ddcpci/main.c:284
+#: ../src/ddcpci/main.c:290
 #, c-format
 msgid "Invalid arguments.\n"
 msgstr "Неверные аргументы.\n"
 
-#: ../src/ddcpci/main.c:290
+#: ../src/ddcpci/main.c:296
 #, c-format
 msgid "==>Can't read verbosity.\n"
 msgstr "==>Не удалось прочесть подробные сообщения.\n"
 
-#: ../src/ddcpci/main.c:297
+#: ../src/ddcpci/main.c:303
 #, c-format
 msgid "==>Can't read key.\n"
 msgstr "==>Не удалось прочесть ключ.\n"
 
-#: ../src/ddcpci/main.c:302
+#: ../src/ddcpci/main.c:308
 #, c-format
 msgid "==>Can't open key %u\n"
 msgstr "==>Не удалось открыть ключ %u.\n"
 
-#: ../src/ddcpci/main.c:316
+#: ../src/ddcpci/main.c:322
 #, c-format
 msgid "==>No command received for %ld seconds, aborting.\n"
 msgstr "==>Команда не получена в течение %ld секунд, прерывание.\n"
 
-#: ../src/ddcpci/main.c:324
+#: ../src/ddcpci/main.c:330
 msgid "==>Error while receiving query\n"
 msgstr "==>Ошибка при получении очереди\n"
 
-#: ../src/ddcpci/main.c:359
+#: ../src/ddcpci/main.c:365
 #, c-format
 msgid "==>Invalid query...\n"
 msgstr "==>Неправильная очередь...\n"
@@ -476,7 +511,27 @@ msgstr "radeon_open: не удалось открыть /dev/mem"
 msgid "radeon_open: mmap failed"
 msgstr "radeon_open: mmap не выполнена"
 
-#: ../src/gddccontrol/fspatterns.c:195
+#: ../src/ddcpci/sis.c:133
+#, fuzzy, c-format
+msgid "sis.c:init_i2c_bus: Malloc error."
+msgstr "nvidia.c:init_i2c_bus: ошибка malloc."
+
+#: ../src/ddcpci/via.c:125
+#, fuzzy, c-format
+msgid "via.c:init_i2c_bus: Malloc error."
+msgstr "nvidia.c:init_i2c_bus: ошибка malloc."
+
+#: ../src/ddcpci/via.c:177
+#, fuzzy
+msgid "via_open: cannot open /dev/mem"
+msgstr "nvidia_open: не удалось открыть /dev/mem"
+
+#: ../src/ddcpci/via.c:186
+#, fuzzy
+msgid "via_open: mmap failed"
+msgstr "nvidia_open: mmap не выполнена"
+
+#: ../src/gddccontrol/fspatterns.c:137
 msgid ""
 "Adjust brightness and contrast following these rules:\n"
 " - Black must be as dark as possible.\n"
@@ -488,11 +543,11 @@ msgstr ""
 " - Белый должен быть максимально ярким.\n"
 " - Вы должны различать каждый уровень серого (в частности 0 и 12).\n"
 
-#: ../src/gddccontrol/fspatterns.c:211
+#: ../src/gddccontrol/fspatterns.c:259
 msgid "Try to make moire patterns disappear."
 msgstr "Попробуйте убрать муар."
 
-#: ../src/gddccontrol/fspatterns.c:215
+#: ../src/gddccontrol/fspatterns.c:263
 msgid ""
 "Adjust Image Lock Coarse to make the vertical band disappear.\n"
 "Adjust Image Lock Fine to minimize movement on the screen."
@@ -500,167 +555,182 @@ msgstr ""
 "Настройте грубо изображение, чтобы убрать вертикальные полосы.\n"
 "Настройте тонко изображение, чтобы минимизировать смещение экрана."
 
-#: ../src/gddccontrol/fspatterns.c:254
+#: ../src/gddccontrol/fspatterns.c:273
 #, c-format
 msgid "Unknown fullscreen pattern name: %s"
 msgstr "Неизвестное имя полноэкранного шаблона: %s"
 
 #: ../src/gddccontrol/gddccontrol.desktop.in.h:1
+#, fuzzy
+msgid "DDC Control"
+msgstr "Управление"
+
+#: ../src/gddccontrol/gddccontrol.desktop.in.h:2
 msgid "Monitor Settings"
 msgstr "Параметры монитора"
 
-#: ../src/gddccontrol/gddccontrol.desktop.in.h:2
-msgid "Set your monitor preferences (contrast, brightness,...) and manage your profiles"
-msgstr "Изменить параметры работы монитора (контраст, яркость, температура цвета) и переключиться между заводскими предустановками"
+#: ../src/gddccontrol/gddccontrol.desktop.in.h:3
+msgid ""
+"Set your monitor preferences (contrast, brightness,...) and manage your "
+"profiles"
+msgstr ""
+"Изменить параметры работы монитора (контраст, яркость, температура цвета) и "
+"переключиться между заводскими предустановками"
 
-#: ../src/gddccontrol/gprofile.c:53
+#: ../src/gddccontrol/gprofile.c:54
 msgid "You must select at least one control to be saved in the profile."
 msgstr "Вы должны выбрать хотя бы один регистр для сохранения в профиле."
 
-#: ../src/gddccontrol/gprofile.c:61
+#: ../src/gddccontrol/gprofile.c:62
 msgid "Creating profile..."
 msgstr "Создается профиль..."
 
-#: ../src/gddccontrol/gprofile.c:76
+#: ../src/gddccontrol/gprofile.c:77
 msgid "Error while creating profile."
 msgstr "Ошибка при создании профиля"
 
-#: ../src/gddccontrol/gprofile.c:93
+#: ../src/gddccontrol/gprofile.c:94
 msgid "Applying profile..."
 msgstr "Применяется профиль..."
 
-#: ../src/gddccontrol/gprofile.c:116
+#: ../src/gddccontrol/gprofile.c:117
 #, c-format
 msgid "Are you sure you want to delete the profile '%s'?"
 msgstr "Вы действительно хотите удалить профиль '%s'?"
 
-#: ../src/gddccontrol/gprofile.c:142
-msgid "Please select the controls you want to save in the profile using the checkboxes to the left of each control."
-msgstr "Выберите регистры, которые хотите сохранить в профиле, отметив нужные слева от каждого регистра."
+#: ../src/gddccontrol/gprofile.c:143
+msgid ""
+"Please select the controls you want to save in the profile using the "
+"checkboxes to the left of each control."
+msgstr ""
+"Выберите регистры, которые хотите сохранить в профиле, отметив нужные слева "
+"от каждого регистра."
 
-#: ../src/gddccontrol/gprofile.c:174
+#: ../src/gddccontrol/gprofile.c:175
 msgid "Profile Manager"
 msgstr "Управление профилями"
 
-#: ../src/gddccontrol/gprofile.c:193
+#: ../src/gddccontrol/gprofile.c:199
 msgid "Apply profile"
 msgstr "Применить профиль"
 
-#: ../src/gddccontrol/gprofile.c:198
+#: ../src/gddccontrol/gprofile.c:208
 msgid "Show profile details / Rename profile"
 msgstr "Показать профиль детально / Переименовать профиль"
 
-#: ../src/gddccontrol/gprofile.c:203
+#: ../src/gddccontrol/gprofile.c:217
 msgid "Delete profile"
 msgstr "Удалить профиль"
 
-#: ../src/gddccontrol/gprofile.c:229
+#: ../src/gddccontrol/gprofile.c:253
 msgid "Create profile"
 msgstr "Создать профиль"
 
-#: ../src/gddccontrol/gprofile.c:235
+#: ../src/gddccontrol/gprofile.c:259
 msgid "Close profile manager"
 msgstr "Закрыть менеждер профилей"
 
-#: ../src/gddccontrol/gprofile.c:299
+#: ../src/gddccontrol/gprofile.c:321
 msgid "Control name"
 msgstr "Имя регистра"
 
-#: ../src/gddccontrol/gprofile.c:310
+#: ../src/gddccontrol/gprofile.c:332
 msgid "Value"
 msgstr "Значение"
 
-#: ../src/gddccontrol/gprofile.c:313
+#: ../src/gddccontrol/gprofile.c:335
 msgid "Address"
 msgstr "Адрес"
 
-#: ../src/gddccontrol/gprofile.c:316
+#: ../src/gddccontrol/gprofile.c:338
 msgid "Raw value"
 msgstr "Необр. значение"
 
-#: ../src/gddccontrol/gprofile.c:434
-#: ../src/gddccontrol/gprofile.c:454
+#: ../src/gddccontrol/gprofile.c:456 ../src/gddccontrol/gprofile.c:476
 msgid "Profile information:"
 msgstr "Информация о профиле:"
 
-#: ../src/gddccontrol/gprofile.c:463
+#: ../src/gddccontrol/gprofile.c:485
 #, c-format
 msgid "File name: %s"
 msgstr "Имя файла: %s"
 
-#: ../src/gddccontrol/gprofile.c:474
+#: ../src/gddccontrol/gprofile.c:496
 msgid "Profile name:"
 msgstr "Имя профиля:"
 
 #. Save
-#: ../src/gddccontrol/gprofile.c:496
+#: ../src/gddccontrol/gprofile.c:518
 msgid "Saving profile..."
 msgstr "Сохраняется профиль..."
 
-#: ../src/gddccontrol/gprofile.c:505
+#: ../src/gddccontrol/gprofile.c:527
 msgid "Error while saving profile."
 msgstr "Ошибка при сохранении профиля."
 
-#: ../src/gddccontrol/main.c:177
+#: ../src/gddccontrol/main.c:204
 #, c-format
 msgid "Monitor changed (%d %d).\n"
 msgstr "Монитор изменился (%d %d).\n"
 
-#: ../src/gddccontrol/main.c:329
+#: ../src/gddccontrol/main.c:356
 msgid "Probing for available monitors..."
 msgstr "Поиск доступных мониторов..."
 
-#: ../src/gddccontrol/main.c:368
+#: ../src/gddccontrol/main.c:385
 msgid ""
 "No monitor supporting DDC/CI available.\n"
 "\n"
-"If your graphics card need it, please check all the required kernel modules are loaded (i2c-dev, and your framebuffer driver)."
+"If your graphics card need it, please check all the required kernel modules "
+"are loaded (i2c-dev, and your framebuffer driver)."
 msgstr ""
 "Не обнаружены мониторы, поддерживающие DDC/CI.\n"
 "\n"
-"Если ваша видеокарта этого требует, проверьте загружены ли все требуемые модули ядра (i2c-dev и драйвер фреймбуфера)."
+"Если ваша видеокарта этого требует, проверьте загружены ли все требуемые "
+"модули ядра (i2c-dev и драйвер фреймбуфера)."
 
-#: ../src/gddccontrol/main.c:420
+#: ../src/gddccontrol/main.c:438
 msgid "Unable to initialize ddcci library, see console for more details.\n"
-msgstr "Не удалось инициализировать библиотеку ddcci; пояснения выведены в консоль.\n"
+msgstr ""
+"Не удалось инициализировать библиотеку ddcci; пояснения выведены в консоль.\n"
 
-#: ../src/gddccontrol/main.c:430
+#: ../src/gddccontrol/main.c:450
 msgid "Monitor settings"
 msgstr "Параметры монитора"
 
-#: ../src/gddccontrol/main.c:454
+#: ../src/gddccontrol/main.c:474
 msgid "Current monitor: "
 msgstr "Текущий монитор: "
 
-#: ../src/gddccontrol/main.c:464
+#: ../src/gddccontrol/main.c:484
 msgid "Refresh monitor list"
 msgstr "Обновить список мониторов"
 
-#: ../src/gddccontrol/main.c:481
+#: ../src/gddccontrol/main.c:507
 msgid "Profile manager"
 msgstr "Управление профилями"
 
-#: ../src/gddccontrol/main.c:488
+#: ../src/gddccontrol/main.c:514
 msgid "Save profile"
 msgstr "Сохранить профиль"
 
-#: ../src/gddccontrol/main.c:494
+#: ../src/gddccontrol/main.c:520
 msgid "Cancel profile creation"
 msgstr "Отменить создание профиля"
 
-#: ../src/gddccontrol/main.c:518
+#: ../src/gddccontrol/main.c:549
 msgid "OK"
 msgstr "OK"
 
-#: ../src/gddccontrol/main.c:546
+#: ../src/gddccontrol/main.c:585
 msgid "Refresh"
 msgstr "Обновить"
 
-#: ../src/gddccontrol/main.c:546
+#: ../src/gddccontrol/main.c:585
 msgid "Refresh all controls"
 msgstr "Обновить все регистры"
 
-#: ../src/gddccontrol/main.c:553
+#: ../src/gddccontrol/main.c:592
 msgid "Close"
 msgstr "Закрыть"
 
@@ -668,48 +738,51 @@ msgstr "Закрыть"
 #. gtk_misc_set_alignment(GTK_MISC(moninfo), 0, 0);
 #.
 #. gtk_table_attach(GTK_TABLE(table), moninfo, 0, 1, 1, 2, GTK_FILL_EXPAND, 0, 5, 5);
-#: ../src/gddccontrol/main.c:592
+#: ../src/gddccontrol/main.c:634
 #, c-format
 msgid "Welcome to gddccontrol %s."
 msgstr "Добро пожаловать в gddccontrol %s."
 
-#: ../src/gddccontrol/notebook.c:81
+#: ../src/gddccontrol/notebook.c:83
 msgid "Error while getting value"
 msgstr "Ошибка при получении значения"
 
-#: ../src/gddccontrol/notebook.c:116
-#: ../src/gddccontrol/notebook.c:128
+#: ../src/gddccontrol/notebook.c:118 ../src/gddccontrol/notebook.c:130
 #, c-format
 msgid "Refreshing controls values (%d%%)..."
 msgstr "Обновляются значения регистров (%d%%)..."
 
-#: ../src/gddccontrol/notebook.c:133
+#: ../src/gddccontrol/notebook.c:135
 msgid "Could not get the control_db struct related to a control."
 msgstr "Не могу получить структуру control_db, связанную с регистром."
 
-#: ../src/gddccontrol/notebook.c:493
+#: ../src/gddccontrol/notebook.c:495
 msgid "Show fullscreen patterns"
 msgstr "Показать полноэкранные шаблоны"
 
-#: ../src/gddccontrol/notebook.c:525
+#: ../src/gddccontrol/notebook.c:527
 msgid "Section"
 msgstr "Секция"
 
-#: ../src/gddccontrol/notebook.c:572
+#: ../src/gddccontrol/notebook.c:574
 msgid ""
 "The current monitor is in the database but does not support DDC/CI.\n"
 "\n"
-"This often occurs when you connect the VGA/DVI cable on the wrong input of monitors supporting DDC/CI only on one of its two inputs.\n"
+"This often occurs when you connect the VGA/DVI cable on the wrong input of "
+"monitors supporting DDC/CI only on one of its two inputs.\n"
 "\n"
-"If your monitor has two inputs, please try to connect the cable to the other input, and then click on the refresh button near the monitor list."
+"If your monitor has two inputs, please try to connect the cable to the other "
+"input, and then click on the refresh button near the monitor list."
 msgstr ""
 "Этот монитор есть в базе данных, но не поддерживает DDC/CI.\n"
 "\n"
-"Это часто происходит при подключении кабеля VGA/DVI к не тому входу монитора, поддерживающего DDC/CI только по одному из двух входов.\n"
+"Это часто происходит при подключении кабеля VGA/DVI к не тому входу "
+"монитора, поддерживающего DDC/CI только по одному из двух входов.\n"
 "\n"
-"Если у вашего монитора два входа, попробуйте подключить кабель к другому входу и нажмите кнопку обновления возле списка мониторов."
+"Если у вашего монитора два входа, попробуйте подключить кабель к другому "
+"входу и нажмите кнопку обновления возле списка мониторов."
 
-#: ../src/gddccontrol/notebook.c:583
+#: ../src/gddccontrol/notebook.c:585
 #, c-format
 msgid "Opening the monitor device (%s)..."
 msgstr "Открывается устройство монитора (%s)..."
@@ -717,572 +790,587 @@ msgstr "Открывается устройство монитора (%s)..."
 #: ../src/gddccontrol/notebook.c:591
 msgid ""
 "An error occurred while opening the monitor device.\n"
-"Maybe this monitor was disconnected, please click on the refresh button near the monitor list."
+"Maybe this monitor was disconnected, please click on the refresh button near "
+"the monitor list."
 msgstr ""
 "Произошла ошибка при открывании устройства монитора.\n"
-"Возможно, монитор был отключён, пожалуйста, нажмите на кнопку обновления рядом со списком мониторов."
+"Возможно, монитор был отключён, пожалуйста, нажмите на кнопку обновления "
+"рядом со списком мониторов."
 
 #: ../src/gddccontrol/notebook.c:600
 #, c-format
 msgid ""
-"The current monitor is not supported, please run\n"
-"%s\n"
-"and send the output to ddccontrol-users@lists.sourceforge.net.\n"
-"Thanks."
+"Unsupported monitor detected.\n"
+"\n"
+"Please update ddccontrol-db, or, if you are already using the latest\n"
+"version, please open a github issue:\n"
+"https://github.com/ddccontrol/ddccontrol-db/issues/new?template=unsupported-"
+"monitor.yml\n"
+"Then attach the resulting report file of the following command:"
 msgstr ""
 
-#: ../src/gddccontrol/notebook.c:620
+#: ../src/gddccontrol/notebook.c:622
 msgid "Please click on a group name."
 msgstr "Щёлкните имя группы."
 
-#: ../src/gddccontrol/notebook.c:639
-#: ../src/gddccontrol/notebook.c:650
+#: ../src/gddccontrol/notebook.c:647 ../src/gddccontrol/notebook.c:658
 #, c-format
 msgid "Getting controls values (%d%%)..."
 msgstr "Получаются значения регистров (%d%%)..."
 
-#: ../src/gddccontrol/notebook.c:664
+#: ../src/gddccontrol/notebook.c:683
 msgid "Loading profiles..."
 msgstr "Загружаются профили..."
 
-#: ../src/gddccontrol/notebook.c:677
-msgid "There is no support for your monitor in the database, but ddccontrol is using a generic profile for your monitor's manufacturer. Some controls may not be supported, or may not work as expected.\n"
+#: ../src/gddccontrol/notebook.c:696
+msgid ""
+"There is no support for your monitor in the database, but ddccontrol is "
+"using a generic profile for your monitor's manufacturer. Some controls may "
+"not be supported, or may not work as expected.\n"
 msgstr ""
 
-#: ../src/gddccontrol/notebook.c:683
-msgid "There is no support for your monitor in the database, but ddccontrol is using a basic generic profile. Many controls will not be supported, and some controls may not work as expected.\n"
+#: ../src/gddccontrol/notebook.c:702
+msgid ""
+"There is no support for your monitor in the database, but ddccontrol is "
+"using a basic generic profile. Many controls will not be supported, and some "
+"controls may not work as expected.\n"
 msgstr ""
 
-#: ../src/gddccontrol/notebook.c:688
+#: ../src/gddccontrol/notebook.c:707
 msgid "Warning!"
 msgstr "Предупреждение!"
 
-#: ../src/gddccontrol/notebook.c:690
-msgid "Please update ddccontrol-db, or, if you are already using the latest version, please send the output of the following command to ddccontrol-users@lists.sourceforge.net:\n"
-msgstr ""
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.server.in.in.h:1
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:184
-msgid "Monitor Profile Switcher"
-msgstr "Переключатель профилей монитора"
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.server.in.in.h:2
-msgid "Quickly switch monitor profiles created with gddccontrol"
-msgstr ""
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.xml.h:1
-msgid "_About..."
-msgstr "_О программе..."
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.xml.h:2
-msgid "_Properties..."
-msgstr "_Свойства..."
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.xml.h:3
-msgid "_Run gddccontrol..."
-msgstr "_Запустить gddcontrol..."
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:189
+#: ../src/gddccontrol/notebook.c:709
 msgid ""
-"An applet for quick switching of monitor profiles.\n"
-"Based on libddccontrol and part of the ddccontrol project.\n"
-"(http://ddccontrol.sourceforge.net)"
+"Unsupported monitor detected.\n"
+"\n"
+"Please update ddccontrol-db, or, if you are already using the latest\n"
+"version, please open a github issue:\n"
+"https://github.com/ddccontrol/ddccontrol-db/issues/new?template=unsupported-"
+"monitor.yml\n"
+"Then attach the resulting report file of the following command:\n"
 msgstr ""
-"Апплет для быстрого переключения профилей монитора.\n"
-"Работает на основе libddccontrol и является частью проекта ddccontrol.\n"
-"(http://ddccontrol.sourceforge.net)"
 
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:386
-msgid "Unable to initialize ddcci library"
-msgstr "Не удалось инициализировать библиотеку ddcci"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:390
-msgid "No monitor configuration found. Please run gddccontrol first"
-msgstr "Не найдена конфигурация мониторов. Запустите сначала gddccontrol"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:395
-msgid "An error occurred while opening the monitor device"
-msgstr "Произошла ошибка при открытии устройства монитора"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:400
-msgid "Can't find any profiles"
-msgstr "Не удалось найти ни один профиль"
-
-#. only reached, if init was not finished
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:416
-msgid "error"
-msgstr "ошибка"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:440
-msgid "Monitor:"
-msgstr "Монитор:"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:443
-msgid "Monitor Profile Switcher Properties"
-msgstr "Свойства переключателя профилей монитора"
-
-#: ../src/lib/conf.c:61
-#: ../src/lib/conf.c:258
-#: ../src/lib/conf.c:308
-#: ../src/lib/ddcci.c:1202
+#: ../src/lib/conf.c:63 ../src/lib/conf.c:260 ../src/lib/conf.c:310
+#: ../src/lib/ddcci.c:1306
 msgid "Cannot create filename (buffer too small)\n"
 msgstr "Не удалось создать имя файла (буфер слишком мал)\n"
 
-#: ../src/lib/conf.c:86
-#: ../src/lib/conf.c:363
-#: ../src/lib/monitor_db.c:350
-#: ../src/lib/monitor_db.c:714
+#: ../src/lib/conf.c:88 ../src/lib/conf.c:367 ../src/lib/monitor_db.c:353
+#: ../src/lib/monitor_db.c:726
 #, c-format
 msgid "Document not parsed successfully.\n"
 msgstr "Не удалось разобрать документ.\n"
 
-#: ../src/lib/conf.c:93
-#: ../src/lib/conf.c:370
+#: ../src/lib/conf.c:95 ../src/lib/conf.c:375
 #, c-format
 msgid "empty profile file\n"
 msgstr "пустой файл профиля\n"
 
-#: ../src/lib/conf.c:99
-#: ../src/lib/conf.c:376
+#: ../src/lib/conf.c:101 ../src/lib/conf.c:382
 #, c-format
 msgid "profile of the wrong type, root node %s != profile"
 msgstr "некорректный тип профиля, корень %s != profile"
 
-#: ../src/lib/conf.c:105
+#: ../src/lib/conf.c:107
 msgid "Can't find ddccontrolversion property."
 msgstr "Не удалось найти свойство ddccontrolversion."
 
-#: ../src/lib/conf.c:107
+#: ../src/lib/conf.c:109
 #, c-format
 msgid "ddccontrol has been upgraded since monitorlist was saved (%s vs %s).\n"
-msgstr "ddccontrol был обновлён с момента последнего сохранения списка мониторов (%s vs %s).\n"
+msgstr ""
+"ddccontrol был обновлён с момента последнего сохранения списка мониторов (%s "
+"vs %s).\n"
 
-#: ../src/lib/conf.c:124
+#: ../src/lib/conf.c:126
 msgid "Can't find filename property."
 msgstr "Не удалось найти свойство filename."
 
-#: ../src/lib/conf.c:130
+#: ../src/lib/conf.c:132
 msgid "Can't find supported property."
 msgstr "Не удалось найти поддерживаемое свойство."
 
-#: ../src/lib/conf.c:133
+#: ../src/lib/conf.c:135
 msgid "Can't convert supported property to int."
 msgstr "Не удалось преобразовать поддерживаемое свойство в int."
 
-#: ../src/lib/conf.c:138
-#: ../src/lib/conf.c:385
-#: ../src/lib/monitor_db.c:90
-#: ../src/lib/monitor_db.c:194
-#: ../src/lib/monitor_db.c:370
-#: ../src/lib/monitor_db.c:426
-#: ../src/lib/monitor_db.c:447
+#: ../src/lib/conf.c:140 ../src/lib/conf.c:392 ../src/lib/monitor_db.c:92
+#: ../src/lib/monitor_db.c:196 ../src/lib/monitor_db.c:373
+#: ../src/lib/monitor_db.c:429 ../src/lib/monitor_db.c:450
 msgid "Can't find name property."
 msgstr "Не удалось найти элемент name."
 
-#: ../src/lib/conf.c:144
+#: ../src/lib/conf.c:146
 msgid "Can't find digital property."
 msgstr "Не удалось найти цифровое свойство."
 
-#: ../src/lib/conf.c:147
+#: ../src/lib/conf.c:149
 msgid "Can't convert digital property to int."
 msgstr "Не удалось преобразовать цифровое свойство в int."
 
-#: ../src/lib/conf.c:175
-#: ../src/lib/conf.c:439
+#: ../src/lib/conf.c:177 ../src/lib/conf.c:447
 msgid "Cannot create the xml writer\n"
 msgstr "Не удалось создать модуль записи xml\n"
 
-#: ../src/lib/conf.c:239
+#: ../src/lib/conf.c:241
 msgid "Cannot read control value\n"
 msgstr "Не удалось прочесть значение регистра\n"
 
-#: ../src/lib/conf.c:276
+#: ../src/lib/conf.c:278
 msgid "Cannot write control value\n"
 msgstr "Не удалось записать значение регистра\n"
 
-#: ../src/lib/conf.c:313
+#: ../src/lib/conf.c:315
 msgid "Error while opening ddccontrol home directory."
 msgstr "Ошибка при открытии домашнего каталога ddccontrol."
 
-#: ../src/lib/conf.c:337
+#: ../src/lib/conf.c:340
 msgid "Error while reading ddccontrol home directory."
 msgstr "Ошибка при чтении домашнего каталога ddccontrol."
 
-#: ../src/lib/conf.c:382
+#: ../src/lib/conf.c:389
 msgid "Can't find pnpid property."
 msgstr "Не удалось найти свойство pnpid."
 
-#: ../src/lib/conf.c:388
-#: ../src/lib/conf.c:391
+#: ../src/lib/conf.c:395 ../src/lib/conf.c:398
 msgid "Can't find version property."
 msgstr "Не удалось найти свойство version."
 
-#: ../src/lib/conf.c:390
-#: ../src/lib/monitor_db.c:752
+#: ../src/lib/conf.c:397 ../src/lib/monitor_db.c:764
 msgid "Can't convert version to int."
 msgstr "Не удалось преобразовать версию в int"
 
-#: ../src/lib/conf.c:393
+#: ../src/lib/conf.c:400
 #, c-format
 msgid "profile version (%d) is not supported (should be %d).\n"
 msgstr "профиль version (%d) не поддерживается (должно быть %d).\n"
 
-#: ../src/lib/conf.c:407
-#: ../src/lib/monitor_db.c:229
+#: ../src/lib/conf.c:415 ../src/lib/monitor_db.c:233
 msgid "Can't find address property."
 msgstr "Не удалось найти элемент address."
 
-#: ../src/lib/conf.c:409
-#: ../src/lib/monitor_db.c:231
+#: ../src/lib/conf.c:417 ../src/lib/monitor_db.c:235
 msgid "Can't convert address to int."
 msgstr "Не удалось преобразовать адрес в int."
 
-#: ../src/lib/conf.c:413
-#: ../src/lib/monitor_db.c:112
+#: ../src/lib/conf.c:421 ../src/lib/monitor_db.c:114
 msgid "Can't find value property."
 msgstr "Не удалось найти элемент value."
 
-#: ../src/lib/conf.c:415
-#: ../src/lib/monitor_db.c:114
+#: ../src/lib/conf.c:423 ../src/lib/monitor_db.c:116
 msgid "Can't convert value to int."
 msgstr "Не удалось преобразовать значение в int."
 
-#: ../src/lib/conf.c:499
+#: ../src/lib/conf.c:507
 msgid "ddcci_delete_profile: Error, cannot delete profile.\n"
 msgstr "ddcci_delete_profile: Ошибка, не удалось удалить профиль.\n"
 
-#: ../src/lib/conf.c:519
+#: ../src/lib/conf.c:527
 #, c-format
 msgid "ddcci_delete_profile: Error, could not find the profile to delete.\n"
-msgstr "ddcci_delete_profile: Ошибка, не удалось найти этот удаляемый профиль.\n"
+msgstr ""
+"ddcci_delete_profile: Ошибка, не удалось найти этот удаляемый профиль.\n"
 
-#: ../src/lib/ddcci.c:146
+#: ../src/lib/ddcci.c:148
 msgid "Error while initialisating the message queue"
 msgstr "Ошибка при инициализации очереди сообщений"
 
-#: ../src/lib/ddcci.c:175
+#: ../src/lib/ddcci.c:177
 msgid "Error while sending quit message"
 msgstr "Ошибка при отправке сообщения о выходе"
 
-#: ../src/lib/ddcci.c:221
+#: ../src/lib/ddcci.c:223
 msgid "Error while sending heartbeat message"
 msgstr "Ошибка при отправке очередного сообщения"
 
-#: ../src/lib/ddcci.c:239
+#: ../src/lib/ddcci.c:241
 #, c-format
 msgid "Failed to initialize ddccontrol database...\n"
 msgstr "Не удалось инициализировать базу данных ddccontrol...\n"
 
-#: ../src/lib/ddcci.c:275
-#: ../src/lib/ddcci.c:350
+#: ../src/lib/ddcci.c:247
+#, fuzzy, c-format
+msgid "Failed to initialize ADL...\n"
+msgstr "Не удалось инициализировать базу данных ddccontrol...\n"
+
+#: ../src/lib/ddcci.c:292 ../src/lib/ddcci.c:383
 #, c-format
 msgid "ioctl returned %d\n"
 msgstr "ioctl вернул %d\n"
 
-#: ../src/lib/ddcci.c:300
+#: ../src/lib/ddcci.c:321
 msgid "Error while sending write message"
 msgstr "Ошибка при отправке сообщения записи"
 
-#: ../src/lib/ddcci.c:309
+#: ../src/lib/ddcci.c:330
 msgid "Error while reading write message answer"
 msgstr "Ошибка при получении ответа на сообщение записи"
 
-#: ../src/lib/ddcci.c:376
+#: ../src/lib/ddcci.c:413
 msgid "Error while sending read message"
 msgstr "Ошибка при отправке сообщения чтения"
 
-#: ../src/lib/ddcci.c:385
+#: ../src/lib/ddcci.c:422
 msgid "Error while reading read message answer"
 msgstr "Ошибка при получении ответа на сообщение чтения"
 
-#: ../src/lib/ddcci.c:475
+#: ../src/lib/ddcci.c:518
 #, c-format
 msgid "Invalid response, first byte is 0x%02x, should be 0x%02x\n"
 msgstr "Неправильный ответ, первый байт 0x%02x, должен быть 0x%02x\n"
 
-#: ../src/lib/ddcci.c:485
+#: ../src/lib/ddcci.c:528
 #, c-format
 msgid "Non-fatal error: Invalid response, magic is 0x%02x\n"
 msgstr "Некритичная ошибка: неправильный ответ, код 0x%02x\n"
 
-#: ../src/lib/ddcci.c:492
+#: ../src/lib/ddcci.c:535
 #, c-format
 msgid "Invalid response, length is %d, should be %d at most\n"
 msgstr "Неправильный ответ, длина %d, должна быть не менее %d\n"
 
-#: ../src/lib/ddcci.c:505
+#: ../src/lib/ddcci.c:548
 #, c-format
 msgid "Invalid response, corrupted data - xor is 0x%02x, length 0x%02x\n"
-msgstr "Неправильный ответ, разрушенные данные - xor равен 0x%02x, длина 0x%02x\n"
+msgstr ""
+"Неправильный ответ, разрушенные данные - xor равен 0x%02x, длина 0x%02x\n"
 
-#: ../src/lib/ddcci.c:658
-#: ../src/lib/ddcci.c:680
+#: ../src/lib/ddcci.c:709 ../src/lib/ddcci.c:731
 #, fuzzy, c-format
 msgid "Can't convert value to int, invalid CAPS (buf=%s, pos=%d).\n"
 msgstr "Не могу преобразовать значение в int, неверный заголовок."
 
-#: ../src/lib/ddcci.c:763
+#: ../src/lib/ddcci.c:814
 #, c-format
 msgid "Invalid sequence in caps.\n"
 msgstr "Неправильная последовательность в заголовках.\n"
 
-#: ../src/lib/ddcci.c:841
+#: ../src/lib/ddcci.c:892
 #, c-format
 msgid "Corrupted EDID at 0x%02x.\n"
 msgstr "Разрушен EDID в 0x%02x.\n"
 
-#: ../src/lib/ddcci.c:853
+#: ../src/lib/ddcci.c:904
 #, c-format
 msgid "Serial number: %d\n"
 msgstr "Серийный номер: %d\n"
 
-#: ../src/lib/ddcci.c:856
+#: ../src/lib/ddcci.c:907
 #, c-format
 msgid "Manufactured: Week %d, %d\n"
 msgstr "Произведён: %d неделя, %d\n"
 
-#: ../src/lib/ddcci.c:859
+#: ../src/lib/ddcci.c:910
 #, c-format
 msgid "EDID version: %d.%d\n"
 msgstr "Версия EDID: %d.%d\n"
 
-#: ../src/lib/ddcci.c:862
+#: ../src/lib/ddcci.c:913
 #, c-format
 msgid "Maximum size: %d x %d (cm)\n"
 msgstr "Максимальный размер: %d x %d (см)\n"
 
-#: ../src/lib/ddcci.c:873
+#: ../src/lib/ddcci.c:924
 #, c-format
 msgid "Reading EDID 0x%02x failed.\n"
 msgstr "Ошибка чтения EDID 0x%02x.\n"
 
-#: ../src/lib/ddcci.c:903
+#: ../src/lib/ddcci.c:954
 #, c-format
 msgid "Device: %s\n"
 msgstr "Устройство: %s\n"
 
-#: ../src/lib/ddcci.c:917
+#: ../src/lib/ddcci.c:968
 msgid "Error while sending open message"
 msgstr "Ошибка при отправке сообщения открытия"
 
-#: ../src/lib/ddcci.c:925
+#: ../src/lib/ddcci.c:976
 msgid "Error while reading open message answer"
 msgstr "Ошибка при получении ответа на сообщение открытия"
 
-#: ../src/lib/ddcci.c:933
+#: ../src/lib/ddcci.c:988 ../src/lib/ddcci.c:1001
 #, c-format
 msgid "Invalid filename (%s).\n"
 msgstr "Неправильное имя файла (%s).\n"
 
-#: ../src/lib/ddcci.c:1049
+#: ../src/lib/ddcci.c:993
+#, c-format
+msgid "ADL display not found (%s).\n"
+msgstr ""
+
+#: ../src/lib/ddcci.c:1125
 #, c-format
 msgid "ddcci_open returned %d\n"
 msgstr "ddcci_open вернул %d\n"
 
-#: ../src/lib/ddcci.c:1062
+#: ../src/lib/ddcci.c:1138
 #, c-format
 msgid "Unknown monitor (%s)"
 msgstr "Неизвестный монитор (%s)"
 
-#: ../src/lib/ddcci.c:1083
+#: ../src/lib/ddcci.c:1159
 #, c-format
 msgid "Probing for available monitors"
 msgstr "Поиск доступных мониторов"
 
-#: ../src/lib/ddcci.c:1097
+#: ../src/lib/ddcci.c:1173
 msgid "Error while sending list message"
 msgstr "Ошибка при отправке сообщения списка"
 
-#: ../src/lib/ddcci.c:1106
+#: ../src/lib/ddcci.c:1182
 msgid "Error while reading list entry"
 msgstr "Ошибка при чтении элемента списка"
 
-#: ../src/lib/ddcci.c:1123
+#: ../src/lib/ddcci.c:1199
 #, c-format
 msgid "Found PCI device (%s)\n"
 msgstr "Найдено устройство PCI (%s)\n"
 
-#: ../src/lib/ddcci.c:1157
+#: ../src/lib/ddcci.c:1239
 #, c-format
 msgid "Found I2C device (%s)\n"
 msgstr "Найдено устройство I2C (%s)\n"
 
-#: ../src/lib/ddcci.c:1206
+#: ../src/lib/ddcci.c:1264
+#, fuzzy, c-format
+msgid "Found ADL display (%s)\n"
+msgstr "Найдено устройство PCI (%s)\n"
+
+#: ../src/lib/ddcci.c:1310
 msgid "Error while getting information about ddccontrol home directory."
 msgstr "Ошибка при получении информации о домашнем каталоге ddccontrol."
 
-#: ../src/lib/ddcci.c:1211
+#: ../src/lib/ddcci.c:1316
 msgid "Error while creating ddccontrol home directory."
 msgstr "Ошибка при создании домашнего каталога ddccontrol."
 
-#: ../src/lib/ddcci.c:1216
-msgid "Error while getting information about ddccontrol home directory after creating it."
-msgstr "Ошибка при при получении информации о домашнем каталоге ddccontrol после его создания."
+#: ../src/lib/ddcci.c:1322
+msgid ""
+"Error while getting information about ddccontrol home directory after "
+"creating it."
+msgstr ""
+"Ошибка при при получении информации о домашнем каталоге ddccontrol после его "
+"создания."
 
-#: ../src/lib/ddcci.c:1223
+#: ../src/lib/ddcci.c:1330
 msgid "Error: '.ddccontrol' in your home directory is not a directory."
 msgstr "Ошибка: '.ddccontrol' в Вашем домашнем каталоге не является каталогом."
 
-#: ../src/lib/ddcci.c:1231
+#: ../src/lib/ddcci.c:1339
 msgid "Error while getting information about ddccontrol profile directory."
 msgstr "Ошибка при получении информации о каталоге профилей ddccontrol."
 
-#: ../src/lib/ddcci.c:1236
+#: ../src/lib/ddcci.c:1345
 msgid "Error while creating ddccontrol profile directory."
 msgstr "Ошибка при создании каталога профилей ddccontrol."
 
-#: ../src/lib/ddcci.c:1241
-msgid "Error while getting information about ddccontrol profile directory after creating it."
-msgstr "Ошибка при при получении информации о каталоге профилей ddccontrol после его создания."
+#: ../src/lib/ddcci.c:1351
+msgid ""
+"Error while getting information about ddccontrol profile directory after "
+"creating it."
+msgstr ""
+"Ошибка при при получении информации о каталоге профилей ddccontrol после его "
+"создания."
 
-#: ../src/lib/ddcci.c:1248
-msgid "Error: '.ddccontrol/profiles' in your home directory is not a directory."
-msgstr "Ошибка: '.ddccontrol/profiles' в Вашем домашнем каталоге не является каталогом."
+#: ../src/lib/ddcci.c:1359
+msgid ""
+"Error: '.ddccontrol/profiles' in your home directory is not a directory."
+msgstr ""
+"Ошибка: '.ddccontrol/profiles' в Вашем домашнем каталоге не является "
+"каталогом."
 
-#: ../src/lib/monitor_db.c:82
-#: ../src/lib/monitor_db.c:192
+#: ../src/lib/monitor_db.c:84 ../src/lib/monitor_db.c:194
 msgid "Can't find id property."
 msgstr "Не удалось найти элемент id."
 
-#: ../src/lib/monitor_db.c:151
-#: ../src/lib/monitor_db.c:546
+#: ../src/lib/monitor_db.c:153 ../src/lib/monitor_db.c:549
 #, c-format
 msgid "Element %s (id=%s) has not been found (line %ld).\n"
 msgstr "Элемент %s (id=%s) не найден (строка %ld).\n"
 
-#: ../src/lib/monitor_db.c:205
+#: ../src/lib/monitor_db.c:207
 msgid "Invalid refresh type (!= none, != all)."
 msgstr "Неверный тип обновления (!= none, != all)."
 
-#: ../src/lib/monitor_db.c:238
+#: ../src/lib/monitor_db.c:242
 #, c-format
 msgid "Control %s has been discarded by the caps string.\n"
 msgstr "Управление %s отключено согласно строке заголовка.\n"
 
-#: ../src/lib/monitor_db.c:246
+#: ../src/lib/monitor_db.c:250
 #, c-format
 msgid "Control %s (0x%02x) has already been defined.\n"
 msgstr "Регистр %s (0x%02x) уже определен.\n"
 
-#: ../src/lib/monitor_db.c:259
+#: ../src/lib/monitor_db.c:263
 msgid "Can't convert delay to int."
 msgstr "Не удалось преобразовать задержку в int."
 
-#: ../src/lib/monitor_db.c:267
+#: ../src/lib/monitor_db.c:271
 msgid "Can't find type property."
 msgstr "Не удалось найти элемент type."
 
-#: ../src/lib/monitor_db.c:292
-#: ../src/lib/monitor_db.c:381
+#: ../src/lib/monitor_db.c:296 ../src/lib/monitor_db.c:384
 msgid "Invalid type."
 msgstr "Неверный тип."
 
-#: ../src/lib/monitor_db.c:343
+#: ../src/lib/monitor_db.c:346
 #, c-format
 msgid "Database must be inited before reading a monitor file.\n"
 msgstr "База данных должна быть инициализирована до чтения файла монитора.\n"
 
-#: ../src/lib/monitor_db.c:357
+#: ../src/lib/monitor_db.c:360
 #, c-format
 msgid "empty monitor/%s.xml\n"
 msgstr "Пустой файл monitor/%s.xml\n"
 
-#: ../src/lib/monitor_db.c:363
+#: ../src/lib/monitor_db.c:366
 #, c-format
 msgid "monitor/%s.xml of the wrong type, root node %s != monitor"
 msgstr "monitor/%s.xml неверного типа, root node %s != monitor"
 
-#: ../src/lib/monitor_db.c:464
+#: ../src/lib/monitor_db.c:467
 #, fuzzy
 msgid "Can't find add or remove property in caps."
 msgstr "Не могу найти элемент address."
 
-#: ../src/lib/monitor_db.c:466
+#: ../src/lib/monitor_db.c:469
 #, fuzzy
 msgid "Invalid remove caps."
 msgstr "Неправльная последовательность в заголовках.\n"
 
-#: ../src/lib/monitor_db.c:468
+#: ../src/lib/monitor_db.c:471
 #, fuzzy
 msgid "Invalid add caps."
 msgstr "Неверный тип."
 
-#: ../src/lib/monitor_db.c:473
+#: ../src/lib/monitor_db.c:476
 #, c-format
 msgid "Error, include recursion level > 15 (file: %s).\n"
 msgstr "Ошибка, найдена глубина рекурсии > 15 (файл: %s).\n"
 
-#: ../src/lib/monitor_db.c:479
+#: ../src/lib/monitor_db.c:482
 msgid "Can't find file property."
 msgstr "Не удалось найти свойство file."
 
-#: ../src/lib/monitor_db.c:487
+#: ../src/lib/monitor_db.c:490
 msgid "Two controls part in XML file."
 msgstr ""
 
-#: ../src/lib/monitor_db.c:534
+#: ../src/lib/monitor_db.c:537
 msgid "Error enumerating controls in subgroup."
 msgstr "Ошибка при перечислении регистров в подгруппе."
 
-#: ../src/lib/monitor_db.c:589
+#: ../src/lib/monitor_db.c:601
 #, c-format
 msgid "document of the wrong type, can't find controls or include.\n"
 msgstr "Документ неправильного типа, не удалось найти регистры.\n"
 
-#: ../src/lib/monitor_db.c:721
+#: ../src/lib/monitor_db.c:733
 #, c-format
 msgid "empty options.xml\n"
 msgstr "пустой options.xml\n"
 
-#: ../src/lib/monitor_db.c:728
+#: ../src/lib/monitor_db.c:740
 #, c-format
 msgid "options.xml of the wrong type, root node %s != options"
 msgstr "options.xml неверного типа, root node %s != options"
 
-#: ../src/lib/monitor_db.c:738
+#: ../src/lib/monitor_db.c:750
 #, c-format
 msgid "options.xml dbversion attribute missing, please update your database.\n"
 msgstr "В options.xml отсутствует атрибут dbversion, обновите базу данных.\n"
 
-#: ../src/lib/monitor_db.c:745
+#: ../src/lib/monitor_db.c:757
 #, c-format
 msgid "options.xml date attribute missing, please update your database.\n"
 msgstr "В options.xml отсутствует атрибут date, обновите базу данных.\n"
 
-#: ../src/lib/monitor_db.c:755
+#: ../src/lib/monitor_db.c:767
 #, c-format
-msgid "options.xml dbversion (%d) is greater than the supported version (%d).\n"
+msgid ""
+"options.xml dbversion (%d) is greater than the supported version (%d).\n"
 msgstr "В options.xml версия базы данных (%d) больше поддерживаемой (%d).\n"
 
-#: ../src/lib/monitor_db.c:756
+#: ../src/lib/monitor_db.c:768
 #, c-format
 msgid "Please update ddccontrol program.\n"
 msgstr "Обновите программу ddccontrol.\n"
 
-#: ../src/lib/monitor_db.c:763
+#: ../src/lib/monitor_db.c:775
 #, c-format
 msgid "options.xml dbversion (%d) is less than the supported version (%d).\n"
 msgstr "В options.xml версия базы данных (%d) меньше поддерживаемой (%d).\n"
 
-#: ../src/lib/monitor_db.c:764
+#: ../src/lib/monitor_db.c:776
 #, c-format
 msgid "Please update ddccontrol database.\n"
 msgstr "Обновите базу данных ddccontrol.\n"
 
+#~ msgid "Monitor Profile Switcher"
+#~ msgstr "Переключатель профилей монитора"
+
+#~ msgid "_About..."
+#~ msgstr "_О программе..."
+
+#~ msgid "_Properties..."
+#~ msgstr "_Свойства..."
+
+#~ msgid "_Run gddccontrol..."
+#~ msgstr "_Запустить gddcontrol..."
+
+#~ msgid ""
+#~ "An applet for quick switching of monitor profiles.\n"
+#~ "Based on libddccontrol and part of the ddccontrol project.\n"
+#~ "(http://ddccontrol.sourceforge.net)"
+#~ msgstr ""
+#~ "Апплет для быстрого переключения профилей монитора.\n"
+#~ "Работает на основе libddccontrol и является частью проекта ddccontrol.\n"
+#~ "(http://ddccontrol.sourceforge.net)"
+
+#~ msgid "Unable to initialize ddcci library"
+#~ msgstr "Не удалось инициализировать библиотеку ddcci"
+
+#~ msgid "No monitor configuration found. Please run gddccontrol first"
+#~ msgstr "Не найдена конфигурация мониторов. Запустите сначала gddccontrol"
+
+#~ msgid "An error occurred while opening the monitor device"
+#~ msgstr "Произошла ошибка при открытии устройства монитора"
+
+#~ msgid "Can't find any profiles"
+#~ msgstr "Не удалось найти ни один профиль"
+
+#~ msgid "error"
+#~ msgstr "ошибка"
+
+#~ msgid "Monitor:"
+#~ msgstr "Монитор:"
+
+#~ msgid "Monitor Profile Switcher Properties"
+#~ msgstr "Свойства переключателя профилей монитора"
+
 #~ msgid "Buffer too small to contain caps.\n"
 #~ msgstr "Буфер слишком маленький для хранения заголовков.\n"
+
 #~ msgid "Can't find init property."
 #~ msgstr "Не могу найти свойство init."
+
 #~ msgid "i740"
 #~ msgstr "i740"
+
 #~ msgid "intel740_open"
 #~ msgstr "intel740_open"
+
 #~ msgid "Xinerama supported and active\n"
 #~ msgstr "Xinerama поддерживается и активна\n"
+
 #~ msgid "Display %d: %d, %d, %d, %d, %d\n"
 #~ msgstr "Экран %d: %d, %d, %d, %d, %d\n"
+
 #~ msgid "Xinerama supported but inactive.\n"
 #~ msgstr "Xinerama поддерживается, но неактивна\n"
+
 #~ msgid "Xinerama not supported\n"
 #~ msgstr "Xinerama не поддерживается\n"
 
@@ -1381,14 +1469,18 @@ msgstr "Обновите базу данных ddccontrol.\n"
 #, fuzzy
 #~ msgid "options"
 #~ msgstr "пустой options.xml\n"
+
 #~ msgid "Error: %s @%s:%d (%s:%ld)\n"
 #~ msgstr "Ошибка: %s @%s:%d (%s:%ld)\n"
+
 #~ msgid "Error: %s @%s:%d\n"
 #~ msgstr "Ошибка: %s @%s:%d\n"
+
 #~ msgid "nvidia_open: Malloc error.\n"
 #~ msgstr "nvidia_open: ошибка malloc.\n"
+
 #~ msgid "Please click on a parameter on the left to change it."
 #~ msgstr "Пожалуйста, щёлкните на параметре слева для его изменения."
+
 #~ msgid "restore_callback should not be called for command controls."
 #~ msgstr "Нежелательно вызывать restore_callback для командных регистров"
-

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -6,35 +6,34 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: DDC/CI control tool cvs version 2005-11-12\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2006-08-29 19:01+0800\n"
+"Report-Msgid-Bugs-To: https://github.com/ddccontrol/ddccontrol/issues/\n"
+"POT-Creation-Date: 2026-05-13 15:12+0200\n"
 "PO-Revision-Date: 2005-11-12 15:50+0800\n"
 "Last-Translator: Wu Songhai waq@21cn.com\n"
 "Language-Team: Simple Chinese <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/ddccontrol/main.c:83 ../src/ddccontrol/main.c:87
-#: ../src/ddccontrol/main.c:91
-msgid "Control"
-msgstr "控制器"
-
-#: ../src/ddccontrol/main.c:132
+#: ../src/ddccontrol/main.c:85
 #, fuzzy, c-format
 msgid ""
 "Usage:\n"
-"%s [-b datadir] [-v] [-c] [-d] [-f] [-s] [-r ctrl [-w value]] [-p | dev]\n"
+"%s [-b datadir] [-v] [-c] [-d] [-f] [-s] [-r ctrl [-w value]] [-l (profile "
+"path)] [-p | dev]\n"
 "\tdev: device, e.g. dev:/dev/i2c-0\n"
 "\t-p : probe I2C devices to find monitor buses\n"
 "\t-c : query capability\n"
 "\t-d : query ctrls 0 - 255\n"
 "\t-r : query ctrl\n"
 "\t-w : value to write to ctrl\n"
+"\t-W : relatively change ctrl value (+/-)\n"
 "\t-f : force (avoid validity checks)\n"
 "\t-s : save settings\n"
 "\t-v : verbosity (specify more to increase)\n"
 "\t-b : ddccontrol-db directory (if other than %s)\n"
+"\t-l : load values from XML profile file\n"
 msgstr ""
 "用法:\n"
 "%s [-b 数据目录] [-v] [-c] [-d] [-f] [-s] [-r 控制器 [-w 值]] [-p | 设备]\n"
@@ -49,22 +48,22 @@ msgstr ""
 "\t-v : 冗长模式 (增加更多详细的说明)\n"
 "\t-b : ddccontrol-db 目录 (如果不是 %s 的话)\n"
 
-#: ../src/ddccontrol/main.c:150 ../src/ddccontrol/main.c:172
+#: ../src/ddccontrol/main.c:106 ../src/ddccontrol/main.c:128
 #, c-format
 msgid "Checking %s integrity...\n"
 msgstr "正在检查 %s 的完整性...\n"
 
-#: ../src/ddccontrol/main.c:152 ../src/ddccontrol/main.c:174
+#: ../src/ddccontrol/main.c:108 ../src/ddccontrol/main.c:130
 #, c-format
 msgid "[ FAILED ]\n"
 msgstr "[ 失败 ]\n"
 
-#: ../src/ddccontrol/main.c:156 ../src/ddccontrol/main.c:179
+#: ../src/ddccontrol/main.c:112 ../src/ddccontrol/main.c:135
 #, c-format
 msgid "[ OK ]\n"
 msgstr "[ 成功 ]\n"
 
-#: ../src/ddccontrol/main.c:217
+#: ../src/ddccontrol/main.c:194
 #, fuzzy, c-format
 msgid ""
 "ddccontrol version %s\n"
@@ -82,73 +81,88 @@ msgstr ""
 "你可以在GNU通用公共许可(GPL)条款下重新发布此程序的拷贝.\n"
 "\n"
 
-#: ../src/ddccontrol/main.c:236
+#: ../src/ddccontrol/main.c:211
 #, c-format
 msgid "'%s' does not seem to be a valid register name\n"
 msgstr "'%s' 不像是一个有效的控制器名\n"
 
-#: ../src/ddccontrol/main.c:242
+#: ../src/ddccontrol/main.c:217
 #, c-format
 msgid "You cannot use -w parameter without -r.\n"
 msgstr "你不能在没有 -r 参数的情况下使用 -w 参数.\n"
 
-#: ../src/ddccontrol/main.c:247
+#: ../src/ddccontrol/main.c:221 ../src/ddccontrol/main.c:231
 #, c-format
 msgid "'%s' does not seem to be a valid value.\n"
 msgstr "'%s' 不像是一个有效的值.\n"
 
-#: ../src/ddccontrol/main.c:292 ../src/gddccontrol/main.c:414
+#: ../src/ddccontrol/main.c:227
+#, fuzzy, c-format
+msgid "You cannot use -W parameter without -r.\n"
+msgstr "你不能在没有 -r 参数的情况下使用 -w 参数.\n"
+
+#: ../src/ddccontrol/main.c:282 ../src/gddccontrol/main.c:432
 #, c-format
 msgid "Unable to initialize ddcci library.\n"
 msgstr "未能初始化ddcci库.\n"
 
-#: ../src/ddccontrol/main.c:304
+#: ../src/ddccontrol/main.c:288
+#, fuzzy, c-format
+msgid "Unable to initialize ddcci db library.\n"
+msgstr "未能初始化ddcci库.\n"
+
+#: ../src/ddccontrol/main.c:293
+#, c-format
+msgid "Failed to open D-Bus proxy, try with DDCCONTROL_NO_DAEMON=1.\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:310
 #, c-format
 msgid "Detected monitors :\n"
 msgstr "检查到的显示器:\n"
 
-#: ../src/ddccontrol/main.c:309
+#: ../src/ddccontrol/main.c:314
 #, c-format
 msgid " - Device: %s\n"
 msgstr " - 设备: %s\n"
 
-#: ../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 #, c-format
 msgid "   DDC/CI supported: %s\n"
 msgstr "   DDC/CI 支持: %s\n"
 
-#: ../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 msgid "Yes"
 msgstr "是"
 
-#: ../src/ddccontrol/main.c:310
+#: ../src/ddccontrol/main.c:315
 msgid "No"
 msgstr "否"
 
-#: ../src/ddccontrol/main.c:311
+#: ../src/ddccontrol/main.c:316
 #, c-format
 msgid "   Monitor Name: %s\n"
 msgstr "   显示器名称: %s\n"
 
-#: ../src/ddccontrol/main.c:312
+#: ../src/ddccontrol/main.c:317
 #, c-format
 msgid "   Input type: %s\n"
 msgstr "   输入类型: %s\n"
 
-#: ../src/ddccontrol/main.c:312 ../src/ddccontrol/main.c:350
+#: ../src/ddccontrol/main.c:317 ../src/ddccontrol/main.c:364
 msgid "Digital"
 msgstr "数字"
 
-#: ../src/ddccontrol/main.c:312 ../src/ddccontrol/main.c:350
+#: ../src/ddccontrol/main.c:317 ../src/ddccontrol/main.c:364
 msgid "Analog"
 msgstr "模拟"
 
-#: ../src/ddccontrol/main.c:316
+#: ../src/ddccontrol/main.c:321
 #, c-format
 msgid "  (Automatically selected)\n"
 msgstr "  (已自动选择)\n"
 
-#: ../src/ddccontrol/main.c:326
+#: ../src/ddccontrol/main.c:333
 #, c-format
 msgid ""
 "No monitor supporting DDC/CI available.\n"
@@ -159,12 +173,12 @@ msgstr ""
 "如果你的图形卡需要它,请检查所有的必需的内核模块已经加载 (i2c-dev, 以及你的 "
 "framebuffer 驱动).\n"
 
-#: ../src/ddccontrol/main.c:339
+#: ../src/ddccontrol/main.c:346
 #, c-format
 msgid "Reading EDID and initializing DDC/CI at bus %s...\n"
 msgstr "正在总线 %s 中读取EDID和初始化DDC/CI...\n"
 
-#: ../src/ddccontrol/main.c:343
+#: ../src/ddccontrol/main.c:357
 #, c-format
 msgid ""
 "\n"
@@ -177,7 +191,7 @@ msgstr ""
 "如果你的图形卡需要它,请检查所有的必需的内核模块已经加载 (i2c-dev, 以及你的 "
 "framebuffer 驱动).\n"
 
-#: ../src/ddccontrol/main.c:347
+#: ../src/ddccontrol/main.c:361
 #, c-format
 msgid ""
 "\n"
@@ -186,51 +200,17 @@ msgstr ""
 "\n"
 "正在读取EDID数据:\n"
 
-#: ../src/ddccontrol/main.c:348
+#: ../src/ddccontrol/main.c:362
 #, c-format
 msgid "\tPlug and Play ID: %s [%s]\n"
 msgstr "\t即插即用ID: %s [%s]\n"
 
-#: ../src/ddccontrol/main.c:350
+#: ../src/ddccontrol/main.c:364
 #, c-format
 msgid "\tInput type: %s\n"
 msgstr "\t输入信号类型: %s\n"
 
-#. Put a big warning (in red if we are writing to a terminal).
-#: ../src/ddccontrol/main.c:354 ../src/ddccontrol/main.c:373
-msgid "=============================== WARNING ==============================="
-msgstr ""
-
-#: ../src/ddccontrol/main.c:357
-#, c-format
-msgid ""
-"There is no support for your monitor in the database, but ddccontrol is\n"
-"using a generic profile for your monitor's manufacturer. Some controls\n"
-"may not be supported, or may not work as expected.\n"
-msgstr ""
-
-#: ../src/ddccontrol/main.c:363
-#, c-format
-msgid ""
-"There is no support for your monitor in the database, but ddccontrol is\n"
-"using a basic generic profile. Many controls will not be supported, and\n"
-"some controls may not work as expected.\n"
-msgstr ""
-
-#: ../src/ddccontrol/main.c:368
-#, c-format
-msgid ""
-"Please update ddccontrol-db, or, if you are already using the latest\n"
-"version, please send the output of the following command to\n"
-"ddccontrol-users@lists.sourceforge.net:\n"
-msgstr ""
-
-#: ../src/ddccontrol/main.c:372 ../src/gddccontrol/notebook.c:695
-#, c-format
-msgid "Thank you.\n"
-msgstr ""
-
-#: ../src/ddccontrol/main.c:377
+#: ../src/ddccontrol/main.c:370
 #, c-format
 msgid ""
 "\n"
@@ -239,42 +219,52 @@ msgstr ""
 "\n"
 "功能:\n"
 
-#: ../src/ddccontrol/main.c:381
+#: ../src/ddccontrol/main.c:374
 #, c-format
 msgid "Raw output: %s\n"
 msgstr ""
 
-#: ../src/ddccontrol/main.c:383
+#: ../src/ddccontrol/main.c:376
 #, c-format
 msgid "Parsed output: \n"
 msgstr ""
 
-#: ../src/ddccontrol/main.c:392
+#: ../src/ddccontrol/main.c:385
 #, c-format
 msgid "\tType: "
 msgstr ""
 
-#: ../src/ddccontrol/main.c:395
+#: ../src/ddccontrol/main.c:388
 #, c-format
 msgid "LCD"
 msgstr ""
 
-#: ../src/ddccontrol/main.c:398
+#: ../src/ddccontrol/main.c:391
 #, c-format
 msgid "CRT"
 msgstr ""
 
-#: ../src/ddccontrol/main.c:401
+#: ../src/ddccontrol/main.c:394
 #, c-format
 msgid "Unknown"
 msgstr ""
 
-#: ../src/ddccontrol/main.c:410
+#: ../src/ddccontrol/main.c:403
 #, c-format
 msgid "Capabilities read fail.\n"
 msgstr "读取功能失败.\n"
 
-#: ../src/ddccontrol/main.c:418
+#: ../src/ddccontrol/main.c:417
+#, c-format
+msgid "Value cannot be lower than zero! %d -> %d\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:420
+#, c-format
+msgid "Value cannot be higher than maximum! %d / %d\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:428
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -283,7 +273,7 @@ msgstr ""
 "\n"
 "正在写 0x%02x, 0x%02x(%d)...\n"
 
-#: ../src/ddccontrol/main.c:422
+#: ../src/ddccontrol/main.c:431
 #, c-format
 msgid ""
 "\n"
@@ -292,7 +282,7 @@ msgstr ""
 "\n"
 "正在写 0x%02x, 0x%02x(%d)...\n"
 
-#: ../src/ddccontrol/main.c:427
+#: ../src/ddccontrol/main.c:436
 #, c-format
 msgid ""
 "\n"
@@ -301,7 +291,17 @@ msgstr ""
 "\n"
 "正在读 0x%02x...\n"
 
-#: ../src/ddccontrol/main.c:434
+#: ../src/ddccontrol/main.c:445
+#, fuzzy, c-format
+msgid "Applied profile: %s\n"
+msgstr "应用预设"
+
+#: ../src/ddccontrol/main.c:447
+#, c-format
+msgid "Failed to apply profile: %s\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:451
 #, c-format
 msgid ""
 "\n"
@@ -310,32 +310,32 @@ msgstr ""
 "\n"
 "控制器    (有效/当前值/最大值) [描述 - 值名]:\n"
 
-#: ../src/ddccontrol/main.c:458
+#: ../src/ddccontrol/main.c:473
 #, c-format
 msgid "\t\t> id=%s, name=%s, address=%#x, delay=%dms, type=%d\n"
 msgstr "\t\t> 标识符=%s, 名字=%s, 地址=%#x, 延迟=%dms, 类型=%d\n"
 
-#: ../src/ddccontrol/main.c:463
+#: ../src/ddccontrol/main.c:478
 #, c-format
 msgid "\t\t  Possible values:\n"
 msgstr "\t\t  可能的值:\n"
 
-#: ../src/ddccontrol/main.c:467
+#: ../src/ddccontrol/main.c:482
 #, c-format
 msgid "\t\t\t> id=%s - name=%s, value=%d\n"
 msgstr "\t\t\t> 标识符=%s - 名字=%s, 值=%d\n"
 
-#: ../src/ddccontrol/main.c:477
+#: ../src/ddccontrol/main.c:492
 #, c-format
 msgid "\t\t  supported, value=%d, maximum=%d\n"
 msgstr "\t\t  已支持, 值=%d, 最大值=%d\n"
 
-#: ../src/ddccontrol/main.c:478
+#: ../src/ddccontrol/main.c:493
 #, c-format
 msgid "\t\t  not supported, value=%d, maximum=%d\n"
 msgstr "\t\t  不支持, 值=%d, 最大值=%d\n"
 
-#: ../src/ddccontrol/main.c:489
+#: ../src/ddccontrol/main.c:504
 #, c-format
 msgid ""
 "\n"
@@ -343,6 +343,46 @@ msgid ""
 msgstr ""
 "\n"
 "正在保存设置...\n"
+
+#. Put a big warning (in red if we are writing to a terminal).
+#: ../src/ddccontrol/main.c:516 ../src/ddccontrol/main.c:537
+msgid "=============================== WARNING ==============================="
+msgstr ""
+
+#: ../src/ddccontrol/main.c:519
+#, c-format
+msgid ""
+"There is no support for your monitor in the database, but ddccontrol is\n"
+"using a generic profile for your monitor's manufacturer. Some controls\n"
+"may not be supported, or may not work as expected.\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:524
+#, c-format
+msgid ""
+"There is no support for your monitor in the database, but ddccontrol is\n"
+"using a basic generic profile. Many controls will not be supported, and\n"
+"some controls may not work as expected.\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:529
+#, c-format
+msgid ""
+"Unsupported monitor detected.\n"
+"\n"
+"Please update ddccontrol-db, or, if you are already using the latest\n"
+"version, please open this pre-filled GitHub issue:\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:534
+#, c-format
+msgid "Then attach the resulting report file of the following command:\n"
+msgstr ""
+
+#: ../src/ddccontrol/main.c:536 ../src/gddccontrol/notebook.c:715
+#, c-format
+msgid "Thank you.\n"
+msgstr ""
 
 #. arbitration or no acknowledge
 #: ../src/ddcpci/i2c-algo-bit.c:368
@@ -361,8 +401,9 @@ msgstr "i2c-algo-bit.o: readbytes: i2c_inb 超时.\n"
 msgid "i2c-algo-bit.o: readbytes: Timeout at ack\n"
 msgstr "i2c-algo-bit.o: readbytes: 确认时超时\n"
 
-#: ../src/ddcpci/intel740.c:103 ../src/ddcpci/intel810.c:161
+#: ../src/ddcpci/intel740.c:103 ../src/ddcpci/intel810.c:162
 #: ../src/ddcpci/nvidia.c:155 ../src/ddcpci/radeon.c:209
+#: ../src/ddcpci/sis.c:174 ../src/ddcpci/via.c:167
 #, c-format
 msgid "%s: Malloc error.\n"
 msgstr "%s: malloc 出错.\n"
@@ -382,61 +423,61 @@ msgstr "%s: 错误: 未知的显卡类型 (%#x)\n"
 msgid "%s: Malloc error."
 msgstr "%s: malloc 出错."
 
-#: ../src/ddcpci/intel810.c:171
+#: ../src/ddcpci/intel810.c:172
 msgid "i810_open: cannot open /dev/mem"
 msgstr "i810_open: 打不开 /dev/mem"
 
-#: ../src/ddcpci/intel810.c:206
+#: ../src/ddcpci/intel810.c:207
 #, c-format
 msgid "i810_open: Error: cannot find any valid MMIO PCI region.\n"
 msgstr "i810_open: 错误 :找不到任何有效的 MMIO　PCI　区域.\n"
 
-#: ../src/ddcpci/intel810.c:213
+#: ../src/ddcpci/intel810.c:214
 msgid "i810_open: mmap failed"
 msgstr "i810_open: mmap 失败"
 
-#: ../src/ddcpci/main.c:154
+#: ../src/ddcpci/main.c:160
 msgid "==>Error while sending open message"
 msgstr "==>发送打开消息时出错"
 
-#: ../src/ddcpci/main.c:178 ../src/ddcpci/main.c:184 ../src/ddcpci/main.c:202
+#: ../src/ddcpci/main.c:184 ../src/ddcpci/main.c:190 ../src/ddcpci/main.c:208
 msgid "==>Error while sending data answer message"
 msgstr "==>发送数据应答消息时出错"
 
-#: ../src/ddcpci/main.c:251 ../src/ddcpci/main.c:266
+#: ../src/ddcpci/main.c:257 ../src/ddcpci/main.c:272
 msgid "==>Error while sending list message"
 msgstr "==>发送列表消息时出错"
 
-#: ../src/ddcpci/main.c:284
+#: ../src/ddcpci/main.c:290
 #, c-format
 msgid "Invalid arguments.\n"
 msgstr "无效的参数.\n"
 
-#: ../src/ddcpci/main.c:290
+#: ../src/ddcpci/main.c:296
 #, c-format
 msgid "==>Can't read verbosity.\n"
 msgstr "==>不能读取详细资料.\n"
 
-#: ../src/ddcpci/main.c:297
+#: ../src/ddcpci/main.c:303
 #, c-format
 msgid "==>Can't read key.\n"
 msgstr "==>不能读取键值.\n"
 
-#: ../src/ddcpci/main.c:302
+#: ../src/ddcpci/main.c:308
 #, c-format
 msgid "==>Can't open key %u\n"
 msgstr "==>打不开键值 %u\n"
 
-#: ../src/ddcpci/main.c:316
+#: ../src/ddcpci/main.c:322
 #, c-format
 msgid "==>No command received for %ld seconds, aborting.\n"
 msgstr "==>在 %ld 秒时间内没收到命令, 中止.\n"
 
-#: ../src/ddcpci/main.c:324
+#: ../src/ddcpci/main.c:330
 msgid "==>Error while receiving query\n"
 msgstr "==>接收查询时出错\n"
 
-#: ../src/ddcpci/main.c:359
+#: ../src/ddcpci/main.c:365
 #, c-format
 msgid "==>Invalid query...\n"
 msgstr "==>无效的查询...\n"
@@ -467,7 +508,27 @@ msgstr "radeon_open: 打不开 /dev/mem"
 msgid "radeon_open: mmap failed"
 msgstr "radeon_open: mmap 失败"
 
-#: ../src/gddccontrol/fspatterns.c:195
+#: ../src/ddcpci/sis.c:133
+#, fuzzy, c-format
+msgid "sis.c:init_i2c_bus: Malloc error."
+msgstr "nvidia.c:init_i2c_bus: malloc 出错."
+
+#: ../src/ddcpci/via.c:125
+#, fuzzy, c-format
+msgid "via.c:init_i2c_bus: Malloc error."
+msgstr "nvidia.c:init_i2c_bus: malloc 出错."
+
+#: ../src/ddcpci/via.c:177
+#, fuzzy
+msgid "via_open: cannot open /dev/mem"
+msgstr "nvidia_open: 打不开 /dev/mem"
+
+#: ../src/ddcpci/via.c:186
+#, fuzzy
+msgid "via_open: mmap failed"
+msgstr "nvidia_open: mmap 失败"
+
+#: ../src/gddccontrol/fspatterns.c:137
 msgid ""
 "Adjust brightness and contrast following these rules:\n"
 " - Black must be as dark as possible.\n"
@@ -479,11 +540,11 @@ msgstr ""
 " - 白色必须尽可能地亮.\n"
 " - 你必须能够辨别每一个灰度级 (特别是 0 和 12).\n"
 
-#: ../src/gddccontrol/fspatterns.c:211
+#: ../src/gddccontrol/fspatterns.c:259
 msgid "Try to make moire patterns disappear."
 msgstr "试图使摩尔纹图案消失."
 
-#: ../src/gddccontrol/fspatterns.c:215
+#: ../src/gddccontrol/fspatterns.c:263
 msgid ""
 "Adjust Image Lock Coarse to make the vertical band disappear.\n"
 "Adjust Image Lock Fine to minimize movement on the screen."
@@ -491,110 +552,125 @@ msgstr ""
 "粗调使垂直区域消失.\n"
 "调节图像锁定细调使屏幕波动最小."
 
-#: ../src/gddccontrol/fspatterns.c:254
+#: ../src/gddccontrol/fspatterns.c:273
 #, c-format
 msgid "Unknown fullscreen pattern name: %s"
 msgstr "未知的全屏图案名字: %s"
 
-#: ../src/gddccontrol/gprofile.c:53
+#: ../src/gddccontrol/gddccontrol.desktop.in.h:1
+#, fuzzy
+msgid "DDC Control"
+msgstr "控制器"
+
+#: ../src/gddccontrol/gddccontrol.desktop.in.h:2
+msgid "Monitor Settings"
+msgstr "显示器的设置"
+
+#: ../src/gddccontrol/gddccontrol.desktop.in.h:3
+msgid ""
+"Set your monitor preferences (contrast, brightness,...) and manage your "
+"profiles"
+msgstr ""
+
+#: ../src/gddccontrol/gprofile.c:54
 msgid "You must select at least one control to be saved in the profile."
 msgstr "你必须至少选择一个控制项来保存到预设文件中."
 
-#: ../src/gddccontrol/gprofile.c:61
+#: ../src/gddccontrol/gprofile.c:62
 msgid "Creating profile..."
 msgstr "正在创建预设文件..."
 
-#: ../src/gddccontrol/gprofile.c:76
+#: ../src/gddccontrol/gprofile.c:77
 msgid "Error while creating profile."
 msgstr "创建预设文件时出错."
 
-#: ../src/gddccontrol/gprofile.c:93
+#: ../src/gddccontrol/gprofile.c:94
 msgid "Applying profile..."
 msgstr "正在应用预设..."
 
-#: ../src/gddccontrol/gprofile.c:116
+#: ../src/gddccontrol/gprofile.c:117
 #, c-format
 msgid "Are you sure you want to delete the profile '%s'?"
 msgstr "你确认要删除预设文件 '%s' 吗?"
 
-#: ../src/gddccontrol/gprofile.c:142
+#: ../src/gddccontrol/gprofile.c:143
 msgid ""
 "Please select the controls you want to save in the profile using the "
 "checkboxes to the left of each control."
 msgstr "请选择你想要保存到预设文件中的控制项, 使用各个控制项前的检查框."
 
-#: ../src/gddccontrol/gprofile.c:174
+#: ../src/gddccontrol/gprofile.c:175
 msgid "Profile Manager"
 msgstr "预设文件管理器"
 
-#: ../src/gddccontrol/gprofile.c:193
+#: ../src/gddccontrol/gprofile.c:199
 msgid "Apply profile"
 msgstr "应用预设"
 
-#: ../src/gddccontrol/gprofile.c:198
+#: ../src/gddccontrol/gprofile.c:208
 msgid "Show profile details / Rename profile"
 msgstr "显示预设文件详细信息/给预设文件改名"
 
-#: ../src/gddccontrol/gprofile.c:203
+#: ../src/gddccontrol/gprofile.c:217
 msgid "Delete profile"
 msgstr "删除预设文件"
 
-#: ../src/gddccontrol/gprofile.c:229
+#: ../src/gddccontrol/gprofile.c:253
 msgid "Create profile"
 msgstr "创建预设文件"
 
-#: ../src/gddccontrol/gprofile.c:235
+#: ../src/gddccontrol/gprofile.c:259
 msgid "Close profile manager"
 msgstr "关闭预设文件管理器"
 
-#: ../src/gddccontrol/gprofile.c:299
+#: ../src/gddccontrol/gprofile.c:321
 msgid "Control name"
 msgstr "控制器名称"
 
-#: ../src/gddccontrol/gprofile.c:310
+#: ../src/gddccontrol/gprofile.c:332
 msgid "Value"
 msgstr "值"
 
-#: ../src/gddccontrol/gprofile.c:313
+#: ../src/gddccontrol/gprofile.c:335
 msgid "Address"
 msgstr "地址"
 
-#: ../src/gddccontrol/gprofile.c:316
+#: ../src/gddccontrol/gprofile.c:338
 msgid "Raw value"
 msgstr "原始值"
 
-#: ../src/gddccontrol/gprofile.c:434 ../src/gddccontrol/gprofile.c:454
+#: ../src/gddccontrol/gprofile.c:456 ../src/gddccontrol/gprofile.c:476
 msgid "Profile information:"
 msgstr "预设信息:"
 
-#: ../src/gddccontrol/gprofile.c:463
+#: ../src/gddccontrol/gprofile.c:485
 #, c-format
 msgid "File name: %s"
 msgstr "文件名: %s"
 
-#: ../src/gddccontrol/gprofile.c:474
+#: ../src/gddccontrol/gprofile.c:496
 msgid "Profile name:"
 msgstr "预设名:"
 
 #. Save
-#: ../src/gddccontrol/gprofile.c:496
+#: ../src/gddccontrol/gprofile.c:518
 msgid "Saving profile..."
 msgstr "正在保存预设文件..."
 
-#: ../src/gddccontrol/gprofile.c:505
+#: ../src/gddccontrol/gprofile.c:527
 msgid "Error while saving profile."
 msgstr "保存预设文件是出错."
 
-#: ../src/gddccontrol/main.c:177
+#: ../src/gddccontrol/main.c:204
 #, c-format
 msgid "Monitor changed (%d %d).\n"
 msgstr "显示器已改变 (%d %d).\n"
 
-#: ../src/gddccontrol/main.c:329
+#: ../src/gddccontrol/main.c:356
 msgid "Probing for available monitors..."
 msgstr "正在检测可用的显示器..."
 
-#: ../src/gddccontrol/main.c:368
+#: ../src/gddccontrol/main.c:385
 msgid ""
 "No monitor supporting DDC/CI available.\n"
 "\n"
@@ -606,47 +682,47 @@ msgstr ""
 "如果你的图形卡需要它,请检查所有必需的内核模块已经加载 (i2c-dev, 及你的 "
 "framebuffer 驱动)."
 
-#: ../src/gddccontrol/main.c:420
+#: ../src/gddccontrol/main.c:438
 msgid "Unable to initialize ddcci library, see console for more details.\n"
 msgstr "不能初始化ddcci库,详细信息参见控制台.\n"
 
-#: ../src/gddccontrol/main.c:430
+#: ../src/gddccontrol/main.c:450
 msgid "Monitor settings"
 msgstr "显示器的设置"
 
-#: ../src/gddccontrol/main.c:454
+#: ../src/gddccontrol/main.c:474
 msgid "Current monitor: "
 msgstr "当前显示器: "
 
-#: ../src/gddccontrol/main.c:464
+#: ../src/gddccontrol/main.c:484
 msgid "Refresh monitor list"
 msgstr "刷新显示器列表"
 
-#: ../src/gddccontrol/main.c:481
+#: ../src/gddccontrol/main.c:507
 msgid "Profile manager"
 msgstr "预设文件管理"
 
-#: ../src/gddccontrol/main.c:488
+#: ../src/gddccontrol/main.c:514
 msgid "Save profile"
 msgstr "保存预设文件"
 
-#: ../src/gddccontrol/main.c:494
+#: ../src/gddccontrol/main.c:520
 msgid "Cancel profile creation"
 msgstr "取消建立预设文件"
 
-#: ../src/gddccontrol/main.c:518
+#: ../src/gddccontrol/main.c:549
 msgid "OK"
 msgstr ""
 
-#: ../src/gddccontrol/main.c:546
+#: ../src/gddccontrol/main.c:585
 msgid "Refresh"
 msgstr "刷新"
 
-#: ../src/gddccontrol/main.c:546
+#: ../src/gddccontrol/main.c:585
 msgid "Refresh all controls"
 msgstr "刷新所有控制项"
 
-#: ../src/gddccontrol/main.c:553
+#: ../src/gddccontrol/main.c:592
 msgid "Close"
 msgstr "关闭"
 
@@ -654,33 +730,33 @@ msgstr "关闭"
 #. gtk_misc_set_alignment(GTK_MISC(moninfo), 0, 0);
 #.
 #. gtk_table_attach(GTK_TABLE(table), moninfo, 0, 1, 1, 2, GTK_FILL_EXPAND, 0, 5, 5);
-#: ../src/gddccontrol/main.c:592
+#: ../src/gddccontrol/main.c:634
 #, c-format
 msgid "Welcome to gddccontrol %s."
 msgstr "欢迎使用gddccontrol %s"
 
-#: ../src/gddccontrol/notebook.c:81
+#: ../src/gddccontrol/notebook.c:83
 msgid "Error while getting value"
 msgstr "在取值时发生错误"
 
-#: ../src/gddccontrol/notebook.c:116 ../src/gddccontrol/notebook.c:128
+#: ../src/gddccontrol/notebook.c:118 ../src/gddccontrol/notebook.c:130
 #, c-format
 msgid "Refreshing controls values (%d%%)..."
 msgstr "正在刷新控制项的值 (%d%%)..."
 
-#: ../src/gddccontrol/notebook.c:133
+#: ../src/gddccontrol/notebook.c:135
 msgid "Could not get the control_db struct related to a control."
 msgstr "不能获取与一个控制器相关的控制库结构."
 
-#: ../src/gddccontrol/notebook.c:493
+#: ../src/gddccontrol/notebook.c:495
 msgid "Show fullscreen patterns"
 msgstr "显示全屏式样"
 
-#: ../src/gddccontrol/notebook.c:525
+#: ../src/gddccontrol/notebook.c:527
 msgid "Section"
 msgstr "区段"
 
-#: ../src/gddccontrol/notebook.c:572
+#: ../src/gddccontrol/notebook.c:574
 msgid ""
 "The current monitor is in the database but does not support DDC/CI.\n"
 "\n"
@@ -698,7 +774,7 @@ msgstr ""
 "如果你的显示器有两个信号输入接口, 请尝试连接到另一个接口, 然后点击显示器列表"
 "旁的刷新按钮."
 
-#: ../src/gddccontrol/notebook.c:583
+#: ../src/gddccontrol/notebook.c:585
 #, c-format
 msgid "Opening the monitor device (%s)..."
 msgstr "正在打开显示器设备 (%s)..."
@@ -715,543 +791,538 @@ msgstr ""
 #: ../src/gddccontrol/notebook.c:600
 #, c-format
 msgid ""
-"The current monitor is not supported, please run\n"
-"%s\n"
-"and send the output to ddccontrol-users@lists.sourceforge.net.\n"
-"Thanks."
+"Unsupported monitor detected.\n"
+"\n"
+"Please update ddccontrol-db, or, if you are already using the latest\n"
+"version, please open a github issue:\n"
+"https://github.com/ddccontrol/ddccontrol-db/issues/new?template=unsupported-"
+"monitor.yml\n"
+"Then attach the resulting report file of the following command:"
 msgstr ""
 
-#: ../src/gddccontrol/notebook.c:620
+#: ../src/gddccontrol/notebook.c:622
 msgid "Please click on a group name."
 msgstr "请单击一个组名."
 
-#: ../src/gddccontrol/notebook.c:639 ../src/gddccontrol/notebook.c:650
+#: ../src/gddccontrol/notebook.c:647 ../src/gddccontrol/notebook.c:658
 #, c-format
 msgid "Getting controls values (%d%%)..."
 msgstr "正在获取控制器的值 (%d%%)..."
 
-#: ../src/gddccontrol/notebook.c:664
+#: ../src/gddccontrol/notebook.c:683
 msgid "Loading profiles..."
 msgstr "正在装载预设文件..."
 
-#: ../src/gddccontrol/notebook.c:677
+#: ../src/gddccontrol/notebook.c:696
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is "
 "using a generic profile for your monitor's manufacturer. Some controls may "
 "not be supported, or may not work as expected.\n"
 msgstr ""
 
-#: ../src/gddccontrol/notebook.c:683
+#: ../src/gddccontrol/notebook.c:702
 msgid ""
 "There is no support for your monitor in the database, but ddccontrol is "
 "using a basic generic profile. Many controls will not be supported, and some "
 "controls may not work as expected.\n"
 msgstr ""
 
-#: ../src/gddccontrol/notebook.c:688
+#: ../src/gddccontrol/notebook.c:707
 msgid "Warning!"
 msgstr ""
 
-#: ../src/gddccontrol/notebook.c:690
+#: ../src/gddccontrol/notebook.c:709
 msgid ""
-"Please update ddccontrol-db, or, if you are already using the latest "
-"version, please send the output of the following command to ddccontrol-"
-"users@lists.sourceforge.net:\n"
+"Unsupported monitor detected.\n"
+"\n"
+"Please update ddccontrol-db, or, if you are already using the latest\n"
+"version, please open a github issue:\n"
+"https://github.com/ddccontrol/ddccontrol-db/issues/new?template=unsupported-"
+"monitor.yml\n"
+"Then attach the resulting report file of the following command:\n"
 msgstr ""
 
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.server.in.in.h:1
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:184
-msgid "Monitor Profile Switcher"
-msgstr "显示器预设切换器"
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.server.in.in.h:2
-msgid "Quickly switch monitor profiles created with gddccontrol"
-msgstr ""
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.xml.h:1
-msgid "_About..."
-msgstr ""
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.xml.h:2
-msgid "_Properties..."
-msgstr ""
-
-#: ../src/gnome-ddcc-applet/GNOME_ddcc-applet.xml.h:3
-msgid "_Run gddccontrol..."
-msgstr ""
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:189
-msgid ""
-"An applet for quick switching of monitor profiles.\n"
-"Based on libddccontrol and part of the ddccontrol project.\n"
-"(http://ddccontrol.sourceforge.net)"
-msgstr ""
-"一个快速切换显示器预设的小程序.\n"
-"基于 libddccontrol 和部分 ddccontrol 项目.\n"
-"(http://ddccontrol.sourceforge.net)"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:386
-msgid "Unable to initialize ddcci library"
-msgstr "未能初始化ddcci库"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:390
-msgid "No monitor configuration found. Please run gddccontrol first"
-msgstr "没找到显示器配置. 请先运行 gddccontrol"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:395
-msgid "An error occurred while opening the monitor device"
-msgstr "打开显示器设备时发生了一个错误"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:400
-msgid "Can't find any profiles"
-msgstr "找不到任何预设文件."
-
-#. only reached, if init was not finished
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:416
-msgid "error"
-msgstr "错误"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:440
-msgid "Monitor:"
-msgstr "显示器:"
-
-#: ../src/gnome-ddcc-applet/ddcc-applet.c:443
-msgid "Monitor Profile Switcher Properties"
-msgstr "显示器预设切换器属性"
-
-#: ../src/lib/conf.c:61 ../src/lib/conf.c:258 ../src/lib/conf.c:308
-#: ../src/lib/ddcci.c:1202
+#: ../src/lib/conf.c:63 ../src/lib/conf.c:260 ../src/lib/conf.c:310
+#: ../src/lib/ddcci.c:1306
 msgid "Cannot create filename (buffer too small)\n"
 msgstr "不能创建文件名 (缓冲区太小)\n"
 
-#: ../src/lib/conf.c:86 ../src/lib/conf.c:363 ../src/lib/monitor_db.c:350
-#: ../src/lib/monitor_db.c:714
+#: ../src/lib/conf.c:88 ../src/lib/conf.c:367 ../src/lib/monitor_db.c:353
+#: ../src/lib/monitor_db.c:726
 #, c-format
 msgid "Document not parsed successfully.\n"
 msgstr "文档语法分析不成功.\n"
 
-#: ../src/lib/conf.c:93 ../src/lib/conf.c:370
+#: ../src/lib/conf.c:95 ../src/lib/conf.c:375
 #, c-format
 msgid "empty profile file\n"
 msgstr "空的预设文件\n"
 
-#: ../src/lib/conf.c:99 ../src/lib/conf.c:376
+#: ../src/lib/conf.c:101 ../src/lib/conf.c:382
 #, c-format
 msgid "profile of the wrong type, root node %s != profile"
 msgstr "预设文件有错误类型, 根节点 %s 不等于 profile"
 
-#: ../src/lib/conf.c:105
+#: ../src/lib/conf.c:107
 msgid "Can't find ddccontrolversion property."
 msgstr "找不到ddccontrol版本属性."
 
-#: ../src/lib/conf.c:107
+#: ../src/lib/conf.c:109
 #, c-format
 msgid "ddccontrol has been upgraded since monitorlist was saved (%s vs %s).\n"
 msgstr "在显示器列表保存之后 ddccontrol 已经被升级了(%s vs %s).\n"
 
-#: ../src/lib/conf.c:124
+#: ../src/lib/conf.c:126
 msgid "Can't find filename property."
 msgstr "找不到文件名属性."
 
-#: ../src/lib/conf.c:130
+#: ../src/lib/conf.c:132
 msgid "Can't find supported property."
 msgstr "找不到支持属性."
 
-#: ../src/lib/conf.c:133
+#: ../src/lib/conf.c:135
 msgid "Can't convert supported property to int."
 msgstr "支持属性不能转换成整数."
 
-#: ../src/lib/conf.c:138 ../src/lib/conf.c:385 ../src/lib/monitor_db.c:90
-#: ../src/lib/monitor_db.c:194 ../src/lib/monitor_db.c:370
-#: ../src/lib/monitor_db.c:426 ../src/lib/monitor_db.c:447
+#: ../src/lib/conf.c:140 ../src/lib/conf.c:392 ../src/lib/monitor_db.c:92
+#: ../src/lib/monitor_db.c:196 ../src/lib/monitor_db.c:373
+#: ../src/lib/monitor_db.c:429 ../src/lib/monitor_db.c:450
 msgid "Can't find name property."
 msgstr "找不到名称属性."
 
-#: ../src/lib/conf.c:144
+#: ../src/lib/conf.c:146
 msgid "Can't find digital property."
 msgstr "找不到数字式属性."
 
-#: ../src/lib/conf.c:147
+#: ../src/lib/conf.c:149
 msgid "Can't convert digital property to int."
 msgstr "数字式属性不能转换成整数."
 
-#: ../src/lib/conf.c:175 ../src/lib/conf.c:439
+#: ../src/lib/conf.c:177 ../src/lib/conf.c:447
 msgid "Cannot create the xml writer\n"
 msgstr "不能创建xml写入器\n"
 
-#: ../src/lib/conf.c:239
+#: ../src/lib/conf.c:241
 msgid "Cannot read control value\n"
 msgstr "不能读取控制器值\n"
 
-#: ../src/lib/conf.c:276
+#: ../src/lib/conf.c:278
 msgid "Cannot write control value\n"
 msgstr "不能写控制器值\n"
 
-#: ../src/lib/conf.c:313
+#: ../src/lib/conf.c:315
 msgid "Error while opening ddccontrol home directory."
 msgstr "打开ddccontrol的目录时出错."
 
-#: ../src/lib/conf.c:337
+#: ../src/lib/conf.c:340
 msgid "Error while reading ddccontrol home directory."
 msgstr "读取ddccontrol的目录时出错."
 
-#: ../src/lib/conf.c:382
+#: ../src/lib/conf.c:389
 msgid "Can't find pnpid property."
 msgstr "找不到 pnpid 属性."
 
-#: ../src/lib/conf.c:388 ../src/lib/conf.c:391
+#: ../src/lib/conf.c:395 ../src/lib/conf.c:398
 msgid "Can't find version property."
 msgstr "找不到版本属性."
 
-#: ../src/lib/conf.c:390 ../src/lib/monitor_db.c:752
+#: ../src/lib/conf.c:397 ../src/lib/monitor_db.c:764
 msgid "Can't convert version to int."
 msgstr "版本不能转换到整数."
 
-#: ../src/lib/conf.c:393
+#: ../src/lib/conf.c:400
 #, c-format
 msgid "profile version (%d) is not supported (should be %d).\n"
 msgstr "不支持的预设文件版本 (%d), 应该是 (%d).\n"
 
-#: ../src/lib/conf.c:407 ../src/lib/monitor_db.c:229
+#: ../src/lib/conf.c:415 ../src/lib/monitor_db.c:233
 msgid "Can't find address property."
 msgstr "找不到地址属性."
 
-#: ../src/lib/conf.c:409 ../src/lib/monitor_db.c:231
+#: ../src/lib/conf.c:417 ../src/lib/monitor_db.c:235
 msgid "Can't convert address to int."
 msgstr "地址不能转换成整数."
 
-#: ../src/lib/conf.c:413 ../src/lib/monitor_db.c:112
+#: ../src/lib/conf.c:421 ../src/lib/monitor_db.c:114
 msgid "Can't find value property."
 msgstr "找不到值属性."
 
-#: ../src/lib/conf.c:415 ../src/lib/monitor_db.c:114
+#: ../src/lib/conf.c:423 ../src/lib/monitor_db.c:116
 msgid "Can't convert value to int."
 msgstr "值不能转换成整数."
 
-#: ../src/lib/conf.c:499
+#: ../src/lib/conf.c:507
 msgid "ddcci_delete_profile: Error, cannot delete profile.\n"
 msgstr "ddcci_delete_profile: 错误, 不能删除预设文件.\n"
 
-#: ../src/lib/conf.c:519
+#: ../src/lib/conf.c:527
 #, c-format
 msgid "ddcci_delete_profile: Error, could not find the profile to delete.\n"
 msgstr "ddcci_delete_profile: 错误, 找不到要删除的预设文件.\n"
 
-#: ../src/lib/ddcci.c:146
+#: ../src/lib/ddcci.c:148
 msgid "Error while initialisating the message queue"
 msgstr "初始化消息队列时出错"
 
-#: ../src/lib/ddcci.c:175
+#: ../src/lib/ddcci.c:177
 msgid "Error while sending quit message"
 msgstr "发送退出消息时出错"
 
-#: ../src/lib/ddcci.c:221
+#: ../src/lib/ddcci.c:223
 msgid "Error while sending heartbeat message"
 msgstr "发送心跳消息时出错"
 
-#: ../src/lib/ddcci.c:239
+#: ../src/lib/ddcci.c:241
 #, c-format
 msgid "Failed to initialize ddccontrol database...\n"
 msgstr "初始化 ddccontrol 数据库时失败...\n"
 
-#: ../src/lib/ddcci.c:275 ../src/lib/ddcci.c:350
+#: ../src/lib/ddcci.c:247
+#, fuzzy, c-format
+msgid "Failed to initialize ADL...\n"
+msgstr "初始化 ddccontrol 数据库时失败...\n"
+
+#: ../src/lib/ddcci.c:292 ../src/lib/ddcci.c:383
 #, c-format
 msgid "ioctl returned %d\n"
 msgstr "ioctl返回 %d\n"
 
-#: ../src/lib/ddcci.c:300
+#: ../src/lib/ddcci.c:321
 msgid "Error while sending write message"
 msgstr "发送写消息时出错"
 
-#: ../src/lib/ddcci.c:309
+#: ../src/lib/ddcci.c:330
 msgid "Error while reading write message answer"
 msgstr "读取写消息的应答时出错"
 
-#: ../src/lib/ddcci.c:376
+#: ../src/lib/ddcci.c:413
 msgid "Error while sending read message"
 msgstr "发送读消息时出错"
 
-#: ../src/lib/ddcci.c:385
+#: ../src/lib/ddcci.c:422
 msgid "Error while reading read message answer"
 msgstr "读取读消息的应答时出错"
 
-#: ../src/lib/ddcci.c:475
+#: ../src/lib/ddcci.c:518
 #, c-format
 msgid "Invalid response, first byte is 0x%02x, should be 0x%02x\n"
 msgstr "无效的响应, 首字节是 0x%02x, 应该是 0x%02x\n"
 
-#: ../src/lib/ddcci.c:485
+#: ../src/lib/ddcci.c:528
 #, fuzzy, c-format
 msgid "Non-fatal error: Invalid response, magic is 0x%02x\n"
 msgstr "无效的响应, 魔术数是 0x%02x\n"
 
-#: ../src/lib/ddcci.c:492
+#: ../src/lib/ddcci.c:535
 #, c-format
 msgid "Invalid response, length is %d, should be %d at most\n"
 msgstr "无效的响应, 长度是 %d, 最多应该是 %d\n"
 
-#: ../src/lib/ddcci.c:505
+#: ../src/lib/ddcci.c:548
 #, c-format
 msgid "Invalid response, corrupted data - xor is 0x%02x, length 0x%02x\n"
 msgstr "无效的响应, 已损坏的数据 - xor 是 0x%02x, 长度 0x%02x\n"
 
-#: ../src/lib/ddcci.c:658 ../src/lib/ddcci.c:680
+#: ../src/lib/ddcci.c:709 ../src/lib/ddcci.c:731
 #, fuzzy, c-format
 msgid "Can't convert value to int, invalid CAPS (buf=%s, pos=%d).\n"
 msgstr "值不能转换成整数, 无效的功能值."
 
-#: ../src/lib/ddcci.c:763
+#: ../src/lib/ddcci.c:814
 #, c-format
 msgid "Invalid sequence in caps.\n"
 msgstr "无效的功能响应.\n"
 
-#: ../src/lib/ddcci.c:841
+#: ../src/lib/ddcci.c:892
 #, c-format
 msgid "Corrupted EDID at 0x%02x.\n"
 msgstr "在 0x%02x 中已损坏的 EDIT.\n"
 
-#: ../src/lib/ddcci.c:853
+#: ../src/lib/ddcci.c:904
 #, c-format
 msgid "Serial number: %d\n"
 msgstr "序列号: %d\n"
 
-#: ../src/lib/ddcci.c:856
+#: ../src/lib/ddcci.c:907
 #, c-format
 msgid "Manufactured: Week %d, %d\n"
 msgstr "制造: %2$d年 第%1$d周\n"
 
-#: ../src/lib/ddcci.c:859
+#: ../src/lib/ddcci.c:910
 #, c-format
 msgid "EDID version: %d.%d\n"
 msgstr "EDID版本: %d.%d\n"
 
-#: ../src/lib/ddcci.c:862
+#: ../src/lib/ddcci.c:913
 #, c-format
 msgid "Maximum size: %d x %d (cm)\n"
 msgstr "最大尺寸: %d x %d (cm)\n"
 
-#: ../src/lib/ddcci.c:873
+#: ../src/lib/ddcci.c:924
 #, c-format
 msgid "Reading EDID 0x%02x failed.\n"
 msgstr "读取EDID 0x%02x 失败.\n"
 
-#: ../src/lib/ddcci.c:903
+#: ../src/lib/ddcci.c:954
 #, c-format
 msgid "Device: %s\n"
 msgstr "设备: %s\n"
 
-#: ../src/lib/ddcci.c:917
+#: ../src/lib/ddcci.c:968
 msgid "Error while sending open message"
 msgstr "发送打开消息时出错"
 
-#: ../src/lib/ddcci.c:925
+#: ../src/lib/ddcci.c:976
 msgid "Error while reading open message answer"
 msgstr "读取打开消息的应答时出错"
 
-#: ../src/lib/ddcci.c:933
+#: ../src/lib/ddcci.c:988 ../src/lib/ddcci.c:1001
 #, c-format
 msgid "Invalid filename (%s).\n"
 msgstr "无效的文件名 (%s).\n"
 
-#: ../src/lib/ddcci.c:1049
+#: ../src/lib/ddcci.c:993
+#, c-format
+msgid "ADL display not found (%s).\n"
+msgstr ""
+
+#: ../src/lib/ddcci.c:1125
 #, c-format
 msgid "ddcci_open returned %d\n"
 msgstr "ddcci_open 返回 %d\n"
 
-#: ../src/lib/ddcci.c:1062
+#: ../src/lib/ddcci.c:1138
 #, c-format
 msgid "Unknown monitor (%s)"
 msgstr "未知的显示器 (%s)"
 
-#: ../src/lib/ddcci.c:1083
+#: ../src/lib/ddcci.c:1159
 #, c-format
 msgid "Probing for available monitors"
 msgstr "正在探测可用的显示器"
 
-#: ../src/lib/ddcci.c:1097
+#: ../src/lib/ddcci.c:1173
 msgid "Error while sending list message"
 msgstr "发送列表消息时出错"
 
-#: ../src/lib/ddcci.c:1106
+#: ../src/lib/ddcci.c:1182
 msgid "Error while reading list entry"
 msgstr "读取列表入口时出错"
 
-#: ../src/lib/ddcci.c:1123
+#: ../src/lib/ddcci.c:1199
 #, c-format
 msgid "Found PCI device (%s)\n"
 msgstr "找到 PCI 设备 (%s)\n"
 
-#: ../src/lib/ddcci.c:1157
+#: ../src/lib/ddcci.c:1239
 #, c-format
 msgid "Found I2C device (%s)\n"
 msgstr "找到 I2C 设备 (%s)\n"
 
-#: ../src/lib/ddcci.c:1206
+#: ../src/lib/ddcci.c:1264
+#, fuzzy, c-format
+msgid "Found ADL display (%s)\n"
+msgstr "找到 PCI 设备 (%s)\n"
+
+#: ../src/lib/ddcci.c:1310
 msgid "Error while getting information about ddccontrol home directory."
 msgstr "获取ddccontrol的目录信息时出错."
 
-#: ../src/lib/ddcci.c:1211
+#: ../src/lib/ddcci.c:1316
 msgid "Error while creating ddccontrol home directory."
 msgstr "创建ddccontrol的目录时出错."
 
-#: ../src/lib/ddcci.c:1216
+#: ../src/lib/ddcci.c:1322
 msgid ""
 "Error while getting information about ddccontrol home directory after "
 "creating it."
 msgstr "创建ddccontrol的目录后再获取目录信息时出错."
 
-#: ../src/lib/ddcci.c:1223
+#: ../src/lib/ddcci.c:1330
 msgid "Error: '.ddccontrol' in your home directory is not a directory."
 msgstr "错误: 你目录的中'.ddccontrol'不是一个目录."
 
-#: ../src/lib/ddcci.c:1231
+#: ../src/lib/ddcci.c:1339
 msgid "Error while getting information about ddccontrol profile directory."
 msgstr "获取ddccontrol的预设目录信息时出错."
 
-#: ../src/lib/ddcci.c:1236
+#: ../src/lib/ddcci.c:1345
 msgid "Error while creating ddccontrol profile directory."
 msgstr "创建ddccontrol的预设目录时出错."
 
-#: ../src/lib/ddcci.c:1241
+#: ../src/lib/ddcci.c:1351
 msgid ""
 "Error while getting information about ddccontrol profile directory after "
 "creating it."
 msgstr "创建ddccontrol的预设文件目录后再获取目录信息时出错."
 
-#: ../src/lib/ddcci.c:1248
+#: ../src/lib/ddcci.c:1359
 msgid ""
 "Error: '.ddccontrol/profiles' in your home directory is not a directory."
 msgstr "错误: 你目录的中'.ddccontrol/profiles'不是一个目录."
 
-#: ../src/lib/monitor_db.c:82 ../src/lib/monitor_db.c:192
+#: ../src/lib/monitor_db.c:84 ../src/lib/monitor_db.c:194
 msgid "Can't find id property."
 msgstr "找不到id属性."
 
-#: ../src/lib/monitor_db.c:151 ../src/lib/monitor_db.c:546
+#: ../src/lib/monitor_db.c:153 ../src/lib/monitor_db.c:549
 #, c-format
 msgid "Element %s (id=%s) has not been found (line %ld).\n"
 msgstr "元件 %s (id=%s) 已经找到 (%ld行).\n"
 
-#: ../src/lib/monitor_db.c:205
+#: ../src/lib/monitor_db.c:207
 msgid "Invalid refresh type (!= none, != all)."
 msgstr "无效的刷新类型 (!= none, != all)."
 
-#: ../src/lib/monitor_db.c:238
+#: ../src/lib/monitor_db.c:242
 #, c-format
 msgid "Control %s has been discarded by the caps string.\n"
 msgstr "控制器 %s 功能字符串已经被丢弃.\n"
 
-#: ../src/lib/monitor_db.c:246
+#: ../src/lib/monitor_db.c:250
 #, c-format
 msgid "Control %s (0x%02x) has already been defined.\n"
 msgstr ""
 
-#: ../src/lib/monitor_db.c:259
+#: ../src/lib/monitor_db.c:263
 msgid "Can't convert delay to int."
 msgstr "延迟不能转换成整数."
 
-#: ../src/lib/monitor_db.c:267
+#: ../src/lib/monitor_db.c:271
 msgid "Can't find type property."
 msgstr "找不到类型属性."
 
-#: ../src/lib/monitor_db.c:292 ../src/lib/monitor_db.c:381
+#: ../src/lib/monitor_db.c:296 ../src/lib/monitor_db.c:384
 msgid "Invalid type."
 msgstr "无效的类型."
 
-#: ../src/lib/monitor_db.c:343
+#: ../src/lib/monitor_db.c:346
 #, c-format
 msgid "Database must be inited before reading a monitor file.\n"
 msgstr "在读取一个显示器文件之前必须初始化数据库.\n"
 
-#: ../src/lib/monitor_db.c:357
+#: ../src/lib/monitor_db.c:360
 #, c-format
 msgid "empty monitor/%s.xml\n"
 msgstr "monitor/%s.xml 是空的\n"
 
-#: ../src/lib/monitor_db.c:363
+#: ../src/lib/monitor_db.c:366
 #, c-format
 msgid "monitor/%s.xml of the wrong type, root node %s != monitor"
 msgstr "monitor/%s.xml 有错误的类型, 根节点 %s 不等于 monitor"
 
-#: ../src/lib/monitor_db.c:464
+#: ../src/lib/monitor_db.c:467
 #, fuzzy
 msgid "Can't find add or remove property in caps."
 msgstr "找不到地址属性."
 
-#: ../src/lib/monitor_db.c:466
+#: ../src/lib/monitor_db.c:469
 #, fuzzy
 msgid "Invalid remove caps."
 msgstr "无效的功能响应.\n"
 
-#: ../src/lib/monitor_db.c:468
+#: ../src/lib/monitor_db.c:471
 #, fuzzy
 msgid "Invalid add caps."
 msgstr "无效的类型."
 
-#: ../src/lib/monitor_db.c:473
+#: ../src/lib/monitor_db.c:476
 #, c-format
 msgid "Error, include recursion level > 15 (file: %s).\n"
 msgstr "错误, 循环嵌套大于15层 (文件:%s).\n"
 
-#: ../src/lib/monitor_db.c:479
+#: ../src/lib/monitor_db.c:482
 #, fuzzy
 msgid "Can't find file property."
 msgstr "找不到文件名属性."
 
-#: ../src/lib/monitor_db.c:487
+#: ../src/lib/monitor_db.c:490
 msgid "Two controls part in XML file."
 msgstr ""
 
-#: ../src/lib/monitor_db.c:534
+#: ../src/lib/monitor_db.c:537
 #, fuzzy
 msgid "Error enumerating controls in subgroup."
 msgstr "组中有错误的控制器列举."
 
-#: ../src/lib/monitor_db.c:589
+#: ../src/lib/monitor_db.c:601
 #, fuzzy, c-format
 msgid "document of the wrong type, can't find controls or include.\n"
 msgstr "文档有错误的类型, 找不到控制器.\n"
 
-#: ../src/lib/monitor_db.c:721
+#: ../src/lib/monitor_db.c:733
 #, c-format
 msgid "empty options.xml\n"
 msgstr "options.xml 是空的\n"
 
-#: ../src/lib/monitor_db.c:728
+#: ../src/lib/monitor_db.c:740
 #, c-format
 msgid "options.xml of the wrong type, root node %s != options"
 msgstr "options.xml 有错误的类型, 根节点 %s 不等于 options"
 
-#: ../src/lib/monitor_db.c:738
+#: ../src/lib/monitor_db.c:750
 #, c-format
 msgid "options.xml dbversion attribute missing, please update your database.\n"
 msgstr "options.xml 的数据库版本(dbversion)属性缺失, 请更新你的数据库.\n"
 
-#: ../src/lib/monitor_db.c:745
+#: ../src/lib/monitor_db.c:757
 #, c-format
 msgid "options.xml date attribute missing, please update your database.\n"
 msgstr "options.xml 的日期(date)属性缺失, 请更新你的数据库.\n"
 
-#: ../src/lib/monitor_db.c:755
+#: ../src/lib/monitor_db.c:767
 #, c-format
 msgid ""
 "options.xml dbversion (%d) is greater than the supported version (%d).\n"
 msgstr "options.xml 的数据库版本 (%d) 大于支持的版本 (%d).\n"
 
-#: ../src/lib/monitor_db.c:756
+#: ../src/lib/monitor_db.c:768
 #, c-format
 msgid "Please update ddccontrol program.\n"
 msgstr "请更新ddccontrol程序.\n"
 
-#: ../src/lib/monitor_db.c:763
+#: ../src/lib/monitor_db.c:775
 #, c-format
 msgid "options.xml dbversion (%d) is less than the supported version (%d).\n"
 msgstr "options.xml 的数据库版本 (%d) 小于支持的版本 (%d).\n"
 
-#: ../src/lib/monitor_db.c:764
+#: ../src/lib/monitor_db.c:776
 #, c-format
 msgid "Please update ddccontrol database.\n"
 msgstr "请更新ddccontrol数据库.\n"
+
+#~ msgid "Monitor Profile Switcher"
+#~ msgstr "显示器预设切换器"
+
+#~ msgid ""
+#~ "An applet for quick switching of monitor profiles.\n"
+#~ "Based on libddccontrol and part of the ddccontrol project.\n"
+#~ "(http://ddccontrol.sourceforge.net)"
+#~ msgstr ""
+#~ "一个快速切换显示器预设的小程序.\n"
+#~ "基于 libddccontrol 和部分 ddccontrol 项目.\n"
+#~ "(http://ddccontrol.sourceforge.net)"
+
+#~ msgid "Unable to initialize ddcci library"
+#~ msgstr "未能初始化ddcci库"
+
+#~ msgid "No monitor configuration found. Please run gddccontrol first"
+#~ msgstr "没找到显示器配置. 请先运行 gddccontrol"
+
+#~ msgid "An error occurred while opening the monitor device"
+#~ msgstr "打开显示器设备时发生了一个错误"
+
+#~ msgid "Can't find any profiles"
+#~ msgstr "找不到任何预设文件."
+
+#~ msgid "error"
+#~ msgstr "错误"
+
+#~ msgid "Monitor:"
+#~ msgstr "显示器:"
+
+#~ msgid "Monitor Profile Switcher Properties"
+#~ msgstr "显示器预设切换器属性"
 
 #~ msgid "Buffer too small to contain caps.\n"
 #~ msgstr "缓冲区太小不能容纳功能数据.\n"
@@ -1270,9 +1341,6 @@ msgstr "请更新ddccontrol数据库.\n"
 
 #~ msgid "Xinerama not supported\n"
 #~ msgstr "Xinerama 不支持\n"
-
-#~ msgid "Monitor Settings"
-#~ msgstr "显示器的设置"
 
 #~ msgid "Error: %s @%s:%d\n"
 #~ msgstr "错误: %s @%s:%d\n"

--- a/src/daemon/data/ddccontrol.service.in
+++ b/src/daemon/data/ddccontrol.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Control monitor parameters, like brightness, contrast, and other...
+Documentation=man:ddccontrol(1)
 
 [Service]
 Type=dbus

--- a/src/ddccontrol/Makefile.am
+++ b/src/ddccontrol/Makefile.am
@@ -4,7 +4,6 @@ AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/src/lib -DLOCALEDIR=\"$(locale
 LDADD = ../lib/libddccontrol.la ../daemon/libddccontrol_dbus_client.la
 
 bin_PROGRAMS = ddccontrol
-ddccontrol_SOURCES = main.c printing.c
+ddccontrol_SOURCES = main.c printing.c ../lib/urlencode.c ../lib/issueurl.c
 ddccontrol_LDFLAGS = $(LIBXML2_LIBS) $(LIBINTL)
 AM_CFLAGS = $(LIBXML2_CFLAGS)
-

--- a/src/ddccontrol/main.c
+++ b/src/ddccontrol/main.c
@@ -26,6 +26,7 @@
 #include "internal.h"
 #include "monitor_db.h"
 #include "conf.h"
+#include "issueurl.h"
 
 #include <stdio.h>
 #include <unistd.h>
@@ -163,9 +164,13 @@ int main(int argc, char **argv)
 
 	char *datadir = NULL;
 	char *pnpname = NULL; /* pnpname for -i parameter */
+	char *selected_monitor_name = NULL;
 
 	/* -l (load profile) parameter */
 	struct profile *profilefile = NULL;
+
+	struct issue_report report = {0};
+	report.ddccontrol_version = VERSION;
 
 	/* what to do */
 	int dump = 0;
@@ -311,14 +316,17 @@ int main(int argc, char **argv)
 			printf(_("   Monitor Name: %s\n"), current->name);
 			printf(_("   Input type: %s\n"), current->digital ? _("Digital") : _("Analog"));
 
+
 			if ((!fn) && (current->supported)) {
 				printf(_("  (Automatically selected)\n"));
 				fn = malloc(strlen(current->filename) + 1);
 				strcpy(fn, current->filename);
+				selected_monitor_name = strdup(current->name);
+				report.monitor_name = selected_monitor_name;
 			}
-
 			current = current->next;
 		}
+
 
 		if (fn == NULL) {
 			fprintf(stderr, _(
@@ -333,6 +341,7 @@ int main(int argc, char **argv)
 	} else {
 		fn = argv[optind];
 	}
+	report.device = fn;
 
 	fprintf(stdout, _("Reading EDID and initializing DDC/CI at bus %s...\n"), fn);
 
@@ -353,29 +362,9 @@ int main(int argc, char **argv)
 		fprintf(stdout, _("\tPlug and Play ID: %s [%s]\n"),
 		        mon->pnpid, mon->db ? mon->db->name : NULL);
 		fprintf(stdout, _("\tInput type: %s\n"), mon->digital ? _("Digital") : _("Analog"));
-
-		if (mon->fallback) {
-			/* Put a big warning (in red if we are writing to a terminal). */
-			printf("%s%s\n", isatty(1) ? "\x1B[0;31m" : "", _("=============================== WARNING ==============================="));
-			if (mon->fallback == 1) {
-				printf(_(
-				           "There is no support for your monitor in the database, but ddccontrol is\n"
-				           "using a generic profile for your monitor's manufacturer. Some controls\n"
-				           "may not be supported, or may not work as expected.\n"));
-			} else if (mon->fallback == 2) {
-				printf(_(
-				           "There is no support for your monitor in the database, but ddccontrol is\n"
-				           "using a basic generic profile. Many controls will not be supported, and\n"
-				           "some controls may not work as expected.\n"));
-			}
-			printf(_(
-			           "Please update ddccontrol-db, or, if you are already using the latest\n"
-			           "version, please send the output of the following command to\n"
-			           "ddccontrol-users@lists.sourceforge.net:\n"));
-			printf("\nLANG= LC_ALL= ddccontrol -p -c -d\n\n");
-			printf(_("Thank you.\n"));
-			printf("%s%s\n", _("=============================== WARNING ==============================="), isatty(1) ? "\x1B[0m" : "");
-		}
+		report.pnp_id = mon->pnpid;
+		if (!report.monitor_name && mon->db)
+			report.monitor_name = (const char *)mon->db->name;
 
 		if (caps) {
 			fprintf(stdout, _("\nCapabilities:\n"));
@@ -516,6 +505,39 @@ int main(int argc, char **argv)
 
 			ddcci_save(mon);
 		}
+
+		if (mon->fallback) {
+			char *issue_url;
+
+			report.fallback_profile = "yes";
+			issue_url = build_issue_url(&report);
+
+			/* Put a big warning (in red if we are writing to a terminal). */
+			printf("%s%s\n", isatty(1) ? "\x1B[0;31m" : "", _("=============================== WARNING ==============================="));
+			if (mon->fallback == 1) {
+				printf(_(
+				           "There is no support for your monitor in the database, but ddccontrol is\n"
+				           "using a generic profile for your monitor's manufacturer. Some controls\n"
+				           "may not be supported, or may not work as expected.\n"));
+			} else if (mon->fallback == 2) {
+				printf(_(
+				           "There is no support for your monitor in the database, but ddccontrol is\n"
+				           "using a basic generic profile. Many controls will not be supported, and\n"
+				           "some controls may not work as expected.\n"));
+			}
+			printf(_(
+			           "Unsupported monitor detected.\n\n"
+			           "Please update ddccontrol-db, or, if you are already using the latest\n"
+			           "version, please open this pre-filled GitHub issue:\n"));
+			printf("%s\n", issue_url ? issue_url : "https://github.com/ddccontrol/ddccontrol-db/issues/new?template=unsupported-monitor.yml");
+			printf(_(
+			           "Then attach the resulting report file of the following command:\n"));
+			printf("\nLANG=C LC_ALL=C ddccontrol -p -c -d &> /tmp/ddccontrol-report.txt\n\n");
+			printf(_("Thank you.\n"));
+			printf("%s%s\n", _("=============================== WARNING ==============================="), isatty(1) ? "\x1B[0m" : "");
+
+			free(issue_url);
+		}
 	}
 
 	ddcci_close(mon);
@@ -524,6 +546,7 @@ int main(int argc, char **argv)
 	if (probe) {
 		free(fn);
 	}
+	free(selected_monitor_name);
 
 	ddcci_release();
 	exit(0);

--- a/src/gddccontrol/Makefile.am
+++ b/src/gddccontrol/Makefile.am
@@ -4,7 +4,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/src/lib -I$(top_srcdir)/src -DLOCALEDIR=\"$(locale
 EXTRA_DIST = gddccontrol.desktop.in gddccontrol.png gddccontrol-bluecurve.png
 
 bin_PROGRAMS = gddccontrol
-gddccontrol_SOURCES = main.c notebook.c notebook.h gprofile.c fspatterns.c
+gddccontrol_SOURCES = main.c stack.c gui.h gprofile.c fspatterns.c
 gddccontrol_LDFLAGS = $(GNOME_LDFLAGS) -lm
 gddccontrol_LDADD = ../daemon/libddccontrol_dbus_client.la ../lib/libddccontrol.la
 AM_CFLAGS = $(GNOME_CFLAGS)

--- a/src/gddccontrol/fspatterns.c
+++ b/src/gddccontrol/fspatterns.c
@@ -70,7 +70,7 @@ static void create_fullscreen_patterns_window()
 	gtk_box_pack_end(GTK_BOX(centervbox), close_button, TRUE, 5, 5);
 	gtk_widget_show(centervbox);
 	gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled_window), GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC);
-	gtk_scrolled_window_add_with_viewport(GTK_SCROLLED_WINDOW(scrolled_window), centervbox);
+	gtk_container_add(GTK_CONTAINER(scrolled_window), centervbox);
 	
 	gtk_widget_show(scrolled_window);
 }

--- a/src/gddccontrol/fspatterns.c
+++ b/src/gddccontrol/fspatterns.c
@@ -61,8 +61,8 @@ static void create_fullscreen_patterns_window()
 	scrolled_window = gtk_scrolled_window_new(NULL, NULL);
 	
 	centervbox = gtk_box_new(GTK_ORIENTATION_VERTICAL,10);
-	
-	GtkWidget* close_button = gtk_button_new_from_stock(GTK_STOCK_CLOSE);
+
+	GtkWidget* close_button = button_from_icon_name("view-restore", _("_Close fullscreen patterns"), NULL);
 	g_signal_connect(G_OBJECT(close_button),"clicked",G_CALLBACK (destroy), NULL);
 	gtk_widget_show(close_button);
 	gtk_widget_set_halign(close_button, GTK_ALIGN_CENTER);
@@ -76,7 +76,6 @@ static void create_fullscreen_patterns_window()
 }
 
 static void draw_shade(cairo_surface_t* surface, int y_position, int shade_height, int shade_count) {
-	GdkColor color;
 	PangoLayout* layout;
 	gchar* tmp;
 	

--- a/src/gddccontrol/fspatterns.c
+++ b/src/gddccontrol/fspatterns.c
@@ -18,7 +18,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
  ***************************************************************************/
 
-#include "notebook.h"
+#include "gui.h"
 #include "internal.h"
 
 #include <string.h>

--- a/src/gddccontrol/fspatterns.c
+++ b/src/gddccontrol/fspatterns.c
@@ -77,7 +77,6 @@ static void create_fullscreen_patterns_window()
 
 static void draw_shade(cairo_surface_t* surface, int y_position, int shade_height, int shade_count) {
 	PangoLayout* layout;
-	gchar* tmp;
 	
 	cairo_t* cairo_shade = cairo_create(surface);
 	cairo_t* cairo_white = cairo_create(surface);
@@ -111,7 +110,7 @@ static void draw_shade(cairo_surface_t* surface, int y_position, int shade_heigh
 		cairo_stroke(cairo_white);
 
 		// draw label displaying color value
-		tmp = g_strdup_printf("%d", (int)(gray_level * 255));
+		gchar* tmp = g_strdup_printf("%d", (int)(gray_level * 255));
 		layout = gtk_widget_create_pango_layout(fs_patterns_window, tmp);
 		g_free(tmp);
 		pango_layout_get_pixel_size(layout, &label_width, &label_height);
@@ -193,9 +192,9 @@ static void draw_color_crosses(cairo_surface_t* surface, int width, int height) 
 	cairo_set_line_cap(cairo, CAIRO_LINE_CAP_SQUARE);
 	cairo_set_line_width(cairo, 1);
 	
-	int x, y, color_index = 0, color_column = 0;
+	int x, y, color_column = 0;
 	for (x = 0; x < width; x += cross_size) {
-		color_index = color_column;
+		int color_index = color_column;
 		for (y = 0; y < height; y += cross_size) {
 			switch (color_index % 4) {
 			case 0:
@@ -267,17 +266,17 @@ static void show_pattern(gchar* patternname)
 	}
 	else { // TODO when using enum above, this code can be deleted
 		int label_width, label_height;
-		cairo_t* cairo = cairo_create(surface);
-		cairo_set_source_rgb(cairo, 1.0, 1.0, 1.0);
+		cairo_t* inner_cairo = cairo_create(surface);
+		cairo_set_source_rgb(inner_cairo, 1.0, 1.0, 1.0);
 		gchar* tmp = g_strdup_printf(_("Unknown fullscreen pattern name: %s"), patternname);
 		PangoLayout* layout = pango_layout_new(gtk_widget_get_pango_context(fs_patterns_window));
 		pango_layout_set_markup(layout, tmp, -1);
 		g_free(tmp);
 		pango_layout_get_pixel_size(layout, &label_width, &label_height);
-		cairo_move_to(cairo, (drect.width-label_width)/2, drect.height/8);
-		pango_cairo_show_layout(cairo, layout);
+		cairo_move_to(inner_cairo, (drect.width-label_width)/2, drect.height/8);
+		pango_cairo_show_layout(inner_cairo, layout);
 		g_object_unref(layout);
-		cairo_destroy(cairo);
+		cairo_destroy(inner_cairo);
 	}
 
 	GdkPixbuf* pixbufs[4];

--- a/src/gddccontrol/gddccontrol.desktop.in
+++ b/src/gddccontrol/gddccontrol.desktop.in
@@ -7,3 +7,4 @@ Icon=gddccontrol
 Terminal=false
 Type=Application
 Categories=GTK;Settings;HardwareSettings;
+Keywords=monitor;brightness;contrast;display;screen;DDC;

--- a/src/gddccontrol/gprofile.c
+++ b/src/gddccontrol/gprofile.c
@@ -347,16 +347,14 @@ static GtkWidget* create_info_tree(struct profile* profile, GtkWidget* dialog)
 	struct control_db* control;
 	struct value_db* value_db;
 	
-	gboolean group_created, subgroup_created;
-	
 	int i;
 	
 	for (group = mon->db->group_list; group != NULL; group = group->next)
 	{
-		group_created = FALSE;
+		gboolean group_created = FALSE;
 		for (subgroup = group->subgroup_list; subgroup != NULL; subgroup = subgroup->next)
 		{
-			subgroup_created = FALSE;
+			gboolean subgroup_created = FALSE;
 			for (control = subgroup->control_list; control != NULL; control = control->next)
 			{
 				for (i = 0; i < profile->size; i++)
@@ -529,14 +527,14 @@ void show_profile_information(struct profile* profile, gboolean new_profile) {
 		ddcci_set_profile_name(profile, gtk_entry_get_text(GTK_ENTRY(entry)));
 		rc = ddcci_save_profile(profile, mon);
 		if (!rc) {
-			GtkWidget* dialog = gtk_message_dialog_new(
+			GtkWidget* errordialog = gtk_message_dialog_new(
 					GTK_WINDOW(main_app_window),
 					GTK_DIALOG_DESTROY_WITH_PARENT,
 					GTK_MESSAGE_ERROR,
 					GTK_BUTTONS_CLOSE,
 					_("Error while saving profile."));
-			gtk_dialog_run(GTK_DIALOG(dialog));
-			gtk_widget_destroy(dialog);
+			gtk_dialog_run(GTK_DIALOG(errordialog));
+			gtk_widget_destroy(errordialog);
 			set_message("");
 			return;
 		}

--- a/src/gddccontrol/gprofile.c
+++ b/src/gddccontrol/gprofile.c
@@ -536,6 +536,8 @@ void show_profile_information(struct profile* profile, gboolean new_profile) {
 			gtk_dialog_run(GTK_DIALOG(errordialog));
 			gtk_widget_destroy(errordialog);
 			set_message("");
+			g_free(title);
+			gtk_widget_destroy(dialog);
 			return;
 		}
 		refresh_profile_manager();

--- a/src/gddccontrol/gprofile.c
+++ b/src/gddccontrol/gprofile.c
@@ -196,7 +196,7 @@ void fill_profile_manager() {
 		gtk_widget_set_margin_end(label, 0);
 		gtk_widget_show(label);
 		
-		button = stock_label_button(GTK_STOCK_APPLY, NULL, _("Apply profile"));
+		button = button_from_icon_name("document-open", NULL, _("Apply profile"));
 		gtk_grid_attach(GTK_GRID(grid), button, 1, crow, 1, 1);
 		gtk_widget_set_margin_top(button, 5);
 		gtk_widget_set_margin_bottom(button, 5);
@@ -205,7 +205,7 @@ void fill_profile_manager() {
 		gtk_widget_show(button);
 		g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(apply_callback), profile);
 		
-		button = stock_label_button(GTK_STOCK_EDIT, NULL, _("Show profile details / Rename profile"));
+		button = button_from_icon_name("dialog-information", NULL, _("Show profile details / Rename profile"));
 		gtk_grid_attach(GTK_GRID(grid), button, 2, crow, 1, 1);
 		gtk_widget_set_margin_top(button, 5);
 		gtk_widget_set_margin_bottom(button, 5);
@@ -214,7 +214,7 @@ void fill_profile_manager() {
 		gtk_widget_show(button);
 		g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(show_info_callback), profile);
 		
-		button = stock_label_button(GTK_STOCK_DELETE, NULL, _("Delete profile"));
+		button = button_from_icon_name("edit-delete", NULL, _("Delete profile"));
 		gtk_grid_attach(GTK_GRID(grid), button, 3, crow, 1, 1);
 		gtk_widget_set_margin_top(button, 5);
 		gtk_widget_set_margin_bottom(button, 5);
@@ -250,13 +250,13 @@ void fill_profile_manager() {
 	gtk_widget_set_halign(hbox, GTK_ALIGN_CENTER);
 	gtk_widget_set_valign(hbox, GTK_ALIGN_START);
 	
-	button = stock_label_button(GTK_STOCK_SAVE, _("Create profile"), NULL);
+	button = button_from_icon_name("document-new", _("Create profile"), NULL);
 	g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(create_callback), NULL);
 
 	gtk_box_pack_start(GTK_BOX(hbox), button, 0, 0, 0);
 	gtk_widget_show(button);
 	
-	button = stock_label_button(GTK_STOCK_CLOSE, _("Close profile manager"), NULL);
+	button = button_from_icon_name("window-close", _("Close profile manager"), NULL);
 	g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(close_profile_manager), NULL);
 
 	gtk_box_pack_start(GTK_BOX(hbox), button, 0, 0, 0);
@@ -438,8 +438,12 @@ static void entry_modified_callback(GtkWidget* entry, GtkWidget* dialog) {
 	
 	if (ok_button) {
 		gtk_container_remove(GTK_CONTAINER(gtk_widget_get_parent(ok_button)), ok_button);
-		gtk_dialog_add_button(GTK_DIALOG(dialog), GTK_STOCK_SAVE,   GTK_RESPONSE_OK);
-		gtk_dialog_add_button(GTK_DIALOG(dialog), GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL);
+		GtkWidget *save_button = button_from_icon_name("document-save", _("_Rename profile"), NULL);
+		gtk_widget_show(save_button);
+		gtk_dialog_add_action_widget(GTK_DIALOG(dialog), save_button, GTK_RESPONSE_OK);
+		GtkWidget *cancel_button = button_from_icon_name("edit-clear", _("_Cancel"), NULL);
+		gtk_widget_show(cancel_button);
+		gtk_dialog_add_action_widget(GTK_DIALOG(dialog), cancel_button, GTK_RESPONSE_CANCEL);
 		g_object_set_data(G_OBJECT(dialog), "ok_button", NULL);
 	}
 }
@@ -460,15 +464,21 @@ void show_profile_information(struct profile* profile, gboolean new_profile) {
 		title,
 		GTK_WINDOW(main_app_window),
 		GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
-		NULL);
+		NULL, NULL);
 	
 	if (new_profile) {
 		g_object_set_data(G_OBJECT(dialog), "ok_button", NULL);
-		gtk_dialog_add_button(GTK_DIALOG(dialog), GTK_STOCK_SAVE,   GTK_RESPONSE_OK);
-		gtk_dialog_add_button(GTK_DIALOG(dialog), GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL);
+		GtkWidget* save_button = button_from_icon_name("document-save", _("_Save profile"), NULL);
+		gtk_widget_show(save_button);
+		gtk_dialog_add_action_widget(GTK_DIALOG(dialog), save_button, GTK_RESPONSE_OK);
+		GtkWidget* abort_button = button_from_icon_name("edit-clear-all", _("_Abort creating profile"), NULL);
+		gtk_widget_show(abort_button);
+		gtk_dialog_add_action_widget(GTK_DIALOG(dialog), abort_button, GTK_RESPONSE_CANCEL);
 	}
 	else {
-		GtkWidget* ok_button = gtk_dialog_add_button(GTK_DIALOG(dialog), GTK_STOCK_OK, GTK_RESPONSE_ACCEPT);
+		GtkWidget* ok_button = button_from_icon_name("window-close", _("_Close"), NULL);
+		gtk_widget_show(ok_button);
+		gtk_dialog_add_action_widget(GTK_DIALOG(dialog), ok_button, GTK_RESPONSE_ACCEPT);
 		g_object_set_data(G_OBJECT(dialog), "ok_button", ok_button);
 	}
 	

--- a/src/gddccontrol/gprofile.c
+++ b/src/gddccontrol/gprofile.c
@@ -462,7 +462,7 @@ void show_profile_information(struct profile* profile, gboolean new_profile) {
 		title,
 		GTK_WINDOW(main_app_window),
 		GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
-		NULL, NULL);
+		NULL);
 	
 	if (new_profile) {
 		g_object_set_data(G_OBJECT(dialog), "ok_button", NULL);

--- a/src/gddccontrol/gprofile.c
+++ b/src/gddccontrol/gprofile.c
@@ -19,7 +19,7 @@
  ***************************************************************************/
 
 #include "config.h"
-#include "notebook.h"
+#include "gui.h"
 #include "internal.h"
 
 #include <string.h>

--- a/src/gddccontrol/gprofile.c
+++ b/src/gddccontrol/gprofile.c
@@ -140,7 +140,7 @@ static void create_callback(GtkWidget *widget, gpointer data)
 	gtk_widget_show(saveprofile_button);
 	gtk_widget_show(cancelprofile_button);
 	
-	set_status(_("Please select the controls you want to save in the profile using the checkboxes to the left of each control."));
+	set_status(_("Please select the controls you want to save in the profile using the checkboxes above each control."));
 }
 
 static void close_profile_manager(GtkWidget *widget, gpointer data)

--- a/src/gddccontrol/gprofile.c
+++ b/src/gddccontrol/gprofile.c
@@ -182,7 +182,7 @@ void fill_profile_manager() {
 	
 	gtk_container_set_border_width(GTK_CONTAINER(scrolled_window), 10);
 	gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scrolled_window),
-	                                GTK_POLICY_NEVER, GTK_POLICY_ALWAYS);
+	                                GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
 	
 	grid = gtk_grid_new();
 	
@@ -240,7 +240,7 @@ void fill_profile_manager() {
 		profile = profile->next;
 	}
 	
-	gtk_scrolled_window_add_with_viewport(GTK_SCROLLED_WINDOW(scrolled_window), grid);
+	gtk_container_add(GTK_CONTAINER(scrolled_window), grid);
 	gtk_widget_show(grid);
 	
 	gtk_box_pack_start(GTK_BOX(profile_manager), scrolled_window, TRUE, TRUE, 0);

--- a/src/gddccontrol/gui.h
+++ b/src/gddccontrol/gui.h
@@ -81,7 +81,6 @@ void set_status(char* message);
 void set_message(char* message);
 void set_message_ok(char* message, int with_ok);
 
-GtkWidget *stock_label_button(const gchar * stockid, const gchar *label_text, const gchar *tool_tip);
 GtkWidget *button_from_icon_name(const gchar * icon_name, const gchar *label_text, const gchar *tool_tip);
 
 extern GtkWidget* profile_manager_button;

--- a/src/gddccontrol/gui.h
+++ b/src/gddccontrol/gui.h
@@ -42,7 +42,7 @@ extern GtkWidget* main_app_window;
 extern GtkWidget* monitor_manager;
 extern GtkWidget* profile_manager;
 
-/* notebook.c */
+/* stack.c */
 
 void create_monitor_manager(struct monitorlist* monitor);
 void delete_monitor_manager();

--- a/src/gddccontrol/main.c
+++ b/src/gddccontrol/main.c
@@ -251,7 +251,7 @@ void set_status(char* message) {
 	gtk_label_set_text(GTK_LABEL(statuslabel), message);
 }
 
-static void messagebutton_callback(GtkWidget *widget, gpointer data)
+static void messagebutton_callback(GtkButton *button, gpointer user_data)
 {
 	set_message("");
 }
@@ -546,7 +546,7 @@ int main( int argc, char *argv[] )
 	gtk_box_pack_start(GTK_BOX(messagebox), messagelabel, 1, 1, 0);
 	gtk_widget_show(messagelabel);
 	
-	messagebutton = gtk_label_new_with_mnemonic(_("OK"));
+	messagebutton = gtk_button_new_with_mnemonic(_("OK"));
 	g_signal_connect(G_OBJECT(messagebutton), "clicked", G_CALLBACK(messagebutton_callback), NULL);
 	gtk_widget_set_halign(messagebutton, GTK_ALIGN_CENTER);
 	gtk_widget_set_valign(messagebutton, GTK_ALIGN_CENTER);

--- a/src/gddccontrol/main.c
+++ b/src/gddccontrol/main.c
@@ -26,7 +26,7 @@
 
 #define IDLE_TIMEOUT 60
 
-#include "notebook.h"
+#include "gui.h"
 #include "internal.h"
 
 #include "daemon/dbus_client.h"

--- a/src/gddccontrol/main.c
+++ b/src/gddccontrol/main.c
@@ -357,7 +357,7 @@ static void probe_monitors(GtkWidget *widget, gpointer data) {
 	// TODO: rescan on button, initial get only
 	monlist = ddcci_dbus_rescan_monitors(ddccontrol_proxy);
 
-	struct monitorlist* current;
+	const struct monitorlist* current;
 	
 	char buffer[256];
 	

--- a/src/gddccontrol/main.c
+++ b/src/gddccontrol/main.c
@@ -306,6 +306,49 @@ static gboolean heartbeat(gpointer data)
 
 /* Create a new button with an image and a label packed into it
  * and return the button. */
+GtkWidget *button_from_icon_name(const gchar * icon_name, const gchar *label_text, const gchar *tool_tip)
+{
+	GtkWidget *box;
+	GtkWidget *label = NULL;
+	GtkWidget *image;
+	GtkWidget *button;
+	
+	button = gtk_button_new();
+	
+	/* Create box for image and label */
+	box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
+	gtk_container_set_border_width(GTK_CONTAINER (box), 1);
+	
+	/* Now on to the image stuff */
+	image = gtk_image_new_from_icon_name(icon_name, GTK_ICON_SIZE_BUTTON);
+	gtk_box_pack_start(GTK_BOX(box), image, FALSE, FALSE, 3);
+	gtk_widget_show(image);
+
+	if (label_text) {
+		/* Create a label for the button */
+		label = gtk_label_new_with_mnemonic(label_text);
+		
+		/* Pack the image and label into the box */
+		gtk_box_pack_start(GTK_BOX(box), label, FALSE, FALSE, 3);
+		
+		gtk_widget_show(label);
+	}
+	
+	gtk_widget_show(box);
+	
+	gtk_container_add (GTK_CONTAINER(button), box);
+	
+	g_object_set_data(G_OBJECT(button), "button_label", label);
+	
+	if (tool_tip) {
+		gtk_widget_set_tooltip_text(GTK_WIDGET(button), tool_tip);
+	}
+	
+	return button;
+}
+
+/* Create a new button with an image and a label packed into it
+ * and return the button. */
 GtkWidget *stock_label_button(const gchar * stockid, const gchar *label_text, const gchar *tool_tip)
 {
 	GtkWidget *box;
@@ -480,8 +523,8 @@ int main( int argc, char *argv[] )
 	gtk_widget_show(combo_box);
 
 	gtk_box_pack_start(GTK_BOX(choice_hbox),combo_box, 1, 1, 0);
-	
-	refresh_monitors_button = stock_label_button(GTK_STOCK_REFRESH, NULL, _("Refresh monitor list"));
+
+	refresh_monitors_button = button_from_icon_name("view-refresh", NULL, _("Refresh monitor list"));
 	g_signal_connect(G_OBJECT(refresh_monitors_button), "clicked", G_CALLBACK(probe_monitors), NULL);
 	gtk_widget_show(refresh_monitors_button);
 	gtk_box_pack_start(GTK_BOX(choice_hbox),refresh_monitors_button, 0, 0, 0);
@@ -504,20 +547,20 @@ int main( int argc, char *argv[] )
 	/* Toolbar (profile...) */
 	profile_hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 10);
 	
-	profile_manager_button = stock_label_button(GTK_STOCK_OPEN, _("Profile manager"), NULL);
+	profile_manager_button = button_from_icon_name("folder-symbolic", _("Profile manager"), NULL);
 	g_signal_connect(G_OBJECT(profile_manager_button), "clicked", G_CALLBACK(loadprofile_callback), NULL);
 
 	gtk_box_pack_start(GTK_BOX(profile_hbox), profile_manager_button, 0, 0, 0);
 	gtk_widget_show (profile_manager_button);
 	gtk_widget_set_sensitive(profile_manager_button, FALSE);
 	
-	saveprofile_button = stock_label_button(GTK_STOCK_SAVE, _("Save profile"), NULL);
+	saveprofile_button = button_from_icon_name("document-save", _("Save profile"), NULL);
 	g_signal_connect(G_OBJECT(saveprofile_button), "clicked", G_CALLBACK(saveprofile_callback), NULL);
 
 	gtk_box_pack_start(GTK_BOX(profile_hbox), saveprofile_button, 0, 0, 0);
 	gtk_widget_set_sensitive(saveprofile_button, FALSE);
 	
-	cancelprofile_button = stock_label_button(GTK_STOCK_SAVE, _("Cancel profile creation"), NULL);
+	cancelprofile_button = button_from_icon_name("edit-clear-all", _("Cancel profile creation"), NULL);
 	g_signal_connect(G_OBJECT(cancelprofile_button), "clicked", G_CALLBACK(cancelprofile_callback), NULL);
 
 	gtk_box_pack_start(GTK_BOX(profile_hbox), cancelprofile_button, 0, 0, 0);
@@ -582,14 +625,14 @@ int main( int argc, char *argv[] )
 	gtk_widget_set_halign(br_hbox, GTK_ALIGN_END);
 	gtk_widget_set_valign(br_hbox, GTK_ALIGN_CENTER);
 	
-	refresh_controls_button = stock_label_button(GTK_STOCK_REFRESH, _("Refresh"), _("Refresh all controls"));
+	refresh_controls_button = button_from_icon_name("view-refresh", _("Refresh"), _("Refresh all controls"));
 	g_signal_connect(G_OBJECT(refresh_controls_button),"clicked",G_CALLBACK (refresh_all_controls), NULL);
 
 	gtk_box_pack_start(GTK_BOX(br_hbox),refresh_controls_button,0,0,0);
 	gtk_widget_show (refresh_controls_button);
 	gtk_widget_set_sensitive(refresh_controls_button, FALSE);
 	
-	close_button = stock_label_button(GTK_STOCK_CLOSE, _("Close"), NULL);
+	close_button = button_from_icon_name("window-close", _("Close"), NULL);
 	g_signal_connect(G_OBJECT(close_button),"clicked",G_CALLBACK (destroy), NULL);
 
 	gtk_box_pack_start(GTK_BOX(br_hbox),close_button,0,0,0);

--- a/src/gddccontrol/main.c
+++ b/src/gddccontrol/main.c
@@ -301,7 +301,7 @@ void set_message_ok(char* message, int with_ok)
 static gboolean heartbeat(gpointer data)
 {
 	ddcpci_send_heartbeat();
-	return TRUE;
+	return G_SOURCE_CONTINUE;
 }
 
 /* Create a new button with an image and a label packed into it

--- a/src/gddccontrol/main.c
+++ b/src/gddccontrol/main.c
@@ -347,49 +347,6 @@ GtkWidget *button_from_icon_name(const gchar * icon_name, const gchar *label_tex
 	return button;
 }
 
-/* Create a new button with an image and a label packed into it
- * and return the button. */
-GtkWidget *stock_label_button(const gchar * stockid, const gchar *label_text, const gchar *tool_tip)
-{
-	GtkWidget *box;
-	GtkWidget *label = NULL;
-	GtkWidget *image;
-	GtkWidget *button;
-	
-	button = gtk_button_new();
-	
-	/* Create box for image and label */
-	box = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-	gtk_container_set_border_width(GTK_CONTAINER (box), 1);
-	
-	/* Now on to the image stuff */
-	image = gtk_image_new_from_stock(stockid, GTK_ICON_SIZE_BUTTON);
-	gtk_box_pack_start(GTK_BOX(box), image, FALSE, FALSE, 3);
-	gtk_widget_show(image);
-
-	if (label_text) {
-		/* Create a label for the button */
-		label = gtk_label_new(label_text);
-		
-		/* Pack the image and label into the box */
-		gtk_box_pack_start(GTK_BOX(box), label, FALSE, FALSE, 3);
-		
-		gtk_widget_show(label);
-	}
-	
-	gtk_widget_show(box);
-	
-	gtk_container_add (GTK_CONTAINER(button), box);
-	
-	g_object_set_data(G_OBJECT(button), "button_label", label);
-	
-	if (tool_tip) {
-		gtk_widget_set_tooltip_text(GTK_WIDGET(button), tool_tip);
-	}
-	
-	return button;
-}
-
 static void probe_monitors(GtkWidget *widget, gpointer data) {
 	if (combo_box_changed_handler_id)
 		g_signal_handler_disconnect(G_OBJECT(combo_box), combo_box_changed_handler_id);
@@ -589,7 +546,7 @@ int main( int argc, char *argv[] )
 	gtk_box_pack_start(GTK_BOX(messagebox), messagelabel, 1, 1, 0);
 	gtk_widget_show(messagelabel);
 	
-	messagebutton = stock_label_button(GTK_STOCK_OK, _("OK"), NULL);
+	messagebutton = gtk_label_new_with_mnemonic(_("OK"));
 	g_signal_connect(G_OBJECT(messagebutton), "clicked", G_CALLBACK(messagebutton_callback), NULL);
 	gtk_widget_set_halign(messagebutton, GTK_ALIGN_CENTER);
 	gtk_widget_set_valign(messagebutton, GTK_ALIGN_CENTER);

--- a/src/gddccontrol/notebook.c
+++ b/src/gddccontrol/notebook.c
@@ -19,7 +19,7 @@
  ***************************************************************************/
 
 #include "config.h"
-  
+
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/time.h>
@@ -32,7 +32,7 @@
 #include "internal.h"
 
 #include "daemon/dbus_client.h"
-	
+
 #define GTK_FILL_EXPAND (GtkAttachOptions)(GTK_FILL|GTK_EXPAND)
 
 #define RETRYS 5 // number of read retrys
@@ -65,7 +65,7 @@ extern DDCControl *ddccontrol_proxy;
 static void write_dbctrl(struct control_db *control, unsigned short nval) {
 	ddcci_writectrl(mon, control->address, nval, control->delay);
 }
-	
+
 static void get_value_and_max(struct control_db *control, unsigned short *currentValue, unsigned short *currentMaximum)
 {
 	int result;
@@ -88,7 +88,7 @@ static void get_value_and_max(struct control_db *control, unsigned short *curren
 
 short get_control_max(struct control_db *control) {
 	GSList* list = all_controls;
-	
+
 	while (list) {
 		struct control_db *control_db = (struct control_db*)g_object_get_data(G_OBJECT(list->data), "ddc_control");
 		if (control == control_db) {
@@ -96,7 +96,7 @@ short get_control_max(struct control_db *control) {
 		}
 		list = g_slist_next(list);
 	}
-	
+
 	return 0;
 }
 
@@ -106,19 +106,19 @@ short get_control_max(struct control_db *control) {
 void refresh_all_controls(GtkWidget *widget, gpointer data)
 {
 	/* Maybe we could lock a Mutex here, but I don't think it is really necessary... */
-	
+
 	gtk_widget_set_sensitive(refresh_controls_button, FALSE);
-	
+
 	int current = 0;
 	int count = g_slist_length(all_controls);
 	GSList* list = all_controls;
 	unsigned short currentValue = 1;
 	unsigned short currentMaximum = 1;
-	
+
 	gchar* tmp = g_strdup_printf(_("Refreshing controls values (%d%%)..."), (current*100)/count);
 	set_message(tmp);
 	g_free(tmp);
-	
+
 	refreshing = 1; /* Tell callbacks not to write values back to the monitor. */
 	while (list) {
 		struct control_db *control = (struct control_db*)g_object_get_data(G_OBJECT(list->data), "ddc_control");
@@ -138,21 +138,21 @@ void refresh_all_controls(GtkWidget *widget, gpointer data)
 		current++;
 	}
 	refreshing = 0;
-	
+
 	set_message("");
-	
+
 	gtk_widget_set_sensitive(refresh_controls_button, TRUE);
 }
 
 static void change_control_value(GtkWidget *widget, gpointer nval)
 {
 	struct control_db *control = (struct control_db*)g_object_get_data(G_OBJECT(widget),"ddc_control");
-	
+
 	/* No control found on the widget, we are probably on an item of a group (list) */
 	if (control == NULL) {
 		GtkWidget *parent = gtk_widget_get_parent(widget);
 		control = (struct control_db*)g_object_get_data(G_OBJECT(parent),"ddc_control");
-		
+
 		if ((control) && (control->type == list)) {
 			struct value_db *value = (struct value_db*)g_object_get_data(G_OBJECT(widget), "ddc_value");
 			unsigned short val = value->value;
@@ -160,7 +160,7 @@ static void change_control_value(GtkWidget *widget, gpointer nval)
 		}
 		return;
 	}
-	
+
 	switch(control->type)
 	{
 		case value:
@@ -186,9 +186,9 @@ static void range_callback(GtkWidget *widget, gpointer data)
 	}
 	GtkWidget* button = (GtkWidget*)g_object_get_data(G_OBJECT(widget),"restore_button");
 	g_return_if_fail(button);
-	
+
 	double val = gtk_range_get_value(GTK_RANGE(widget))/100.0;
-	
+
 	unsigned long Default = (unsigned long) g_object_get_data(G_OBJECT(widget),"ddc_default");
 	unsigned long Maximum = (unsigned long) g_object_get_data(G_OBJECT(widget),"ddc_max");
 
@@ -200,49 +200,49 @@ static void range_callback(GtkWidget *widget, gpointer data)
 			val,
 			Maximum);
 #endif
-	
+
 	unsigned short nval = (unsigned short)round(val*(double)Maximum);
 	if (!refreshing)
 		write_dbctrl(control, nval);
-	
+
 	gtk_range_set_value(GTK_RANGE(widget), (double)100.0*nval/(double)Maximum);
-	
+
 	gtk_widget_set_sensitive(GTK_WIDGET(button), nval != Default);
 	modified = 1;
 }
-	
+
 static void group_callback(GtkWidget *widget, gpointer data)
 {
 	struct value_db *value = (struct value_db*)g_object_get_data(G_OBJECT(widget), "ddc_value");
 	g_return_if_fail(value);
-	
+
 	GtkWidget *parent = gtk_widget_get_parent(widget);
 	g_return_if_fail(parent);
-	
+
 	struct control_db *control = (struct control_db*)g_object_get_data(G_OBJECT(parent),"ddc_control");
 	if (!control) {
 		return;
 	}
 	GtkWidget* button = (GtkWidget*)g_object_get_data(G_OBJECT(parent),"restore_button");
 	g_return_if_fail(button);
-	
+
 	unsigned long Default = (unsigned long) g_object_get_data(G_OBJECT(parent),"ddc_default");
-	
+
 	if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget))) {
 		unsigned short val = value->value;
-		
+
 #if 0
 		printf("Would change %#x to %#x\n", currentControl->address, val);
 #endif
-		
+
 		if (control)
 		{
 			if (!refreshing)
 				write_dbctrl(control, val);
-			
+
 			gtk_widget_set_sensitive(GTK_WIDGET(button), val != Default);
 			modified = 1;
-			
+
 			/* Refresh if needed */
 			if (control->refresh == all) {
 				refresh_all_controls(NULL, NULL);
@@ -250,26 +250,26 @@ static void group_callback(GtkWidget *widget, gpointer data)
 		}
 	}
 }
-	
+
 static void command_callback(GtkWidget *widget, gpointer data)
 {
 	struct value_db *value = (struct value_db*) data;
 	struct control_db *control = (struct control_db*)g_object_get_data(G_OBJECT(widget),"ddc_control");
-	
+
 	unsigned short val;
-	
+
 	val = value->value;
-	
+
 #if 0
 	printf("Would change %#x to %#x\n", currentControl->address, val);
 #endif
-	
+
 	if (control)
 	{
 		write_dbctrl(control, val);
-		
+
 		modified = 1;
-		
+
 		/* Refresh if needed */
 		if (control->refresh == all) {
 			refresh_all_controls(NULL, NULL);
@@ -277,33 +277,33 @@ static void command_callback(GtkWidget *widget, gpointer data)
 	}
 	//g_slist_foreach(all_controls,refresh_control,0);
 }
-	
+
 static void restore_callback(GtkWidget *widget, gpointer data)
 {
 	GtkWidget* cwidget = (GtkWidget*)data;
-	
+
 	unsigned long Default = (unsigned long) g_object_get_data(G_OBJECT(cwidget),"ddc_default");
 	struct control_db *control = (struct control_db*)g_object_get_data(G_OBJECT(cwidget),"ddc_control");
-	
+
 	if (control) {
 		write_dbctrl(control, Default);
-		
+
 		change_control_value(cwidget, (gpointer)Default);
 	}
 }
-	
+
 static void tree_selection_changed_callback(GtkTreeSelection *selection, gpointer data)
 {
 	GtkTreeIter iter;
 	GtkTreeModel *model;
 	gint  id;
 	GtkWidget *notebook;
-	
+
 	if (gtk_tree_selection_get_selected(selection, &model, &iter))
 	{
 		gtk_tree_model_get(model,&iter,ID_COL,&id,-1);
 		gtk_tree_model_get(model,&iter,WIDGET_COL,&notebook,-1);
-		
+
 		gtk_notebook_set_current_page(GTK_NOTEBOOK(notebook),id);
 	}
 }
@@ -314,7 +314,7 @@ static void tree_selection_changed_callback(GtkTreeSelection *selection, gpointe
 
 void show_profile_checks(gboolean show) {
 	GSList* list = all_controls;
-	
+
 	while (list) {
 		GtkWidget* check_frame = (GtkWidget*)g_object_get_data(G_OBJECT(list->data), "check_frame");
 		GtkWidget* check = (GtkWidget*)g_object_get_data(G_OBJECT(list->data), "check");
@@ -334,10 +334,10 @@ void show_profile_checks(gboolean show) {
 /* returns: Number of selected controls */
 int get_profile_checked_controls(unsigned char* controls) {
 	int current = 0;
-	
+
 	GSList* list = all_controls;
 	struct control_db *control;
-	
+
 	while (list) {
 		GtkWidget* check = (GtkWidget*)g_object_get_data(G_OBJECT(list->data), "check");
 		if (check) {
@@ -349,7 +349,7 @@ int get_profile_checked_controls(unsigned char* controls) {
 		}
 		list = g_slist_next(list);
 	}
-	
+
 	return current;
 }
 
@@ -359,13 +359,13 @@ static void createControl(GtkWidget *parent,struct control_db *control)
 	unsigned short currentMaximum = 1;
 	if (control->type != command)
 		get_value_and_max(control,&currentDefault,&currentMaximum);
-	
+
 	GtkWidget* hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL,0);
 	GtkWidget *widget = NULL;
 	GtkWidget *button = NULL;
 	GtkWidget *check_frame = NULL; /* Frame around the check */
 	GtkWidget *check = NULL;
-	
+
 	switch (control->type)
 	{
 		case value:
@@ -375,7 +375,7 @@ static void createControl(GtkWidget *parent,struct control_db *control)
 			gtk_widget_show(image);
 			gtk_container_add(GTK_CONTAINER(button), image);
 			gtk_widget_set_sensitive(GTK_WIDGET(button), FALSE);
-			
+
 			check_frame = gtk_frame_new(NULL);
 			check = gtk_check_button_new();
 			image = gtk_image_new_from_stock(GTK_STOCK_SAVE, GTK_ICON_SIZE_LARGE_TOOLBAR);
@@ -388,7 +388,7 @@ static void createControl(GtkWidget *parent,struct control_db *control)
 			button = NULL;
 			break;
 	}
-	
+
 	switch (control->type)
 	{
 		case value:
@@ -400,13 +400,13 @@ static void createControl(GtkWidget *parent,struct control_db *control)
 				g_object_set_data(G_OBJECT(widget), "restore_button", button);
 				g_object_set_data(G_OBJECT(widget), "check_frame", check_frame);
 				g_object_set_data(G_OBJECT(widget), "check", check);
-				
+
 				gtk_range_set_increments(GTK_RANGE(widget),
 						100.0/(double)currentMaximum,
 						100.0/(double)currentMaximum);
 				gtk_range_set_value(GTK_RANGE(widget),
 						(double)100.0*currentDefault/(double)currentMaximum);
-						
+
 				g_signal_connect_after(G_OBJECT(widget), "change-value", G_CALLBACK(range_callback), NULL);
 			}
 			break;
@@ -441,12 +441,12 @@ static void createControl(GtkWidget *parent,struct control_db *control)
 					group = gtk_radio_button_get_group(GTK_RADIO_BUTTON(radio));
 					g_signal_connect(G_OBJECT(radio), "toggled", G_CALLBACK(group_callback), NULL);
 				}
-				
+
 				g_object_set_data(G_OBJECT(widget), "ddc_default", (gpointer)(long)currentDefault);
 				g_object_set_data(G_OBJECT(widget), "restore_button", button);
 				g_object_set_data(G_OBJECT(widget), "check_frame", check_frame);
 				g_object_set_data(G_OBJECT(widget), "check", check);
-				
+
 				break;
 			}
 		default:
@@ -456,30 +456,30 @@ static void createControl(GtkWidget *parent,struct control_db *control)
 		//gtk_widget_show(check_frame);
 		gtk_box_pack_start(GTK_BOX(hbox), check_frame, 0, 0, 0);
 	}
-	
+
 	all_controls = g_slist_append(all_controls,widget);
 	g_object_set_data(G_OBJECT(widget), "ddc_control", control);
 	/*g_print("%i - %i\n",all_controls,g_slist_length(all_controls));*/
 	gtk_widget_show(widget);
 	gtk_box_pack_start(GTK_BOX(hbox), widget, 1, 1, 0);
-	
+
 	if (button) {
 		g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(restore_callback), widget);
 		gtk_widget_show(button);
 		gtk_box_pack_start(GTK_BOX(hbox), button, 0, 0, 0);
 	}
-	
+
 	gtk_widget_show(hbox);
 	gtk_container_add(GTK_CONTAINER(parent),hbox);
 }
-	
+
 static void createPage(GtkWidget* notebook, struct subgroup_db* subgroup)
 {
 	int i=0;
 	GtkWidget* mainvbox = gtk_box_new(GTK_ORIENTATION_VERTICAL,10);
 	GtkWidget* vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL,10);
 	GtkWidget* frame;
-	
+
 	struct control_db* control;
 	for (control = subgroup->control_list; control != NULL; control = control->next)
 	{
@@ -490,7 +490,7 @@ static void createPage(GtkWidget* notebook, struct subgroup_db* subgroup)
 		gtk_box_pack_start(GTK_BOX(vbox),frame,0,0,0);
 		i++;
 	}
-	
+
 	if (subgroup->pattern) {
 		GtkWidget* button = stock_label_button(GTK_STOCK_FULLSCREEN, _("Show fullscreen patterns"), NULL);
 		gtk_widget_show(button);
@@ -502,10 +502,10 @@ static void createPage(GtkWidget* notebook, struct subgroup_db* subgroup)
 		g_object_set_data(G_OBJECT(button), "vbox", vbox);
 		g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(fullscreen_callback), value);
 	}
-	
+
 	gtk_box_pack_start(GTK_BOX(mainvbox), vbox, 0, 5, 5);
 	gtk_widget_show(vbox);
-	
+
 	GtkWidget* label;
 	label = gtk_label_new((char*)subgroup->name);
 	gtk_widget_show(label);
@@ -513,26 +513,26 @@ static void createPage(GtkWidget* notebook, struct subgroup_db* subgroup)
 	gtk_widget_show(mainvbox);
 }
 
-	
+
 static GtkWidget* createTree(GtkWidget *notebook)
 {
 	GtkTreeStore *store = gtk_tree_store_new(N_COLS,G_TYPE_STRING,G_TYPE_INT,G_TYPE_POINTER);
-	
+
 	GtkWidget *tree = gtk_tree_view_new_with_model(GTK_TREE_MODEL(store));
 	g_object_unref(G_OBJECT(store));
-	
+
 	GtkCellRenderer *renderer;
 	GtkTreeViewColumn *column;
 	renderer = gtk_cell_renderer_text_new();
 	column = gtk_tree_view_column_new_with_attributes(_("Section"),renderer,"text",TITLE_COL,NULL);
 	gtk_tree_view_append_column(GTK_TREE_VIEW(tree),column);
-	
+
 	GtkTreeIter top_iter;
 	GtkTreeIter sub_iter;
-	
+
 	struct group_db* group;
 	struct subgroup_db* subgroup;
-	
+
 	if (mon->db)
 	{
 		int id = 1;
@@ -548,19 +548,19 @@ static GtkWidget* createTree(GtkWidget *notebook)
 			}
 		}
 	}
-	
+
 	gtk_tree_view_expand_all(GTK_TREE_VIEW(tree));
 	gtk_tree_view_set_headers_visible(GTK_TREE_VIEW(tree),0);
 	// gtk_container_set_border_width(GTK_CONTAINER(tree),1);
-	
+
 	GtkTreeSelection *select;
-	
+
 	select = gtk_tree_view_get_selection (GTK_TREE_VIEW (tree));
 	gtk_tree_selection_set_mode (select, GTK_SELECTION_SINGLE);
 	g_signal_connect (G_OBJECT (select), "changed",
 			G_CALLBACK (tree_selection_changed_callback),
 			NULL);
-	
+
 	return tree;
 }
 
@@ -568,7 +568,7 @@ void create_monitor_manager(struct monitorlist* monitor)
 {
 	modified = 0;
 	all_controls = NULL;
-	
+
 	if (!monitor->supported) {
 		set_message(_(
 			"The current monitor is in the database but does not support "
@@ -581,11 +581,11 @@ void create_monitor_manager(struct monitorlist* monitor)
 		monitor_manager = NULL;
 		return;
 	}
-	
+
 	gchar* tmp = g_strdup_printf(_("Opening the monitor device (%s)..."), monitor->filename);
 	set_message(tmp);
 	g_free(tmp);
-	
+
 	if (ddcci_dbus_open(ddccontrol_proxy, &mon, monitor->filename) < 0) {
 		set_message(_(
 			"An error occurred while opening the monitor device.\n"
@@ -594,29 +594,31 @@ void create_monitor_manager(struct monitorlist* monitor)
 		monitor_manager = NULL;
 		return;
 	}
-	
+
 	if (!mon->db) {
 		tmp = g_strdup_printf(_(
-			"The current monitor is not supported, please run\n"
-			"%s\n"
-			"and send the output to ddccontrol-users@lists.sourceforge.net.\n"
-			"Thanks."), "<tt>LANG= LC_ALL= ddccontrol -p -c -d</tt>");
+			"Unsupported monitor detected.\n\n"
+			"Please update ddccontrol-db, or, if you are already using the latest\n"
+			"version, please open a github issue:\n"
+			"https://github.com/ddccontrol/ddccontrol-db/issues/new?template=unsupported-monitor.yml"
+			"\nThen attach the resulting report file of the following command:"),
+			"\n<tt>LANG=C LC_ALL=C ddccontrol -p -c -d &> /tmp/ddccontrol-report.txt</tt>\n\n");
 		set_message(tmp);
 		g_free(tmp);
 		monitor_manager = NULL;
 		return;
 	}
-	
+
 	GtkWidget *notebook = gtk_notebook_new();
-	
+
 	struct group_db* group;
 	struct subgroup_db* subgroup;
-	
+
 	GtkWidget *tree = createTree(notebook);
-	
-	//////////////////////////////	
+
+	//////////////////////////////
 	GtkWidget* none = gtk_grid_new();
-	
+
 	GtkWidget *valuelabel = gtk_label_new (_("Please click on a group name."));
 	gtk_grid_attach(GTK_GRID(none), valuelabel, 0, 0, 1, 1);
 	gtk_widget_set_hexpand(valuelabel, TRUE);
@@ -625,14 +627,14 @@ void create_monitor_manager(struct monitorlist* monitor)
 	gtk_widget_set_margin_bottom(valuelabel, 5);
 	gtk_widget_set_margin_start(valuelabel, 5);
 	gtk_widget_set_margin_end(valuelabel, 5);
-	
+
 	GtkWidget *label = gtk_label_new("zero");
-	
+
 	gtk_widget_show(valuelabel);
 	gtk_notebook_append_page (GTK_NOTEBOOK (notebook), none, label);
 	gtk_widget_show(none);
 	/////////////////////////////
-	
+
 	if (mon->db)
 	{
 		int count = 0, current = 0;
@@ -641,7 +643,7 @@ void create_monitor_manager(struct monitorlist* monitor)
 			for (subgroup = group->subgroup_list; subgroup != NULL; subgroup = subgroup->next)
 				count++;
 		}
-		
+
 		gchar* tmp = g_strdup_printf(_("Getting controls values (%d%%)..."), (current*100)/count);
 		set_message(tmp);
 		g_free(tmp);
@@ -649,7 +651,7 @@ void create_monitor_manager(struct monitorlist* monitor)
 		{
 			gtk_notebook_set_show_tabs(GTK_NOTEBOOK(notebook),0);
 			//	gtk_notebook_set_show_border(GTK_NOTEBOOK(notebook),0);
-			
+
 			for (subgroup = group->subgroup_list; subgroup != NULL; subgroup = subgroup->next) {
 				createPage(notebook, subgroup);
 				current++;
@@ -659,7 +661,7 @@ void create_monitor_manager(struct monitorlist* monitor)
 			}
 		}
 	}
-	
+
 	GtkWidget* grid = gtk_grid_new();
 	gtk_widget_show (tree);
 	gtk_grid_attach(GTK_GRID(grid), tree, 0, 0, 1, 1);
@@ -677,15 +679,15 @@ void create_monitor_manager(struct monitorlist* monitor)
 	gtk_widget_set_margin_start(notebook, 3);
 	gtk_widget_set_margin_end(notebook, 0);
 	gtk_widget_show (grid);
-	
+
 	set_message(_("Loading profiles..."));
-	
+
 	ddcci_get_all_profiles(mon);
-	
+
 	create_profile_manager();
-	
+
 	monitor_manager = grid;
-	
+
 	if (mon->fallback) {
 		/* Put a big warning. */
 		gchar* message;
@@ -702,13 +704,14 @@ void create_monitor_manager(struct monitorlist* monitor)
 				"some controls may not work as expected.\n"));
 		}
 
-		gchar* tmp = g_strconcat("<span size='large' weight='ultrabold'>", _("Warning!"), "</span>\n\n", 
+		gchar* tmp = g_strconcat("<span size='large' weight='ultrabold'>", _("Warning!"), "</span>\n\n",
 				message, _(
-				"Please update ddccontrol-db, or, if you are already using the latest "
-				"version, please send the output of the following command to "
-				"ddccontrol-users@lists.sourceforge.net:\n"
-				),
-				"\n<tt>LANG= LC_ALL= ddccontrol -p -c -d</tt>\n\n",
+				"Unsupported monitor detected.\n\n"
+				"Please update ddccontrol-db, or, if you are already using the latest\n"
+				"version, please open a github issue:\n"
+				"https://github.com/ddccontrol/ddccontrol-db/issues/new?template=unsupported-monitor.yml"
+				"\nThen attach the resulting report file of the following command:\n"),
+				"\n<tt>LANG=C LC_ALL=C ddccontrol -p -c -d &> /tmp/ddccontrol-report.txt</tt>\n\n",
 				_("Thank you.\n"), NULL);
 		gtk_widget_show(monitor_manager);
 		set_message_ok(tmp, 1);
@@ -723,16 +726,16 @@ void create_monitor_manager(struct monitorlist* monitor)
 
 // Cleanup
 ////////////////////
-	
+
 void delete_monitor_manager()
 {
 	if (mon) {
 		if (modified)
 			ddcci_save(mon);
-	
+
 		free(mon);
 	}
-	
+
 	if (all_controls) {
 		g_slist_free(all_controls);
 	}

--- a/src/gddccontrol/notebook.c
+++ b/src/gddccontrol/notebook.c
@@ -371,7 +371,7 @@ static void createControl(GtkWidget *parent,struct control_db *control)
 		case value:
 		case list:
 			button = gtk_button_new();
-			GtkWidget *image = gtk_image_new_from_stock(GTK_STOCK_UNDO, GTK_ICON_SIZE_LARGE_TOOLBAR);
+			GtkWidget *image = gtk_image_new_from_icon_name("edit-undo", GTK_ICON_SIZE_BUTTON);
 			gtk_widget_show(image);
 			gtk_container_add(GTK_CONTAINER(button), image);
 			gtk_widget_set_sensitive(GTK_WIDGET(button), FALSE);
@@ -492,7 +492,7 @@ static void createPage(GtkWidget* notebook, struct subgroup_db* subgroup)
 	}
 	
 	if (subgroup->pattern) {
-		GtkWidget* button = stock_label_button(GTK_STOCK_FULLSCREEN, _("Show fullscreen patterns"), NULL);
+		GtkWidget* button = button_from_icon_name("view-fullscreen", _("_Show fullscreen patterns"), NULL);
 		gtk_widget_show(button);
 		gtk_widget_set_halign(button, GTK_ALIGN_CENTER);
 		gtk_widget_set_valign(button, GTK_ALIGN_START);

--- a/src/gddccontrol/notebook.h
+++ b/src/gddccontrol/notebook.h
@@ -34,14 +34,6 @@
 /* constants */
 #define GTK_FILL_EXPAND (GtkAttachOptions)(GTK_FILL|GTK_EXPAND)
 
-#ifndef GTK_STOCK_EDIT /* GTK <2.6 */
-#define GTK_STOCK_EDIT GTK_STOCK_PREFERENCES
-#endif
-
-#ifndef GTK_STOCK_FULLSCREEN /* GTK <2.8 */
-#define GTK_STOCK_FULLSCREEN GTK_STOCK_EXECUTE
-#endif
-
 /* globals */
 extern struct monitor* mon;
 
@@ -90,6 +82,7 @@ void set_message(char* message);
 void set_message_ok(char* message, int with_ok);
 
 GtkWidget *stock_label_button(const gchar * stockid, const gchar *label_text, const gchar *tool_tip);
+GtkWidget *button_from_icon_name(const gchar * icon_name, const gchar *label_text, const gchar *tool_tip);
 
 extern GtkWidget* profile_manager_button;
 extern GtkWidget* saveprofile_button;

--- a/src/gddccontrol/stack.c
+++ b/src/gddccontrol/stack.c
@@ -127,7 +127,7 @@ void refresh_all_controls(GtkWidget *widget, gpointer data)
 				get_value_and_max(control, &currentValue, &currentMaximum);
 				change_control_value(list->data, (gpointer)(long)currentValue);
 			}
-			gchar* tmp = g_strdup_printf(_("Refreshing controls values (%d%%)..."), (current*100)/count);
+			tmp = g_strdup_printf(_("Refreshing controls values (%d%%)..."), (current*100)/count);
 			set_message(tmp);
 			g_free(tmp);
 		}
@@ -234,19 +234,16 @@ static void group_callback(GtkWidget *widget, gpointer data)
 #if 0
 		printf("Would change %#x to %#x\n", currentControl->address, val);
 #endif
+	
+		if (!refreshing)
+			write_dbctrl(control, val);
 		
-		if (control)
-		{
-			if (!refreshing)
-				write_dbctrl(control, val);
-			
-			gtk_widget_set_sensitive(GTK_WIDGET(button), val != Default);
-			modified = 1;
-			
-			/* Refresh if needed */
-			if (control->refresh == all) {
-				refresh_all_controls(NULL, NULL);
-			}
+		gtk_widget_set_sensitive(GTK_WIDGET(button), val != Default);
+		modified = 1;
+		
+		/* Refresh if needed */
+		if (control->refresh == all) {
+			refresh_all_controls(NULL, NULL);
 		}
 	}
 }
@@ -470,12 +467,11 @@ static GtkWidget* createPage(GtkWidget* stack, struct subgroup_db* subgroup)
 	int i=0;
 	GtkWidget* mainvbox = gtk_box_new(GTK_ORIENTATION_VERTICAL,10);
 	GtkWidget* vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL,10);
-	GtkWidget* frame;
 	
 	struct control_db* control;
 	for (control = subgroup->control_list; control != NULL; control = control->next)
 	{
-		frame = gtk_frame_new((char*)control->name);
+		GtkWidget* frame = gtk_frame_new((char*)control->name);
 		gtk_container_set_border_width(GTK_CONTAINER(frame),5);
 		GtkWidget* controlWidget = createControlWidgets(control);
 		gtk_container_add(GTK_CONTAINER(frame), controlWidget);
@@ -551,15 +547,10 @@ static GtkWidget* createTreeAndPages(GtkWidget *stack)
 	{
 		for (group = mon->db->group_list; group != NULL; group = group->next)
 		{
-			
 			for (subgroup = group->subgroup_list; subgroup != NULL; subgroup = subgroup->next) {
 			}
 		}
-	}
-
-	
-	if (mon->db)
-	{
+		
 		int count = 0, current = 0;
 		
 		for (group = mon->db->group_list; group != NULL; group = group->next)
@@ -582,7 +573,7 @@ static GtkWidget* createTreeAndPages(GtkWidget *stack)
 				
 				GtkWidget* currentPage = createPage(stack, subgroup);
 				current++;
-				gchar* tmp = g_strdup_printf(_("Getting controls values (%d%%)..."), (current*100)/count);
+				tmp = g_strdup_printf(_("Getting controls values (%d%%)..."), (current*100)/count);
 				set_message(tmp);
 				g_free(tmp);
 				
@@ -700,7 +691,7 @@ void create_monitor_manager(struct monitorlist* monitor)
 				"some controls may not work as expected.\n"));
 		}
 
-		gchar* tmp = g_strconcat("<span size='large' weight='ultrabold'>", _("Warning!"), "</span>\n\n", 
+		tmp = g_strconcat("<span size='large' weight='ultrabold'>", _("Warning!"), "</span>\n\n", 
 				message, _(
 				"Please update ddccontrol-db, or, if you are already using the latest "
 				"version, please send the output of the following command to "

--- a/src/gddccontrol/stack.c
+++ b/src/gddccontrol/stack.c
@@ -393,7 +393,7 @@ static void createControl(GtkWidget *parent,struct control_db *control)
 	{
 		case value:
 			{
-				widget = gtk_hscale_new_with_range(0.0, 100.0, 1.0);
+				widget = gtk_scale_new_with_range(GTK_ORIENTATION_HORIZONTAL, 0.0, 100.0, 1.0);
 				gtk_scale_set_digits(GTK_SCALE(widget), 1);
 				g_object_set_data(G_OBJECT(widget), "ddc_default", (gpointer)(long)currentDefault);
 				g_object_set_data(G_OBJECT(widget), "ddc_max", (gpointer)(long)currentMaximum);

--- a/src/gddccontrol/stack.c
+++ b/src/gddccontrol/stack.c
@@ -28,7 +28,7 @@
 #include <string.h>
 #include <math.h>
 
-#include "notebook.h"
+#include "gui.h"
 #include "internal.h"
 
 #include "daemon/dbus_client.h"
@@ -40,8 +40,8 @@
 enum
 {
 	TITLE_COL,
-	ID_COL,
-	WIDGET_COL,
+	PAGE_WIDGET,
+	PARENT_CONTAINER,
 	N_COLS,
 };
 
@@ -296,15 +296,15 @@ static void tree_selection_changed_callback(GtkTreeSelection *selection, gpointe
 {
 	GtkTreeIter iter;
 	GtkTreeModel *model;
-	gint  id;
-	GtkWidget *notebook;
+	GtkWidget *page;
+	GtkWidget *parent_container;
 	
 	if (gtk_tree_selection_get_selected(selection, &model, &iter))
 	{
-		gtk_tree_model_get(model,&iter,ID_COL,&id,-1);
-		gtk_tree_model_get(model,&iter,WIDGET_COL,&notebook,-1);
+		gtk_tree_model_get(model, &iter, PAGE_WIDGET, &page, -1);
+		gtk_tree_model_get(model, &iter, PARENT_CONTAINER, &parent_container, -1);
 		
-		gtk_notebook_set_current_page(GTK_NOTEBOOK(notebook),id);
+		gtk_stack_set_visible_child(GTK_STACK(parent_container), page);
 	}
 }
 
@@ -473,8 +473,12 @@ static void createControl(GtkWidget *parent,struct control_db *control)
 	gtk_container_add(GTK_CONTAINER(parent),hbox);
 }
 	
-static void createPage(GtkWidget* notebook, struct subgroup_db* subgroup)
+static GtkWidget* createPage(GtkWidget* stack, struct subgroup_db* subgroup)
 {
+	GtkWidget* scroll_area = gtk_scrolled_window_new(NULL, NULL);
+	gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll_area), GTK_POLICY_NEVER, GTK_POLICY_AUTOMATIC);
+	gtk_widget_show(scroll_area);
+	
 	int i=0;
 	GtkWidget* mainvbox = gtk_box_new(GTK_ORIENTATION_VERTICAL,10);
 	GtkWidget* vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL,10);
@@ -506,17 +510,18 @@ static void createPage(GtkWidget* notebook, struct subgroup_db* subgroup)
 	gtk_box_pack_start(GTK_BOX(mainvbox), vbox, 0, 5, 5);
 	gtk_widget_show(vbox);
 	
-	GtkWidget* label;
-	label = gtk_label_new((char*)subgroup->name);
-	gtk_widget_show(label);
-	gtk_notebook_append_page(GTK_NOTEBOOK(notebook), mainvbox, label);
+	gtk_container_add(GTK_CONTAINER(scroll_area), mainvbox);
+	
+	gtk_stack_add_named(GTK_STACK(stack), scroll_area, subgroup->name);
 	gtk_widget_show(mainvbox);
+
+	return scroll_area;
 }
 
-	
-static GtkWidget* createTree(GtkWidget *notebook)
+/* The GtkTreeView acts as a hierarchical GtkStackSwitcher */
+static GtkWidget* createTreeAndPages(GtkWidget *stack)
 {
-	GtkTreeStore *store = gtk_tree_store_new(N_COLS,G_TYPE_STRING,G_TYPE_INT,G_TYPE_POINTER);
+	GtkTreeStore *store = gtk_tree_store_new(N_COLS,G_TYPE_STRING,G_TYPE_POINTER,G_TYPE_POINTER);
 	
 	GtkWidget *tree = gtk_tree_view_new_with_model(GTK_TREE_MODEL(store));
 	g_object_unref(G_OBJECT(store));
@@ -529,22 +534,70 @@ static GtkWidget* createTree(GtkWidget *notebook)
 	
 	GtkTreeIter top_iter;
 	GtkTreeIter sub_iter;
+
+	////////////////
+	GtkWidget* empty_selection_info = gtk_grid_new();
+	
+	GtkWidget *valuelabel = gtk_label_new (_("Please click on a group name."));
+	gtk_grid_attach(GTK_GRID(empty_selection_info), valuelabel, 0, 0, 1, 1);
+	gtk_widget_set_hexpand(valuelabel, TRUE);
+	gtk_widget_set_vexpand(valuelabel, TRUE);
+	gtk_widget_set_margin_top(valuelabel, 5);
+	gtk_widget_set_margin_bottom(valuelabel, 5);
+	gtk_widget_set_margin_start(valuelabel, 5);
+	gtk_widget_set_margin_end(valuelabel, 5);
+	gtk_widget_show(valuelabel);
+	
+	gtk_stack_add_named(GTK_STACK(stack), empty_selection_info, "__zero");
+	gtk_widget_show(empty_selection_info);
+	gtk_stack_set_visible_child(GTK_STACK(stack), empty_selection_info);
+	///////////////////////
+	
 	
 	struct group_db* group;
 	struct subgroup_db* subgroup;
+
+
+	if (mon->db)
+	{
+		for (group = mon->db->group_list; group != NULL; group = group->next)
+		{
+			
+			for (subgroup = group->subgroup_list; subgroup != NULL; subgroup = subgroup->next) {
+			}
+		}
+	}
+
 	
 	if (mon->db)
 	{
-		int id = 1;
+		int count = 0, current = 0;
+		
+		for (group = mon->db->group_list; group != NULL; group = group->next)
+		{
+			for (subgroup = group->subgroup_list; subgroup != NULL; subgroup = subgroup->next)
+				count++;
+		}
+		
+		gchar* tmp = g_strdup_printf(_("Getting controls values (%d%%)..."), (current*100)/count);
+		set_message(tmp);
+		g_free(tmp);
+		
 		for (group = mon->db->group_list; group != NULL; group = group->next)
 		{
 			gtk_tree_store_append(store,&top_iter,NULL);
-			gtk_tree_store_set(store,&top_iter,TITLE_COL,group->name,ID_COL,0,WIDGET_COL,notebook,-1);
+			gtk_tree_store_set(store, &top_iter, TITLE_COL, group->name, PAGE_WIDGET, empty_selection_info, PARENT_CONTAINER, stack,-1);
 			for (subgroup = group->subgroup_list; subgroup != NULL; subgroup = subgroup->next)
 			{
 				gtk_tree_store_append(store,&sub_iter,&top_iter);
-				gtk_tree_store_set(store,&sub_iter,TITLE_COL,subgroup->name,ID_COL,id,WIDGET_COL,notebook,-1);
-				id++;
+				
+				GtkWidget* currentPage = createPage(stack, subgroup);
+				current++;
+				gchar* tmp = g_strdup_printf(_("Getting controls values (%d%%)..."), (current*100)/count);
+				set_message(tmp);
+				g_free(tmp);
+				
+				gtk_tree_store_set(store, &sub_iter, TITLE_COL, subgroup->name, PAGE_WIDGET, currentPage, PARENT_CONTAINER, stack,-1);
 			}
 		}
 	}
@@ -607,58 +660,9 @@ void create_monitor_manager(struct monitorlist* monitor)
 		return;
 	}
 	
-	GtkWidget *notebook = gtk_notebook_new();
+	GtkWidget *stack = gtk_stack_new();
 	
-	struct group_db* group;
-	struct subgroup_db* subgroup;
-	
-	GtkWidget *tree = createTree(notebook);
-	
-	//////////////////////////////	
-	GtkWidget* none = gtk_grid_new();
-	
-	GtkWidget *valuelabel = gtk_label_new (_("Please click on a group name."));
-	gtk_grid_attach(GTK_GRID(none), valuelabel, 0, 0, 1, 1);
-	gtk_widget_set_hexpand(valuelabel, TRUE);
-	gtk_widget_set_vexpand(valuelabel, TRUE);
-	gtk_widget_set_margin_top(valuelabel, 5);
-	gtk_widget_set_margin_bottom(valuelabel, 5);
-	gtk_widget_set_margin_start(valuelabel, 5);
-	gtk_widget_set_margin_end(valuelabel, 5);
-	
-	GtkWidget *label = gtk_label_new("zero");
-	
-	gtk_widget_show(valuelabel);
-	gtk_notebook_append_page (GTK_NOTEBOOK (notebook), none, label);
-	gtk_widget_show(none);
-	/////////////////////////////
-	
-	if (mon->db)
-	{
-		int count = 0, current = 0;
-		for (group = mon->db->group_list; group != NULL; group = group->next)
-		{
-			for (subgroup = group->subgroup_list; subgroup != NULL; subgroup = subgroup->next)
-				count++;
-		}
-		
-		gchar* tmp = g_strdup_printf(_("Getting controls values (%d%%)..."), (current*100)/count);
-		set_message(tmp);
-		g_free(tmp);
-		for (group = mon->db->group_list; group != NULL; group = group->next)
-		{
-			gtk_notebook_set_show_tabs(GTK_NOTEBOOK(notebook),0);
-			//	gtk_notebook_set_show_border(GTK_NOTEBOOK(notebook),0);
-			
-			for (subgroup = group->subgroup_list; subgroup != NULL; subgroup = subgroup->next) {
-				createPage(notebook, subgroup);
-				current++;
-				gchar* tmp = g_strdup_printf(_("Getting controls values (%d%%)..."), (current*100)/count);
-				set_message(tmp);
-				g_free(tmp);
-			}
-		}
-	}
+	GtkWidget *tree = createTreeAndPages(stack);
 	
 	GtkWidget* grid = gtk_grid_new();
 	gtk_widget_show (tree);
@@ -668,14 +672,19 @@ void create_monitor_manager(struct monitorlist* monitor)
 	gtk_widget_set_margin_bottom(tree, 0);
 	gtk_widget_set_margin_start(tree, 3);
 	gtk_widget_set_margin_end(tree, 0);
-	gtk_widget_show (notebook);
-	gtk_grid_attach(GTK_GRID(grid), notebook, 1, 0, 1, 1);
-	gtk_widget_set_hexpand(notebook, TRUE);
-	gtk_widget_set_vexpand(notebook, TRUE);
-	gtk_widget_set_margin_top(notebook, 3);
-	gtk_widget_set_margin_bottom(notebook, 0);
-	gtk_widget_set_margin_start(notebook, 3);
-	gtk_widget_set_margin_end(notebook, 0);
+	gtk_widget_show (stack);
+	
+	GtkWidget* separator = gtk_separator_new(GTK_ORIENTATION_VERTICAL);
+	gtk_grid_attach(GTK_GRID(grid), separator, 1, 0, 1, 1);
+	gtk_widget_show(separator);
+	
+	gtk_grid_attach(GTK_GRID(grid), stack, 2, 0, 1, 1);
+	gtk_widget_set_hexpand(stack, TRUE);
+	gtk_widget_set_vexpand(stack, TRUE);
+	gtk_widget_set_margin_top(stack, 3);
+	gtk_widget_set_margin_bottom(stack, 0);
+	gtk_widget_set_margin_start(stack, 3);
+	gtk_widget_set_margin_end(stack, 0);
 	gtk_widget_show (grid);
 	
 	set_message(_("Loading profiles..."));

--- a/src/gddccontrol/stack.c
+++ b/src/gddccontrol/stack.c
@@ -316,16 +316,15 @@ void show_profile_checks(gboolean show) {
 	GSList* list = all_controls;
 	
 	while (list) {
-		GtkWidget* check_frame = (GtkWidget*)g_object_get_data(G_OBJECT(list->data), "check_frame");
-		GtkWidget* check = (GtkWidget*)g_object_get_data(G_OBJECT(list->data), "check");
-		if (check_frame) {
+		GtkWidget* profileCheckBox = (GtkWidget*)g_object_get_data(G_OBJECT(list->data), "profile_check_box");
+		if (profileCheckBox) {
 			if (show)
-				gtk_widget_show(check_frame);
+				gtk_widget_show(profileCheckBox);
 			else
-				gtk_widget_hide(check_frame);
+				gtk_widget_hide(profileCheckBox);
 		}
-		if (check && show) {
-			gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(check), FALSE);
+		if (profileCheckBox && show) {
+			gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(profileCheckBox), FALSE);
 		}
 		list = g_slist_next(list);
 	}
@@ -339,9 +338,9 @@ int get_profile_checked_controls(unsigned char* controls) {
 	struct control_db *control;
 	
 	while (list) {
-		GtkWidget* check = (GtkWidget*)g_object_get_data(G_OBJECT(list->data), "check");
-		if (check) {
-			if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(check))) {
+		GtkWidget* profileCheckBox = (GtkWidget*)g_object_get_data(G_OBJECT(list->data), "profile_check_box");
+		if (profileCheckBox) {
+			if (gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(profileCheckBox))) {
 				control = (struct control_db*)g_object_get_data(G_OBJECT(list->data), "ddc_control");
 				controls[current] = control->address;
 				current++;
@@ -353,39 +352,29 @@ int get_profile_checked_controls(unsigned char* controls) {
 	return current;
 }
 
-static void createControl(GtkWidget *parent,struct control_db *control)
+static GtkWidget* createControlWidgets(struct control_db *control)
 {
 	unsigned short currentDefault = 1;
 	unsigned short currentMaximum = 1;
 	if (control->type != command)
 		get_value_and_max(control,&currentDefault,&currentMaximum);
 	
-	GtkWidget* hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL,0);
+	GtkWidget* outerBox = gtk_box_new(GTK_ORIENTATION_VERTICAL,0);
+	GtkWidget* controlWithUndo = gtk_box_new(GTK_ORIENTATION_HORIZONTAL,0);
 	GtkWidget *widget = NULL;
-	GtkWidget *button = NULL;
-	GtkWidget *check_frame = NULL; /* Frame around the check */
-	GtkWidget *check = NULL;
+	GtkWidget *undoButton = NULL;
+	GtkWidget *profileCheckBox = NULL;
 	
 	switch (control->type)
 	{
 		case value:
 		case list:
-			button = gtk_button_new();
-			GtkWidget *image = gtk_image_new_from_icon_name("edit-undo", GTK_ICON_SIZE_BUTTON);
-			gtk_widget_show(image);
-			gtk_container_add(GTK_CONTAINER(button), image);
-			gtk_widget_set_sensitive(GTK_WIDGET(button), FALSE);
+			undoButton = button_from_icon_name("edit-undo", NULL, NULL);
+			gtk_widget_set_sensitive(GTK_WIDGET(undoButton), FALSE);
 			
-			check_frame = gtk_frame_new(NULL);
-			check = gtk_check_button_new();
-			image = gtk_image_new_from_stock(GTK_STOCK_SAVE, GTK_ICON_SIZE_LARGE_TOOLBAR);
-			gtk_widget_show(image);
-			gtk_container_add(GTK_CONTAINER(check), image);
-			gtk_widget_show(check);
-			gtk_container_add(GTK_CONTAINER(check_frame),check);
+			profileCheckBox = gtk_check_button_new_with_label(_("Include in new profile"));
 			break;
 		default:
-			button = NULL;
 			break;
 	}
 	
@@ -397,9 +386,8 @@ static void createControl(GtkWidget *parent,struct control_db *control)
 				gtk_scale_set_digits(GTK_SCALE(widget), 1);
 				g_object_set_data(G_OBJECT(widget), "ddc_default", (gpointer)(long)currentDefault);
 				g_object_set_data(G_OBJECT(widget), "ddc_max", (gpointer)(long)currentMaximum);
-				g_object_set_data(G_OBJECT(widget), "restore_button", button);
-				g_object_set_data(G_OBJECT(widget), "check_frame", check_frame);
-				g_object_set_data(G_OBJECT(widget), "check", check);
+				g_object_set_data(G_OBJECT(widget), "restore_button", undoButton);
+				g_object_set_data(G_OBJECT(widget), "profile_check_box", profileCheckBox);
 				
 				gtk_range_set_increments(GTK_RANGE(widget),
 						100.0/(double)currentMaximum,
@@ -443,34 +431,34 @@ static void createControl(GtkWidget *parent,struct control_db *control)
 				}
 				
 				g_object_set_data(G_OBJECT(widget), "ddc_default", (gpointer)(long)currentDefault);
-				g_object_set_data(G_OBJECT(widget), "restore_button", button);
-				g_object_set_data(G_OBJECT(widget), "check_frame", check_frame);
-				g_object_set_data(G_OBJECT(widget), "check", check);
+				g_object_set_data(G_OBJECT(widget), "restore_button", undoButton);
+				g_object_set_data(G_OBJECT(widget), "profile_check_box", profileCheckBox);
 				
 				break;
 			}
 		default:
-			return;
+			break;
 	}
-	if (check) {
-		//gtk_widget_show(check_frame);
-		gtk_box_pack_start(GTK_BOX(hbox), check_frame, 0, 0, 0);
+	if (profileCheckBox) {
+		gtk_box_pack_start(GTK_BOX(outerBox), profileCheckBox, 0, 0, 0);
 	}
 	
 	all_controls = g_slist_append(all_controls,widget);
 	g_object_set_data(G_OBJECT(widget), "ddc_control", control);
 	/*g_print("%i - %i\n",all_controls,g_slist_length(all_controls));*/
 	gtk_widget_show(widget);
-	gtk_box_pack_start(GTK_BOX(hbox), widget, 1, 1, 0);
+	gtk_box_pack_start(GTK_BOX(controlWithUndo), widget, 1, 1, 0);
 	
-	if (button) {
-		g_signal_connect(G_OBJECT(button), "clicked", G_CALLBACK(restore_callback), widget);
-		gtk_widget_show(button);
-		gtk_box_pack_start(GTK_BOX(hbox), button, 0, 0, 0);
+	if (undoButton) {
+		g_signal_connect(G_OBJECT(undoButton), "clicked", G_CALLBACK(restore_callback), widget);
+		gtk_widget_show(undoButton);
+		gtk_box_pack_start(GTK_BOX(controlWithUndo), undoButton, 0, 0, 0);
 	}
-	
-	gtk_widget_show(hbox);
-	gtk_container_add(GTK_CONTAINER(parent),hbox);
+
+	gtk_box_pack_end(GTK_BOX(outerBox), controlWithUndo, 0, 0, 0);
+	gtk_widget_show(controlWithUndo);
+	gtk_widget_show(outerBox);
+	return outerBox;
 }
 	
 static GtkWidget* createPage(GtkWidget* stack, struct subgroup_db* subgroup)
@@ -489,7 +477,8 @@ static GtkWidget* createPage(GtkWidget* stack, struct subgroup_db* subgroup)
 	{
 		frame = gtk_frame_new((char*)control->name);
 		gtk_container_set_border_width(GTK_CONTAINER(frame),5);
-		createControl(frame,control);
+		GtkWidget* controlWidget = createControlWidgets(control);
+		gtk_container_add(GTK_CONTAINER(frame), controlWidget);
 		gtk_widget_show(frame);
 		gtk_box_pack_start(GTK_BOX(vbox),frame,0,0,0);
 		i++;

--- a/src/lib/issueurl.c
+++ b/src/lib/issueurl.c
@@ -1,0 +1,57 @@
+#include "issueurl.h"
+#include "urlencode.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+char *build_issue_url(const struct issue_report *report) {
+    const char *base =
+        "https://github.com/ddccontrol/ddccontrol-db/issues/new"
+        "?template=unsupported-monitor.yml";
+
+    char *enc_name = url_encode(report->monitor_name ? report->monitor_name : "");
+    char *enc_pnp  = url_encode(report->pnp_id ? report->pnp_id : "");
+    char *enc_dev  = url_encode(report->device ? report->device : "");
+    char *enc_ver  = url_encode(report->ddccontrol_version ? report->ddccontrol_version : "");
+    char *enc_fallback = url_encode(report->fallback_profile ? report->fallback_profile : "");
+
+    if (!enc_name || !enc_pnp || !enc_dev || !enc_ver || !enc_fallback) {
+        free(enc_name);
+        free(enc_pnp);
+        free(enc_dev);
+        free(enc_ver);
+        free(enc_fallback);
+        return NULL;
+    }
+
+    size_t len = strlen(base)
+               + strlen("&monitor_name=") + strlen(enc_name)
+               + strlen("&pnp_id=") + strlen(enc_pnp)
+               + strlen("&device=") + strlen(enc_dev)
+               + strlen("&ddccontrol_version=") + strlen(enc_ver)
+               + strlen("&fallback_profile=") + strlen(enc_fallback)
+               + 1;
+
+    char *url = malloc(len);
+    if (!url) {
+        free(enc_name);
+        free(enc_pnp);
+        free(enc_dev);
+        free(enc_ver);
+        free(enc_fallback);
+        return NULL;
+    }
+
+    snprintf(url, len,
+             "%s&monitor_name=%s&pnp_id=%s&device=%s&ddccontrol_version=%s&fallback_profile=%s",
+             base, enc_name, enc_pnp, enc_dev, enc_ver, enc_fallback);
+
+    free(enc_name);
+    free(enc_pnp);
+    free(enc_dev);
+    free(enc_ver);
+    free(enc_fallback);
+
+    return url;
+}

--- a/src/lib/issueurl.h
+++ b/src/lib/issueurl.h
@@ -1,0 +1,14 @@
+#ifndef ISSUEURL_H
+#define ISSUEURL_H
+
+struct issue_report {
+    const char *monitor_name;
+    const char *pnp_id;
+    const char *device;
+    const char *ddccontrol_version;
+    const char *fallback_profile;
+};
+
+char *build_issue_url(const struct issue_report *report);
+
+#endif

--- a/src/lib/urlencode.c
+++ b/src/lib/urlencode.c
@@ -1,0 +1,39 @@
+#include "urlencode.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+char *url_encode(const char *s) {
+    if (!s) return NULL;
+
+    size_t len = 0;
+    const unsigned char *p;
+
+    for (p = (const unsigned char *)s; *p; p++) {
+        if (isalnum(*p) || *p == '-' || *p == '_' || *p == '.' || *p == '~') {
+            len += 1;
+        } else {
+            len += 3;
+        }
+    }
+
+    char *out = malloc(len + 1);
+    if (!out) {
+        return NULL;
+    }
+
+    char *q = out;
+    for (p = (const unsigned char *)s; *p; p++) {
+        if (isalnum(*p) || *p == '-' || *p == '_' || *p == '.' || *p == '~') {
+            *q++ = (char)*p;
+        } else {
+            sprintf(q, "%%%02X", *p);
+            q += 3;
+        }
+    }
+
+    *q = '\0';
+    return out;
+}

--- a/src/lib/urlencode.h
+++ b/src/lib/urlencode.h
@@ -1,0 +1,20 @@
+#ifndef URLENCODE_H
+#define URLENCODE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * URL encodes a string before use in query parameters.
+ *
+ * - Returns a malloc allocated string (must be free()'d by caller)
+ * - Returns NULL on error
+ */
+char *url_encode(const char *s);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* URLENCODE_H */


### PR DESCRIPTION
This code gets rid of the majority of deprecation warnings in Gtk3 code, most notably related to `GtkStock`. This PR is another step to prepare Gtk4 migration (#153).

Major changes:
- Replace all usages of `GtkStock`. Where applicable, use Gtk's icons instead.
  - In case of selecting a control for a profile, the icon was completely removed (as I found it to be unintuitive) and replaced with text.
  - I tried following Gtk's guidelines of being more descriptive in button labels, e.g. instead of a "Save" icon, the text says "Rename profile"
- Make use of `GtkStack` instead of the crippling `GtkNotebook` to run without tabs.
  - And adapt the `GtkTreeModel` data structure for it
- Put each of the stack's pages into a `GtkScrolledWindow` to make the application's resize behavior less cranky / more intuitive and independent from the control's pages.

Minor changes:
- Remove unused variables
- Fix some other deprecation warnings
- Profile manager: Show scroll bar only when necessary
- Add mnemonics to some buttons