### PR TITLE
Remove unnecessary code for very ancient GLib versions

### DIFF
--- a/src/daemon/dbus_client.c
+++ b/src/daemon/dbus_client.c
@@ -23,7 +23,6 @@
 #include "internal.h"
 #include "interface.h"
 
-#include <glib-object.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -224,10 +223,6 @@ struct monitorlist *ddcci_dbus_rescan_monitors(DDCControl *proxy)
 DDCControl *ddcci_dbus_open_proxy()
 {
 	GError *error = NULL;
-
-#if !GLIB_CHECK_VERSION(2, 36, 0)
-	g_type_init();
-#endif
 
 	DDCControl *proxy = ddccontrol_proxy_new_for_bus_sync(
 	                        G_BUS_TYPE_SYSTEM,

--- a/src/daemon/service.c
+++ b/src/daemon/service.c
@@ -19,7 +19,6 @@
 
 #include "interface.h"
 
-#include <glib-object.h>
 #include <ctype.h>
 #include <limits.h>
 #include <stdio.h>
@@ -455,10 +454,6 @@ int main(void)
 {
 	int i;
 	GMainLoop *loop;
-
-#if !GLIB_CHECK_VERSION(2, 36, 0)
-	g_type_init();
-#endif
 
 	if (check_or_load_i2c_dev() == FALSE) {
 		fprintf(stderr, _("Kernel module i2c_dev isn't available, functionality might be limited, or unavailable...\n"));


### PR DESCRIPTION
The code added in #226 is trying to fix a corner case if someone wants to execute GDDCControl on ancient systems with GLib < 2.36. Please note that GLib 2.36 was tagged in 2013 (see [their git repository](https://gitlab.gnome.org/GNOME/glib/-/tags/2.36.0)), so any Linux distribution major release since 2014 should have GLib 2.36 or newer. Even the ancient Ubuntu 14.04 that had ended non-commercial support in 2019 and commercial support in 2024 has this version of GLib. I don't think it is worth keeping a workaround for this old code.

Reverts ddccontrol/ddccontrol#226