### PR TITLE
Replace deprecated Gtk3/GLib APIs in gddccontrol

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -162,8 +162,8 @@ if test x$support_gnome = xyes; then
       AC_MSG_ERROR(pkg-config not found, please install pkg-config)
    fi
 
-   echo -n "checking for gtk+>=3.0... "
-   if $PKG_CONFIG --atleast-version=3.0 gtk+-3.0 ; then
+   echo -n "checking for gtk+>=3.22... "
+   if $PKG_CONFIG --atleast-version=3.22 gtk+-3.0 ; then
       GNOME_LDFLAGS="$LIBXML2_LIBS `$PKG_CONFIG --libs gtk+-3.0`"
       GNOME_CFLAGS="$LIBXML2_CFLAGS `$PKG_CONFIG --cflags gtk+-3.0`"
       GDDCCONTROL=gddccontrol
@@ -173,7 +173,7 @@ if test x$support_gnome = xyes; then
       AC_PATH_XTRA
    else
       echo "no"
-      AC_MSG_ERROR([gtk+>=3.0 development packages not found])
+      AC_MSG_ERROR([gtk+>=3.22 development packages not found])
    fi
 fi
 

--- a/src/gddccontrol/fspatterns.c
+++ b/src/gddccontrol/fspatterns.c
@@ -230,9 +230,9 @@ static void show_pattern(gchar* patternname)
 	// TODO create and draw fullscreen window instead which we can close with [ESC] key
 	GdkRectangle drect;
 	
-	GdkScreen* screen = gdk_screen_get_default();
-	int i = gdk_screen_get_monitor_at_window(gdk_screen_get_default(), gtk_widget_get_window(main_app_window));
-	gdk_screen_get_monitor_geometry(screen, i, &drect);
+	GdkDisplay* display = gdk_display_get_default();
+	GdkMonitor* monitor = gdk_display_get_monitor_at_window(display, gtk_widget_get_window(main_app_window));
+	gdk_monitor_get_geometry(monitor, &drect);
 		
 	int top = 7*drect.height/12, bottom = 11*drect.height/12, left = drect.width/3, right = 2*drect.width/3;
 	
@@ -289,13 +289,13 @@ static void show_pattern(gchar* patternname)
 	
 	if (images[0])
 	{ /* GtkImages already exist */
-		for (i = 0; i < 4; i++) {
+		for (int i = 0; i < 4; i++) {
 			gtk_image_set_from_pixbuf(GTK_IMAGE(images[i]), pixbufs[i]);
 		}
 	}
 	else
 	{
-		for (i = 0; i < 4; i++) {
+		for (int i = 0; i < 4; i++) {
 			images[i] = gtk_image_new_from_pixbuf(pixbufs[i]);
 			gtk_widget_show(images[i]);
 		}
@@ -317,7 +317,7 @@ static void show_pattern(gchar* patternname)
 		gtk_widget_set_vexpand(images[1], TRUE);
 		gtk_widget_show(grid);
 	}
-	for (i = 0; i < 4; i++) {
+	for (int i = 0; i < 4; i++) {
 		g_object_unref(pixbufs[i]);
 	}
 	

--- a/src/gddccontrol/gprofile.c
+++ b/src/gddccontrol/gprofile.c
@@ -459,11 +459,11 @@ void show_profile_information(struct profile* profile, gboolean new_profile) {
 	gchar* title = g_strdup_printf("%s %s", _("Profile information:"), profile->name);
 	gchar* tmp;
 	
-	GtkWidget *dialog = gtk_dialog_new_with_buttons(
-		title,
-		GTK_WINDOW(main_app_window),
-		GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
-		NULL);
+	GtkWidget *dialog = gtk_dialog_new();
+	gtk_window_set_title(GTK_WINDOW(dialog), title);
+	gtk_window_set_transient_for(GTK_WINDOW(dialog), GTK_WINDOW(main_app_window));
+	gtk_window_set_modal(GTK_WINDOW(dialog), TRUE);
+	gtk_window_set_destroy_with_parent(GTK_WINDOW(dialog), TRUE);
 	
 	if (new_profile) {
 		g_object_set_data(G_OBJECT(dialog), "ok_button", NULL);

--- a/src/gddccontrol/gui.h
+++ b/src/gddccontrol/gui.h
@@ -89,7 +89,7 @@ extern GtkWidget* cancelprofile_button;
 extern GtkWidget* refresh_controls_button;
 
 /* Multimonitor support */
-extern int current_monitor; /* current monitor */
+extern GdkMonitor* current_monitor; /* current monitor */
 extern int num_monitor; /* total number of monitors */
 
 #endif //NOTEBOOK_H

--- a/src/gddccontrol/main.c
+++ b/src/gddccontrol/main.c
@@ -59,7 +59,7 @@ GtkWidget* refresh_controls_button = NULL;
 
 struct monitor* mon;
 
-int current_monitor; /* current monitor */
+GdkMonitor* current_monitor = NULL; /* current monitor */
 int num_monitor; /* total number of monitors */
 
 struct monitorlist* monlist;
@@ -78,7 +78,7 @@ int current_main_component = 0;
 int currentid = -1;
 int nextid = -1;
 
-static GMutex* combo_change_mutex;
+static GMutex combo_change_mutex;
 
 DDCControl *ddccontrol_proxy;
 
@@ -103,7 +103,7 @@ static void loadprofile_callback(GtkWidget *widget, gpointer data)
 static void combo_change(GtkWidget *widget, gpointer data)
 {
 	nextid = gtk_combo_box_get_active(GTK_COMBO_BOX(widget));
-	if (!g_mutex_trylock(combo_change_mutex)) {
+	if (!g_mutex_trylock(&combo_change_mutex)) {
 		if (get_verbosity())
 			printf("Tried to change to %d, but mutex locked.\n", gtk_combo_box_get_active(GTK_COMBO_BOX(widget)));
 		return;
@@ -171,7 +171,7 @@ static void combo_change(GtkWidget *widget, gpointer data)
 		printf("currentid == nextid (%d)\n", currentid);
 	
 	gtk_widget_set_sensitive(widget, TRUE);
-	g_mutex_unlock(combo_change_mutex);
+	g_mutex_unlock(&combo_change_mutex);
 }
 
 static gboolean window_changed(GtkWidget *widget, 
@@ -196,14 +196,14 @@ static gboolean window_changed(GtkWidget *widget,
 			return FALSE;
 		}
 		
-		i = gdk_screen_get_monitor_at_window(gdk_screen_get_default(), gtk_widget_get_window(main_app_window));
-		
-		if (i != current_monitor) {
+		GdkMonitor* monitor = gdk_display_get_monitor_at_window(gdk_display_get_default(), gtk_widget_get_window(main_app_window));
+
+		if (monitor != current_monitor) {
 			int k = nextid;
 			if (get_verbosity())
-				printf(_("Monitor changed (%d %d).\n"), i, k);
+				printf(_("Monitor changed (combo index %d).\n"), k);
 			k = (k == 0) ? 1 : 0;
-			current_monitor = i;
+			current_monitor = monitor;
 			gtk_combo_box_set_active(GTK_COMBO_BOX(combo_box), k);
 		}
 		
@@ -424,7 +424,7 @@ int main( int argc, char *argv[] )
 
 	gtk_init(&argc, &argv);
 	
-	combo_change_mutex = g_mutex_new();
+	g_mutex_init(&combo_change_mutex);
 	
 	/* Full screen patterns test */
 	/*create_fullscreen_patterns_window();
@@ -614,18 +614,18 @@ int main( int argc, char *argv[] )
 	
 	gtk_widget_show(main_app_window);
 	
-	GdkScreen* screen = gdk_screen_get_default();
-	
-	num_monitor = gdk_screen_get_n_monitors(screen);
-	
-	/*for (i = 0; i < nscreen; i++) {
+	GdkDisplay* display = gdk_display_get_default();
+
+	num_monitor = gdk_display_get_n_monitors(display);
+
+	/*for (i = 0; i < num_monitor; i++) {
 		GdkRectangle dest;
-		
-		gdk_screen_get_monitor_geometry(screen, i, &dest);
-		printf("%d: %d, %d %dx%d\n", nscreen, dest.x, dest.y, dest.width, dest.height);
+		GdkMonitor* m = gdk_display_get_monitor(display, i);
+		gdk_monitor_get_geometry(m, &dest);
+		printf("%d: %d, %d %dx%d\n", i, dest.x, dest.y, dest.width, dest.height);
 	}*/
-	
-	current_monitor = gdk_screen_get_monitor_at_window(screen, gtk_widget_get_window(main_app_window));
+
+	current_monitor = gdk_display_get_monitor_at_window(display, gtk_widget_get_window(main_app_window));
 	
 	probe_monitors(NULL, NULL);
 	


### PR DESCRIPTION
## Summary

Cleans up the Gtk3 / GLib deprecation warnings that are emitted when building `gddccontrol`. Now compiles cleanly under `gtk+-3.0` with `-Wdeprecated-declarations` (only pre-existing, unrelated warnings remain).

- **`gdk_screen_get_monitor_at_window` → `gdk_display_get_monitor_at_window`** (3 call sites in `main.c` / `fspatterns.c`). The new API returns `GdkMonitor *` instead of a `gint` index, so `current_monitor` (declared in `gui.h` and `main.c`) is now a `GdkMonitor *`. Pointer equality is used to detect monitor changes.
- **`gdk_screen_get_n_monitors` → `gdk_display_get_n_monitors`** in `main.c`.
- **`gdk_screen_get_monitor_geometry` → `gdk_monitor_get_geometry`** in `fspatterns.c`.
- **`g_mutex_new()` → stack-allocated `GMutex` + `g_mutex_init()`** for `combo_change_mutex`. Updated its trylock/unlock call sites accordingly.
- **`gtk_dialog_new_with_buttons(..., NULL)` → `gtk_dialog_new()` + property setters** in `gprofile.c`. The original call with no buttons trips GCC's `__sentinel__` check on `G_GNUC_NULL_TERMINATED` (the `NULL` is interpreted as `first_button_text`, not a sentinel). Behavior is equivalent: title, transient parent, modal, destroy-with-parent.

## Test plan

- [x] `docker build --platform=linux/arm64 -t ddccontrol-build:latest .` succeeds and emits no GTK/GLib deprecation warnings.
- [ ] Manual UI smoke test (cannot run GUI from Docker on macOS host):
  - [ ] Launch `gddccontrol`, verify monitor combobox lists monitors and switching works.
  - [ ] Move main window across monitors with exactly 2 DDC/CI monitors and verify combobox auto-switches (`window_changed` path).
  - [ ] Open Profile manager → create / edit profile → confirm dialog opens modal, transient over main window, and closes cleanly (`show_profile_information`).
  - [ ] Open full-screen pattern test and confirm it covers the current monitor's geometry (`show_pattern`).

Notes:
- `combo_change_mutex` no longer needs freeing — stack-allocated `GMutex` is correctly initialized with `g_mutex_init` and stays valid for the process lifetime (matches prior behavior: the original `g_mutex_new()` mutex was never freed either).

🤖 Generated with [Claude Code](https://claude.com/claude-code)