### PR TITLE
Remove empty stack loop

### DIFF
--- a/src/gddccontrol/stack.c
+++ b/src/gddccontrol/stack.c
@@ -545,12 +545,6 @@ static GtkWidget* createTreeAndPages(GtkWidget *stack)
 
 	if (mon->db)
 	{
-		for (group = mon->db->group_list; group != NULL; group = group->next)
-		{
-			for (subgroup = group->subgroup_list; subgroup != NULL; subgroup = subgroup->next) {
-			}
-		}
-		
 		int count = 0, current = 0;
 		
 		for (group = mon->db->group_list; group != NULL; group = group->next)


### PR DESCRIPTION
## Summary
- Remove an empty no-op subgroup iteration loop in `createTreeAndPages`
- Keep the actual subgroup counting loop unchanged

## Testing
- Not run; readability-only cleanup with no behavior change