### PR TITLE
fix: null dereference from getenv

### DIFF
--- a/src/lib/conf.c
+++ b/src/lib/conf.c
@@ -53,7 +53,11 @@ static char* get_monitorlist_filename() {
 	
 	ddcci_create_config_dir();
 	
-	home     = getenv("HOME");
+	home = getenv("HOME");
+	if (home == NULL) {
+		fprintf(stderr, _("Cannot get home directory (HOME is not set)\n"));
+		return NULL;
+	}
 	trailing = (home[strlen(home)-1] == '/');
 	
 	len = strlen(home) + 64;
@@ -250,7 +254,12 @@ struct profile* ddcci_create_profile(struct monitor* mon, const unsigned char* a
 	
 	time_t tm = time(NULL);
 	len      = strftime(&date[0], 32, "%Y%m%d-%H%M%S", localtime(&tm));
-	home     = getenv("HOME");
+	home = getenv("HOME");
+	if (home == NULL) {
+		fprintf(stderr, _("Cannot get home directory (HOME is not set)\n"));
+		ddcci_free_profile(profile);
+		return 0;
+	}
 	trailing = (home[strlen(home)-1] == '/');
 	
 	len += strlen(home) + 32;
@@ -300,7 +309,11 @@ int ddcci_get_all_profiles(struct monitor* mon) {
 	struct profile** next = &mon->profiles;
 	struct profile* profile;
 	
-	home     = getenv("HOME");
+	home = getenv("HOME");
+	if (home == NULL) {
+		fprintf(stderr, _("Cannot get home directory (HOME is not set)\n"));
+		return 0;
+	}
 	trailing = (home[strlen(home)-1] == '/');
 	
 	len = strlen(home) + 64;

--- a/src/lib/conf.c
+++ b/src/lib/conf.c
@@ -51,13 +51,14 @@ static char* get_monitorlist_filename() {
 	int len, ret;
 	char* home;
 	
-	ddcci_create_config_dir();
-	
 	home = getenv("HOME");
-	if (home == NULL) {
+	if ((home == NULL) || (home[0] == '\0')) {
 		fprintf(stderr, _("Cannot get home directory (HOME is not set)\n"));
 		return NULL;
 	}
+	
+	ddcci_create_config_dir();
+	
 	trailing = (home[strlen(home)-1] == '/');
 	
 	len = strlen(home) + 64;
@@ -255,7 +256,7 @@ struct profile* ddcci_create_profile(struct monitor* mon, const unsigned char* a
 	time_t tm = time(NULL);
 	len      = strftime(&date[0], 32, "%Y%m%d-%H%M%S", localtime(&tm));
 	home = getenv("HOME");
-	if (home == NULL) {
+	if ((home == NULL) || (home[0] == '\0')) {
 		fprintf(stderr, _("Cannot get home directory (HOME is not set)\n"));
 		ddcci_free_profile(profile);
 		return 0;
@@ -310,7 +311,7 @@ int ddcci_get_all_profiles(struct monitor* mon) {
 	struct profile* profile;
 	
 	home = getenv("HOME");
-	if (home == NULL) {
+	if ((home == NULL) || (home[0] == '\0')) {
 		fprintf(stderr, _("Cannot get home directory (HOME is not set)\n"));
 		return 0;
 	}

--- a/src/lib/conf.c
+++ b/src/lib/conf.c
@@ -45,21 +45,27 @@
 
 /* Read/write monitor list */
 
+static int ddcci_get_home_dir(char** home, int* trailing) {
+	*home = getenv("HOME");
+	if ((*home == NULL) || ((*home)[0] == '\0')) {
+		fprintf(stderr, _("Cannot get home directory (HOME is unset or empty)\n"));
+		return 0;
+	}
+	*trailing = ((*home)[strlen(*home)-1] == '/');
+	return 1;
+}
+
 static char* get_monitorlist_filename() {
 	char* filename;
 	int trailing;
 	int len, ret;
 	char* home;
 	
-	home = getenv("HOME");
-	if ((home == NULL) || (home[0] == '\0')) {
-		fprintf(stderr, _("Cannot get home directory (HOME is not set)\n"));
+	if (!ddcci_get_home_dir(&home, &trailing))
 		return NULL;
-	}
 	
-	ddcci_create_config_dir();
-	
-	trailing = (home[strlen(home)-1] == '/');
+	if (!ddcci_create_config_dir())
+		return NULL;
 	
 	len = strlen(home) + 64;
 	
@@ -255,13 +261,10 @@ struct profile* ddcci_create_profile(struct monitor* mon, const unsigned char* a
 	
 	time_t tm = time(NULL);
 	len      = strftime(&date[0], 32, "%Y%m%d-%H%M%S", localtime(&tm));
-	home = getenv("HOME");
-	if ((home == NULL) || (home[0] == '\0')) {
-		fprintf(stderr, _("Cannot get home directory (HOME is not set)\n"));
+	if (!ddcci_get_home_dir(&home, &trailing)) {
 		ddcci_free_profile(profile);
 		return 0;
 	}
-	trailing = (home[strlen(home)-1] == '/');
 	
 	len += strlen(home) + 32;
 	
@@ -310,12 +313,8 @@ int ddcci_get_all_profiles(struct monitor* mon) {
 	struct profile** next = &mon->profiles;
 	struct profile* profile;
 	
-	home = getenv("HOME");
-	if ((home == NULL) || (home[0] == '\0')) {
-		fprintf(stderr, _("Cannot get home directory (HOME is not set)\n"));
+	if (!ddcci_get_home_dir(&home, &trailing))
 		return 0;
-	}
-	trailing = (home[strlen(home)-1] == '/');
 	
 	len = strlen(home) + 64;
 	
@@ -455,7 +454,8 @@ int ddcci_save_profile(struct profile* profile, struct monitor* monitor) {
 	xmlTextWriterPtr writer;
 	int i;
 
-	ddcci_create_config_dir();
+	if (!ddcci_create_config_dir())
+		return 0;
 
 	writer = xmlNewTextWriterFilename(profile->filename, 0);
 	DDCCI_RETURN_IF_RUN(writer == NULL, 0, _("Cannot create the xml writer\n"), {xmlFreeTextWriter(writer);})

--- a/src/lib/ddcci.c
+++ b/src/lib/ddcci.c
@@ -1365,6 +1365,10 @@ int ddcci_create_config_dir()
 	struct stat buf;
 	
 	home     = getenv("HOME");
+	if ((home == NULL) || (home[0] == '\0')) {
+		fprintf(stderr, _("Cannot get home directory (HOME is unset or empty)\n"));
+		return 0;
+	}
 	trailing = (home[strlen(home)-1] == '/');
 	
 	len = strlen(home) + 32;


### PR DESCRIPTION
NULL dereference from getenv() — src/lib/conf.c getenv("HOME") can return NULL (e.g. in restricted environments), but the result is immediately dereferenced with strlen() and array indexing. This will crash.

```
home = getenv("HOME");
trailing = (home[strlen(home)-1] == '/');  // crash if HOME is unset
```