### PR TITLE
fix: Buffer overflow in fallback profile

### DIFF
--- a/src/daemon/dbus_client.c
+++ b/src/daemon/dbus_client.c
@@ -120,7 +120,7 @@ int ddcci_dbus_open(DDCControl *proxy, struct monitor **_mon, const char *filena
 
 	if (!mon->db) {
 		/* Fallback on manufacturer generic profile */
-		char buffer[7];
+		char buffer[8]; /* 3 chars (pnpid) + 3 chars (suffix) + 1 null terminator + 1 for safety */
 		buffer[0] = 0;
 		strncat(buffer, mon->pnpid, 3); /* copy manufacturer id */
 		switch (mon->caps.type) {

--- a/src/lib/ddcci.c
+++ b/src/lib/ddcci.c
@@ -1022,7 +1022,7 @@ static int ddcci_open_with_addr(struct monitor* mon, const char* filename, int a
 	
 	if (!mon->db) {
 		/* Fallback on manufacturer generic profile */
-		char buffer[7];
+		char buffer[8]; /* 3 chars (pnpid) + 3 chars (suffix) + 1 null terminator + 1 for safety */
 		buffer[0] = 0;
 		strncat(buffer, mon->pnpid, 3); /* copy manufacturer id */
 		switch(mon->caps.type) {


### PR DESCRIPTION
Buffer overflow in fallback profile — src/lib/ddcci.c buffer[7] is allocated for a 3-char PNP ID + 3-char suffix ("lcd"/"crt") + null terminator. That's exactly 7 bytes, but strncat leaves the existing null in place and appends, so the math only works if pnpid is exactly 3 chars. If mon->pnpid is shorter and strncat pads nothing, it's fine — but if pnpid is longer than 3 chars (the 3 limit in strncat is correct), the subsequent strcat(buffer, "lcd") writes to buffer[3..6] which is the last valid byte. There's no room for the null terminator from strcat — it writes a \0 at buffer[7], one byte past the end. This is an off-by-one overflow.

char buffer[7];
buffer[0] = 0;
strncat(buffer, mon->pnpid, 3);  // up to 3 chars + null = 4 bytes used
strcat(buffer, "lcd");            // writes 3 chars + null at buffer[7] — OOB write

Fix: char buffer[8];