### PR TITLE
Harden check_integrity buffer and monitor auto-select allocation

### DIFF
--- a/src/ddccontrol/main.c
+++ b/src/ddccontrol/main.c
@@ -112,15 +112,28 @@ static void check_integrity(char *datadir, char *pnpname)
 	printf(_("[ OK ]\n"));
 
 	/* Create caps with all controls. */
-	char buf2[4];
-	char buffer[256 * 3 + 25];
-	strcpy(buffer, "(vcp(");
+	char buffer[sizeof("(vcp(") + (3 * 256) + sizeof("))")];
+	int pos = snprintf(buffer, sizeof(buffer), "(vcp(");
+	if (pos < 0 || (size_t)pos >= sizeof(buffer)) {
+		fprintf(stderr, "Failed to build monitor capability buffer.\n");
+		ddcci_release_db();
+		exit(1);
+	}
 	int i;
 	for (i = 0; i < 256; i++) {
-		snprintf(buf2, 4, "%02x ", i);
-		strcat(buffer, buf2);
+		int n = snprintf(buffer + pos, sizeof(buffer) - (size_t)pos, "%02x ", i);
+		if (n < 0 || (size_t)n >= sizeof(buffer) - (size_t)pos) {
+			fprintf(stderr, "Failed to build monitor capability buffer.\n");
+			ddcci_release_db();
+			exit(1);
+		}
+		pos += n;
 	}
-	strcat(buffer, "))");
+	if (snprintf(buffer + pos, sizeof(buffer) - (size_t)pos, "))") < 0) {
+		fprintf(stderr, "Failed to build monitor capability buffer.\n");
+		ddcci_release_db();
+		exit(1);
+	}
 
 	struct caps caps;
 	ddcci_parse_caps(buffer, &caps, 1);
@@ -319,9 +332,16 @@ int main(int argc, char **argv)
 
 			if ((!fn) && (current->supported)) {
 				printf(_("  (Automatically selected)\n"));
-				fn = malloc(strlen(current->filename) + 1);
-				strcpy(fn, current->filename);
+				fn = strdup(current->filename);
 				selected_monitor_name = strdup(current->name);
+				if (!fn || !selected_monitor_name) {
+					fprintf(stderr, _("Memory allocation failed\n"));
+					free(fn);
+					free(selected_monitor_name);
+					ddcci_free_list(monlist);
+					ddcci_release();
+					exit(1);
+				}
 				report.monitor_name = selected_monitor_name;
 			}
 			current = current->next;

--- a/src/ddccontrol/main.c
+++ b/src/ddccontrol/main.c
@@ -129,10 +129,13 @@ static void check_integrity(char *datadir, char *pnpname)
 		}
 		pos += n;
 	}
-	if (snprintf(buffer + pos, sizeof(buffer) - (size_t)pos, "))") < 0) {
-		fprintf(stderr, "Failed to build monitor capability buffer.\n");
-		ddcci_release_db();
-		exit(1);
+	{
+		int n = snprintf(buffer + pos, sizeof(buffer) - (size_t)pos, "))");
+		if (n < 0 || (size_t)n >= sizeof(buffer) - (size_t)pos) {
+			fprintf(stderr, "Failed to build monitor capability buffer.\n");
+			ddcci_release_db();
+			exit(1);
+		}
 	}
 
 	struct caps caps;


### PR DESCRIPTION
## Summary
This PR supersedes #197 with stricter hardening in the same code path.

## Changes
- Replaced unbounded string building in `check_integrity()` with bounded `snprintf` appends.
- Added explicit handling for `snprintf` failure/truncation while building the capability buffer.
- Replaced `malloc + strcpy` with `strdup` for auto-selected monitor device name.
- Added allocation-failure cleanup (`free`, `ddcci_free_list`, `ddcci_release`) before exit.

## Why
- Reduces risk of unsafe writes.
- Improves robustness in error/edge paths while preserving normal behavior.
