### PR TITLE
Fix ./configure --enable-doc

### DIFF
--- a/.github/ci/Dockerfile
+++ b/.github/ci/Dockerfile
@@ -16,4 +16,9 @@ RUN apt-get update \
         libpci-dev \
         libxml2-dev \
         pkg-config \
+        xsltproc \
+        tidy \
+        docbook-xml \
+        docbook-xsl \
+        xml-core \
     && rm -rf /var/lib/apt/lists/*

--- a/doc/style.xsl
+++ b/doc/style.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet  
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<xsl:import href="https://cdn.docbook.org/release/xsl/current/xhtml/chunk.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/xhtml/chunk.xsl"/>
 
 <xsl:param name="html.cellspacing" select="'2'"/>
 <xsl:param name="html.cellpadding" select="'5'"/>


### PR DESCRIPTION
configure fails when using the --enable-doc flag:
```
$ ./configure --enable-doc
...
checking for gio-unix-2.0 >= 2.30.0... yes
checking whether /etc/xml/catalog exists... yes
checking for xsltproc... /usr/bin/xsltproc
checking for ssh... /usr/bin/ssh
checking for scp... /usr/bin/scp
checking for aspell... /usr/bin/aspell
checking for fop... no
checking for tidy... /usr/bin/tidy
checking whether xsltproc works... configure: error: xsltproc does not work, fix this problem or disable doc building
```