### PR TITLE
Add tests ddcci parse caps

### DIFF
--- a/src/lib/ddcci.c
+++ b/src/lib/ddcci.c
@@ -656,15 +656,34 @@ int ddcci_parse_caps(const char* caps_str, struct caps* caps, int add)
 	int removeprevious = 0;
 	
 	int num = 0;
+	int step = 1;
+
+#define DDCCI_PARSE_CAPS_FAIL() \
+	do { \
+		int _ci; \
+		for (_ci = 0; _ci < 256; _ci++) { \
+			if (caps->vcp[_ci]) { \
+				free(caps->vcp[_ci]->values); \
+				free(caps->vcp[_ci]); \
+				caps->vcp[_ci] = NULL; \
+			} \
+		} \
+		return -1; \
+	} while (0)
 	
-	for (pos = 0; caps_str[pos] != 0; pos++)
+	for (pos = 0; caps_str[pos] != 0; pos += step)
 	{
+		step = 1;
 		if (caps_str[pos] == '(') {
 			level++;
 		}
 		else if (caps_str[pos] == ')')
 		{
 			level--;
+			if (level < 0) {
+				fprintf(stderr, _("Invalid CAPS, unbalanced parentheses.\n"));
+				DDCCI_PARSE_CAPS_FAIL();
+			}
 			if (level == 1) {
 				svcp = 0;
 				stype = 0;
@@ -693,8 +712,8 @@ int ddcci_parse_caps(const char* caps_str, struct caps* caps, int add)
 				}
 			}
 			else if ((svcp == 1) && (level == 2)) {
-				if (!add && ((removeprevious == 1) || (caps->vcp[ind] && caps->vcp[ind]->values_len == 0))) {
-					if(caps->vcp[ind]) {
+				if (!add && ((removeprevious == 1) || (ind >= 0 && ind < 256 && caps->vcp[ind] && caps->vcp[ind]->values_len == 0))) {
+					if(ind >= 0 && ind < 256 && caps->vcp[ind]) {
 						if (caps->vcp[ind]->values) {
 							free(caps->vcp[ind]->values);
 						}
@@ -706,17 +725,9 @@ int ddcci_parse_caps(const char* caps_str, struct caps* caps, int add)
 				buf[1] = caps_str[++pos];
 				buf[2] = 0;
 				ind = strtol(buf, &endptr, 16);
-				if (*endptr != 0) {
+				if (*endptr != 0 || ind < 0 || ind > 255) {
 					fprintf(stderr, _("Can't convert value to int, invalid CAPS (buf=%s, pos=%d).\n"), buf, pos);
-					int _ci;
-					for (_ci = 0; _ci < 256; _ci++) {
-						if (caps->vcp[_ci]) {
-							free(caps->vcp[_ci]->values);
-							free(caps->vcp[_ci]);
-							caps->vcp[_ci] = NULL;
-						}
-					}
-					return -1;
+					DDCCI_PARSE_CAPS_FAIL();
 				}
 				if (add) {
 					caps->vcp[ind] = malloc(sizeof(struct vcp_entry));
@@ -733,46 +744,26 @@ int ddcci_parse_caps(const char* caps_str, struct caps* caps, int add)
 				while ((caps_str[pos+i] != ' ') && (caps_str[pos+i] != ')') && (caps_str[pos+i] != 0)) {
 					if (i >= (int)sizeof(buf) - 1) {
 						fprintf(stderr, _("CAPS token too long, invalid CAPS (pos=%d).\n"), pos);
-						int _ci;
-						for (_ci = 0; _ci < 256; _ci++) {
-							if (caps->vcp[_ci]) {
-								free(caps->vcp[_ci]->values);
-								free(caps->vcp[_ci]);
-								caps->vcp[_ci] = NULL;
-							}
-						}
-						return -1;
+						DDCCI_PARSE_CAPS_FAIL();
 					}
 					buf[i] = caps_str[pos+i];
 					i++;
 				}
 				if (caps_str[pos+i] == 0) {
 					fprintf(stderr, _("Invalid CAPS, unexpected end of string at pos=%d.\n"), pos);
-					int _ci;
-					for (_ci = 0; _ci < 256; _ci++) {
-						if (caps->vcp[_ci]) {
-							free(caps->vcp[_ci]->values);
-							free(caps->vcp[_ci]);
-							caps->vcp[_ci] = NULL;
-						}
-					}
-					return -1;
+					DDCCI_PARSE_CAPS_FAIL();
 				}
 				buf[i] = 0;
 				val = strtol(buf, &endptr, 16);
-				if (*endptr != 0) {
+				if (*endptr != 0 || val < 0 || val > 0xFFFF) {
 					fprintf(stderr, _("Can't convert value to int, invalid CAPS (buf=%s, pos=%d).\n"), buf, pos);
-					int _ci;
-					for (_ci = 0; _ci < 256; _ci++) {
-						if (caps->vcp[_ci]) {
-							free(caps->vcp[_ci]->values);
-							free(caps->vcp[_ci]);
-							caps->vcp[_ci] = NULL;
-						}
-					}
-					return -1;
+					DDCCI_PARSE_CAPS_FAIL();
 				}
 				if (add) {
+					if (ind < 0 || ind >= 256 || !caps->vcp[ind]) {
+						fprintf(stderr, _("Invalid CAPS, value without VCP id (pos=%d).\n"), pos);
+						DDCCI_PARSE_CAPS_FAIL();
+					}
 					if (caps->vcp[ind]->values_len == -1) {
 						caps->vcp[ind]->values_len = 1;
 					}
@@ -783,22 +774,29 @@ int ddcci_parse_caps(const char* caps_str, struct caps* caps, int add)
 					caps->vcp[ind]->values[caps->vcp[ind]->values_len-1] = val;
 				}
 				else {
-					if (caps->vcp[ind]->values_len > 0) {
+					if (ind >= 0 && ind < 256 && caps->vcp[ind] && caps->vcp[ind]->values_len > 0) {
 						removeprevious = 0;
 						int j = 0;
-						for (i = 0; i < caps->vcp[ind]->values_len; i++) {
-							if (caps->vcp[ind]->values[i] != val) {
-								caps->vcp[ind]->values[j++] = caps->vcp[ind]->values[i];
+						int vi;
+						for (vi = 0; vi < caps->vcp[ind]->values_len; vi++) {
+							if (caps->vcp[ind]->values[vi] != val) {
+								caps->vcp[ind]->values[j++] = caps->vcp[ind]->values[vi];
 							}
 						}
-						caps->vcp[ind]->values_len--;
+						caps->vcp[ind]->values_len = j;
 					}
 				}
+				step = i;
 			}
 		}
 	}
+
+	if (level != 0) {
+		fprintf(stderr, _("Invalid CAPS, unbalanced parentheses.\n"));
+		DDCCI_PARSE_CAPS_FAIL();
+	}
 	
-	if (!add && ((removeprevious == 1) || (caps->vcp[ind] && caps->vcp[ind]->values_len == 0))) {
+	if (!add && ind >= 0 && ind < 256 && ((removeprevious == 1) || (caps->vcp[ind] && caps->vcp[ind]->values_len == 0))) {
 		if(caps->vcp[ind]) {
 			if (caps->vcp[ind]->values) {
 				free(caps->vcp[ind]->values);
@@ -809,6 +807,8 @@ int ddcci_parse_caps(const char* caps_str, struct caps* caps, int add)
 	}
 	
 	return num;
+
+#undef DDCCI_PARSE_CAPS_FAIL
 }
 
 /* read capabilities raw data of ddc/ci at address addr starting at offset to buf */

--- a/src/lib/tests/test_parse_caps.c
+++ b/src/lib/tests/test_parse_caps.c
@@ -64,11 +64,53 @@ static void test_uppercase_crt_type(void) {
 	free_caps_entries(&caps);
 }
 
+static void test_add_values_then_remove_one_value(void) {
+	struct caps caps;
+	memset(&caps, 0, sizeof(caps));
+
+	assert(ddcci_parse_caps("(vcp(10(01 02)))", &caps, 1) == 1);
+	assert(caps.vcp[0x10] != NULL);
+	assert(caps.vcp[0x10]->values != NULL);
+
+	assert(ddcci_parse_caps("(vcp(10(01)))", &caps, 0) == 1);
+	assert(caps.vcp[0x10] != NULL);
+
+	free_caps_entries(&caps);
+}
+
+static void test_remove_whole_control_without_value_list(void) {
+	struct caps caps;
+	memset(&caps, 0, sizeof(caps));
+
+	assert(ddcci_parse_caps("(vcp(10 12))", &caps, 1) == 2);
+	assert(caps.vcp[0x10] != NULL);
+	assert(caps.vcp[0x12] != NULL);
+
+	assert(ddcci_parse_caps("(vcp(10))", &caps, 0) == 1);
+	assert(caps.vcp[0x10] == NULL);
+	assert(caps.vcp[0x12] != NULL);
+
+	free_caps_entries(&caps);
+}
+
+static void test_rejects_invalid_vcp_identifier(void) {
+	struct caps caps;
+	memset(&caps, 0, sizeof(caps));
+
+	assert(ddcci_parse_caps("(vcp(GG))", &caps, 1) < 0);
+	assert(caps.vcp[0x10] == NULL);
+
+	free_caps_entries(&caps);
+}
+
 int main(void) {
 	test_valid_caps();
 	test_rejects_overlong_value_token();
 	test_rejects_unterminated_token();
 	test_uppercase_lcd_type();
 	test_uppercase_crt_type();
+	test_add_values_then_remove_one_value();
+	test_remove_whole_control_without_value_list();
+	test_rejects_invalid_vcp_identifier();
 	return 0;
 }

--- a/src/lib/tests/test_parse_caps.c
+++ b/src/lib/tests/test_parse_caps.c
@@ -103,6 +103,80 @@ static void test_rejects_invalid_vcp_identifier(void) {
 	free_caps_entries(&caps);
 }
 
+static void test_remove_nonexistent_control_is_safe(void) {
+	struct caps caps;
+	memset(&caps, 0, sizeof(caps));
+
+	assert(ddcci_parse_caps("(vcp(10))", &caps, 0) == 1);
+	assert(caps.vcp[0x10] == NULL);
+
+	free_caps_entries(&caps);
+}
+
+static void test_mixed_controls_and_value_lists(void) {
+	struct caps caps;
+	memset(&caps, 0, sizeof(caps));
+
+	assert(ddcci_parse_caps("(vcp(10(01 02) 12 14(0A)))", &caps, 1) == 3);
+	assert(caps.vcp[0x10] != NULL);
+	assert(caps.vcp[0x10]->values != NULL);
+	assert(caps.vcp[0x12] != NULL);
+	assert(caps.vcp[0x14] != NULL);
+	assert(caps.vcp[0x14]->values != NULL);
+
+	free_caps_entries(&caps);
+}
+
+static void test_rejects_invalid_hex_value_in_value_list(void) {
+	struct caps caps;
+	memset(&caps, 0, sizeof(caps));
+
+	assert(ddcci_parse_caps("(vcp(10(0G)))", &caps, 1) < 0);
+	assert(caps.vcp[0x10] == NULL);
+
+	free_caps_entries(&caps);
+}
+
+static void test_nested_sections_still_allow_top_level_vcp(void) {
+	struct caps caps;
+	memset(&caps, 0, sizeof(caps));
+
+	assert(ddcci_parse_caps("(prot(monitor)foo(bar(baz))vcp(10))", &caps, 1) == 1);
+	assert(caps.vcp[0x10] != NULL);
+
+	free_caps_entries(&caps);
+}
+
+static void test_unknown_type_does_not_override_existing_type(void) {
+	struct caps caps;
+	memset(&caps, 0, sizeof(caps));
+	caps.type = lcd;
+
+	assert(ddcci_parse_caps("(type(OLED))", &caps, 1) >= 0);
+	assert(caps.type == lcd);
+
+	free_caps_entries(&caps);
+}
+
+static void test_repeated_add_remove_sequence_on_same_control(void) {
+	struct caps caps;
+	memset(&caps, 0, sizeof(caps));
+
+	assert(ddcci_parse_caps("(vcp(10(01 02)))", &caps, 1) == 1);
+	assert(caps.vcp[0x10] != NULL);
+
+	assert(ddcci_parse_caps("(vcp(10(01)))", &caps, 0) == 1);
+	assert(caps.vcp[0x10] != NULL);
+
+	assert(ddcci_parse_caps("(vcp(10))", &caps, 0) == 1);
+	assert(caps.vcp[0x10] == NULL);
+
+	assert(ddcci_parse_caps("(vcp(10))", &caps, 1) == 1);
+	assert(caps.vcp[0x10] != NULL);
+
+	free_caps_entries(&caps);
+}
+
 int main(void) {
 	test_valid_caps();
 	test_rejects_overlong_value_token();
@@ -112,5 +186,11 @@ int main(void) {
 	test_add_values_then_remove_one_value();
 	test_remove_whole_control_without_value_list();
 	test_rejects_invalid_vcp_identifier();
+	test_remove_nonexistent_control_is_safe();
+	test_mixed_controls_and_value_lists();
+	test_rejects_invalid_hex_value_in_value_list();
+	test_nested_sections_still_allow_top_level_vcp();
+	test_unknown_type_does_not_override_existing_type();
+	test_repeated_add_remove_sequence_on_same_control();
 	return 0;
 }

--- a/src/lib/tests/test_parse_caps.c
+++ b/src/lib/tests/test_parse_caps.c
@@ -66,14 +66,21 @@ static void test_uppercase_crt_type(void) {
 
 static void test_add_values_then_remove_one_value(void) {
 	struct caps caps;
+	int initial_len;
 	memset(&caps, 0, sizeof(caps));
 
-	assert(ddcci_parse_caps("(vcp(10(01 02)))", &caps, 1) == 1);
+	assert(ddcci_parse_caps("(vcp(10(01)))", &caps, 1) == 1);
 	assert(caps.vcp[0x10] != NULL);
 	assert(caps.vcp[0x10]->values != NULL);
+	initial_len = caps.vcp[0x10]->values_len;
+	assert(initial_len > 0);
+
+	assert(ddcci_parse_caps("(vcp(10(03)))", &caps, 0) == 1);
+	assert(caps.vcp[0x10] != NULL);
+	assert(caps.vcp[0x10]->values_len == initial_len);
 
 	assert(ddcci_parse_caps("(vcp(10(01)))", &caps, 0) == 1);
-	assert(caps.vcp[0x10] != NULL);
+	assert(caps.vcp[0x10] == NULL);
 
 	free_caps_entries(&caps);
 }
@@ -132,7 +139,19 @@ static void test_rejects_invalid_hex_value_in_value_list(void) {
 	memset(&caps, 0, sizeof(caps));
 
 	assert(ddcci_parse_caps("(vcp(10(0G)))", &caps, 1) < 0);
+	assert(ddcci_parse_caps("(vcp(10(-1)))", &caps, 1) < 0);
+	assert(ddcci_parse_caps("(vcp(10(10000)))", &caps, 1) < 0);
 	assert(caps.vcp[0x10] == NULL);
+
+	free_caps_entries(&caps);
+}
+
+static void test_rejects_out_of_range_vcp_identifier(void) {
+	struct caps caps;
+	memset(&caps, 0, sizeof(caps));
+
+	assert(ddcci_parse_caps("(vcp(-1))", &caps, 1) < 0);
+	assert(caps.vcp[0x00] == NULL);
 
 	free_caps_entries(&caps);
 }
@@ -177,6 +196,65 @@ static void test_repeated_add_remove_sequence_on_same_control(void) {
 	free_caps_entries(&caps);
 }
 
+static void test_remove_nonexistent_control_with_value_list_is_safe(void) {
+	struct caps caps;
+	memset(&caps, 0, sizeof(caps));
+
+	assert(ddcci_parse_caps("(vcp(10(01)))", &caps, 0) == 1);
+	assert(caps.vcp[0x10] == NULL);
+
+	free_caps_entries(&caps);
+}
+
+static void test_rejects_unbalanced_parentheses(void) {
+	struct caps caps;
+	memset(&caps, 0, sizeof(caps));
+
+	assert(ddcci_parse_caps("(vcp(10)", &caps, 1) < 0);
+	assert(ddcci_parse_caps(")(vcp(10))", &caps, 1) < 0);
+	assert(caps.vcp[0x10] == NULL);
+
+	free_caps_entries(&caps);
+}
+
+static void test_rejects_value_without_vcp_id(void) {
+	struct caps caps;
+	memset(&caps, 0, sizeof(caps));
+
+	assert(ddcci_parse_caps("(vcp((01)))", &caps, 1) < 0);
+	assert(caps.vcp[0x01] == NULL);
+	assert(caps.vcp[0x10] == NULL);
+
+	free_caps_entries(&caps);
+}
+
+static void test_boundary_control_and_value_ranges(void) {
+	struct caps caps;
+	memset(&caps, 0, sizeof(caps));
+
+	assert(ddcci_parse_caps("(vcp(00(0000) FF(FFFF)))", &caps, 1) == 2);
+	assert(caps.vcp[0x00] != NULL);
+	assert(caps.vcp[0x00]->values != NULL);
+	assert(caps.vcp[0x00]->values_len == 1);
+	assert(caps.vcp[0x00]->values[0] == 0x0000);
+	assert(caps.vcp[0xFF] != NULL);
+	assert(caps.vcp[0xFF]->values != NULL);
+	assert(caps.vcp[0xFF]->values_len == 1);
+	assert(caps.vcp[0xFF]->values[0] == 0xFFFF);
+
+	free_caps_entries(&caps);
+}
+
+static void test_repeated_same_control_in_single_string(void) {
+	struct caps caps;
+	memset(&caps, 0, sizeof(caps));
+
+	assert(ddcci_parse_caps("(vcp(10 10 10))", &caps, 1) == 3);
+	assert(caps.vcp[0x10] != NULL);
+
+	free_caps_entries(&caps);
+}
+
 int main(void) {
 	test_valid_caps();
 	test_rejects_overlong_value_token();
@@ -189,8 +267,14 @@ int main(void) {
 	test_remove_nonexistent_control_is_safe();
 	test_mixed_controls_and_value_lists();
 	test_rejects_invalid_hex_value_in_value_list();
+	test_rejects_out_of_range_vcp_identifier();
 	test_nested_sections_still_allow_top_level_vcp();
 	test_unknown_type_does_not_override_existing_type();
 	test_repeated_add_remove_sequence_on_same_control();
+	test_remove_nonexistent_control_with_value_list_is_safe();
+	test_rejects_unbalanced_parentheses();
+	test_rejects_value_without_vcp_id();
+	test_boundary_control_and_value_ranges();
+	test_repeated_same_control_in_single_string();
 	return 0;
 }


### PR DESCRIPTION
This PR expands `ddcci_parse_caps()` unit test coverage and hardens the parser for a crash case seen in CI.

### What changed

- Added multiple new tests in `src/lib/tests/test_parse_caps.c` covering:
  - add/remove behavior with value lists
  - removing entire controls
  - removing non-existing controls (with and without value lists)
  - invalid VCP identifiers and invalid value tokens
  - mixed controls/value lists
  - nested sections
  - unknown `type(...)` behavior
  - repeated add/remove sequences
  - boundary control/value ranges
  - repeated same control in one caps string
  - unbalanced parentheses

- Hardened `ddcci_parse_caps()` in `src/lib/ddcci.c`:
  - Guarded `remove`-path accesses so `caps->vcp[ind]` is never touched when `ind` is invalid (`-1` before first parsed VCP id).
  - Added unbalanced-parentheses validation (`level != 0` returns parse error).
  - Kept cleanup logic bounded to valid `ind` range.

### Why

CI failure on PR #251 (`build (arm64, clang)`) showed `test_parse_caps` aborting due to a parser crash path in `add=0` handling. This patch removes that crash condition and broadens regression coverage around parser edge cases.

### Validation

- `make -C src/lib check` (gcc): PASS
- `make -C src/lib CC=clang check`: PASS
- `./scripts/format_code.sh`: run
- `./scripts/check_git_clean_after_build.sh`: run (expected to report changed tracked files before commit)