### PR TITLE
Add unit tests for EDID parsing and extract parser helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@
 /src/lib/test_parse_caps
 /src/lib/test_parse_caps.log
 /src/lib/test_parse_caps.trs
+/src/lib/test_edid
+/src/lib/test_edid.log
+/src/lib/test_edid.trs
 /src/stamp-h1
 Makefile
 Makefile.in

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -20,7 +20,7 @@ libddccontrol_la_SOURCES = ddcci.c ddcci.h monitor_db.c monitor_db.h \
 
 libddccontrol_la_LIBADD = $(LIBXML2_LIBS)
 
-check_PROGRAMS = test_issueurl test_parse_caps
+check_PROGRAMS = test_issueurl test_parse_caps test_edid
 TESTS = $(check_PROGRAMS)
 
 test_issueurl_SOURCES = tests/test_issueurl.c issueurl.c urlencode.c
@@ -28,3 +28,6 @@ test_issueurl_LDADD = libddccontrol.la $(LIBXML2_LIBS)
 
 test_parse_caps_SOURCES = tests/test_parse_caps.c
 test_parse_caps_LDADD = libddccontrol.la $(LIBXML2_LIBS)
+
+test_edid_SOURCES = tests/test_edid.c
+test_edid_LDADD = libddccontrol.la $(LIBXML2_LIBS)

--- a/src/lib/ddcci.c
+++ b/src/lib/ddcci.c
@@ -945,8 +945,11 @@ int ddcci_parse_edid_buf(struct monitor* mon, const unsigned char* buf, int len)
 	         (buf[9] & 31) + 'A' - 1, buf[11], buf[10]);
 
 	if (!mon->probing && verbosity) {
-		int sn = buf[0xc] + (buf[0xd]<<8) + (buf[0xe]<<16) + (buf[0xf]<<24);
-		printf(_("Serial number: %d\n"), sn);
+		unsigned int sn = (unsigned int)buf[0xc] |
+		                  ((unsigned int)buf[0xd] << 8) |
+		                  ((unsigned int)buf[0xe] << 16) |
+		                  ((unsigned int)buf[0xf] << 24);
+		printf(_("Serial number: %u\n"), sn);
 		int week = buf[0x10];
 		int year = buf[0x11] + 1990;
 		printf(_("Manufactured: Week %d, %d\n"), week, year);

--- a/src/lib/ddcci.c
+++ b/src/lib/ddcci.c
@@ -931,7 +931,7 @@ int ddcci_command(struct monitor* mon, unsigned char cmd)
  * Returns 0 on success, -1 if the buffer is too short or the header is invalid. */
 int ddcci_parse_edid_buf(struct monitor* mon, const unsigned char* buf, int len)
 {
-	if (!buf || len < 0x17)
+	if (!mon || !buf || len < 0x17)
 		return -1;
 
 	if (buf[0] != 0 || buf[1] != 0xff || buf[2] != 0xff || buf[3] != 0xff ||

--- a/src/lib/ddcci.c
+++ b/src/lib/ddcci.c
@@ -927,6 +927,43 @@ int ddcci_command(struct monitor* mon, unsigned char cmd)
 	return ddcci_write(mon, _buf, sizeof(_buf));
 }
 
+/* Parse a raw 128-byte EDID buffer and fill in mon->pnpid and mon->digital.
+ * Returns 0 on success, -1 if the buffer is too short or the header is invalid. */
+int ddcci_parse_edid_buf(struct monitor* mon, const unsigned char* buf, int len)
+{
+	if (!buf || len < 0x17)
+		return -1;
+
+	if (buf[0] != 0 || buf[1] != 0xff || buf[2] != 0xff || buf[3] != 0xff ||
+	    buf[4] != 0xff || buf[5] != 0xff || buf[6] != 0xff || buf[7] != 0)
+		return -1;
+
+	snprintf(mon->pnpid, 8, "%c%c%c%02X%02X",
+	         ((buf[8] >> 2) & 31) + 'A' - 1,
+	         ((buf[8] & 3) << 3) + (buf[9] >> 5) + 'A' - 1,
+	         (buf[9] & 31) + 'A' - 1, buf[11], buf[10]);
+
+	if (!mon->probing && verbosity) {
+		int sn = buf[0xc] + (buf[0xd]<<8) + (buf[0xe]<<16) + (buf[0xf]<<24);
+		printf(_("Serial number: %d\n"), sn);
+		int week = buf[0x10];
+		int year = buf[0x11] + 1990;
+		printf(_("Manufactured: Week %d, %d\n"), week, year);
+		int ver = buf[0x12];
+		int rev = buf[0x13];
+		printf(_("EDID version: %d.%d\n"), ver, rev);
+		int maxwidth = buf[0x15];
+		int maxheight = buf[0x16];
+		printf(_("Maximum size: %d x %d (cm)\n"), maxwidth, maxheight);
+
+		/* Parse more infos... */
+	}
+
+	mon->digital = (buf[0x14] & 0x80);
+
+	return 0;
+}
+
 int ddcci_read_edid(struct monitor* mon, int addr) 
 {
 	unsigned char buf[128];
@@ -938,37 +975,12 @@ int ddcci_read_edid(struct monitor* mon, int addr)
 		if (i2c_write(mon, addr, buf, 1) > 0 &&
 		    i2c_read(mon, addr, buf, sizeof(buf)) > 0) 
 		{		
-			if (buf[0] != 0 || buf[1] != 0xff || buf[2] != 0xff || buf[3] != 0xff ||
-			    buf[4] != 0xff || buf[5] != 0xff || buf[6] != 0xff || buf[7] != 0)
-			{
+			if (ddcci_parse_edid_buf(mon, buf, sizeof(buf)) == 0) {
+				return 0;
+			} else {
 				if (retry == 2 && (!mon->probing || verbosity)) {
 					fprintf(stderr, _("Corrupted EDID at 0x%02x.\n"), addr);
 				}
-			} else {
-				snprintf(mon->pnpid, 8, "%c%c%c%02X%02X", 
-				         ((buf[8] >> 2) & 31) + 'A' - 1, 
-				         ((buf[8] & 3) << 3) + (buf[9] >> 5) + 'A' - 1, 
-				         (buf[9] & 31) + 'A' - 1, buf[11], buf[10]);
-
-				if (!mon->probing && verbosity) {
-					int sn = buf[0xc] + (buf[0xd]<<8) + (buf[0xe]<<16) + (buf[0xf]<<24);
-					printf(_("Serial number: %d\n"), sn);
-					int week = buf[0x10];
-					int year = buf[0x11] + 1990;
-					printf(_("Manufactured: Week %d, %d\n"), week, year);
-					int ver = buf[0x12];
-					int rev = buf[0x13];
-					printf(_("EDID version: %d.%d\n"), ver, rev);
-					int maxwidth = buf[0x15];
-					int maxheight = buf[0x16];
-					printf(_("Maximum size: %d x %d (cm)\n"), maxwidth, maxheight);
-					
-					/* Parse more infos... */
-				}
-
-				mon->digital = (buf[0x14] & 0x80);
-
-				return 0;
 			}
 		} else if (retry == 2 && (!mon->probing || verbosity)) {
 			fprintf(stderr, _("Reading EDID 0x%02x failed.\n"), addr);

--- a/src/lib/ddcci.c
+++ b/src/lib/ddcci.c
@@ -927,11 +927,12 @@ int ddcci_command(struct monitor* mon, unsigned char cmd)
 	return ddcci_write(mon, _buf, sizeof(_buf));
 }
 
-/* Parse a raw 128-byte EDID buffer and fill in mon->pnpid and mon->digital.
- * Returns 0 on success, -1 if the buffer is too short or the header is invalid. */
+/* Parse an EDID buffer and fill in mon->pnpid and mon->digital.
+ * Requires at least DDCCI_EDID_MIN_PARSE_LEN bytes and a valid EDID header.
+ * Returns 0 on success, -1 on failure. */
 int ddcci_parse_edid_buf(struct monitor* mon, const unsigned char* buf, int len)
 {
-	if (!mon || !buf || len < 0x17)
+	if (!mon || !buf || len < DDCCI_EDID_MIN_PARSE_LEN)
 		return -1;
 
 	if (buf[0] != 0 || buf[1] != 0xff || buf[2] != 0xff || buf[3] != 0xff ||

--- a/src/lib/ddcci.h
+++ b/src/lib/ddcci.h
@@ -115,7 +115,12 @@ int ddcci_writectrl(struct monitor* mon, unsigned char ctrl, unsigned short valu
 int ddcci_readctrl(struct monitor* mon, unsigned char ctrl, 
 	unsigned short *value, unsigned short *maximum);
 
-/* Parse a raw EDID buffer (minimum 0x17 bytes) into mon->pnpid and mon->digital.
+enum {
+	DDCCI_EDID_MIN_PARSE_LEN = 0x17
+};
+
+/* Parse an EDID buffer into mon->pnpid and mon->digital.
+ * The buffer must be at least DDCCI_EDID_MIN_PARSE_LEN bytes and contain a valid EDID header.
  * Returns 0 on success, -1 on failure. */
 int ddcci_parse_edid_buf(struct monitor* mon, const unsigned char* buf, int len);
 

--- a/src/lib/ddcci.h
+++ b/src/lib/ddcci.h
@@ -119,7 +119,7 @@ enum {
 	DDCCI_EDID_MIN_PARSE_LEN = 0x17
 };
 
-/* Parse an EDID buffer into mon->pnpid and mon->digital.
+/* Parse an EDID buffer into mon->pnpid and mon->digital (0x80 for digital, 0x00 for analog).
  * The buffer must be at least DDCCI_EDID_MIN_PARSE_LEN bytes and contain a valid EDID header.
  * Returns 0 on success, -1 on failure. */
 int ddcci_parse_edid_buf(struct monitor* mon, const unsigned char* buf, int len);

--- a/src/lib/ddcci.h
+++ b/src/lib/ddcci.h
@@ -115,6 +115,10 @@ int ddcci_writectrl(struct monitor* mon, unsigned char ctrl, unsigned short valu
 int ddcci_readctrl(struct monitor* mon, unsigned char ctrl, 
 	unsigned short *value, unsigned short *maximum);
 
+/* Parse a raw EDID buffer (minimum 0x17 bytes) into mon->pnpid and mon->digital.
+ * Returns 0 on success, -1 on failure. */
+int ddcci_parse_edid_buf(struct monitor* mon, const unsigned char* buf, int len);
+
 /* Parse a monitor capabilities string. */
 int ddcci_parse_caps(const char* caps_str, struct caps* caps, int add);
 

--- a/src/lib/ddcci.h
+++ b/src/lib/ddcci.h
@@ -60,7 +60,7 @@ struct monitor {
 	unsigned int addr;
 	int adl_adapter, adl_display;
 	char pnpid[8];
-	unsigned char digital; /* 0 - digital, 1 - analog */
+	unsigned char digital; /* 0x80 - digital, 0x00 - analog */
 	struct timeval last;
 	struct monitor_db* db;
 	struct caps caps;
@@ -90,7 +90,7 @@ struct monitorlist {
 	
 	unsigned char supported; /* 0 - DDC/CI not supported, 1 - DDC/CI supported */
 	char* name;
-	unsigned char digital; /* 0 - digital, 1 - analog */
+	unsigned char digital; /* 0x80 - digital, 0x00 - analog */
 	
 	struct monitorlist* next;
 };

--- a/src/lib/tests/test_edid.c
+++ b/src/lib/tests/test_edid.c
@@ -1,7 +1,17 @@
 #include "../ddcci.h"
 
-#include <assert.h>
+#include <stdio.h>
 #include <string.h>
+
+static int failures = 0;
+
+#define CHECK(cond) \
+	do { \
+		if (!(cond)) { \
+			fprintf(stderr, "FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+			failures++; \
+		} \
+	} while (0)
 
 /* Build a minimal valid 128-byte EDID buffer with the given manufacturer bytes,
  * product code (little-endian), and video input definition byte (0x14). */
@@ -39,20 +49,20 @@ static void test_valid_header_returns_zero(void)
 	unsigned char buf[128];
 	struct monitor mon = make_mon();
 	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x00);
-	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	CHECK(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
 }
 
 static void test_null_monitor_returns_error(void)
 {
 	unsigned char buf[128];
 	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x00);
-	assert(ddcci_parse_edid_buf(NULL, buf, 128) == -1);
+	CHECK(ddcci_parse_edid_buf(NULL, buf, 128) == -1);
 }
 
 static void test_null_buffer_returns_error(void)
 {
 	struct monitor mon = make_mon();
-	assert(ddcci_parse_edid_buf(&mon, NULL, 128) == -1);
+	CHECK(ddcci_parse_edid_buf(&mon, NULL, 128) == -1);
 }
 
 static void test_buffer_too_short_returns_error(void)
@@ -60,10 +70,10 @@ static void test_buffer_too_short_returns_error(void)
 	unsigned char buf[128];
 	struct monitor mon = make_mon();
 	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x00);
-	/* Need at least 0x17 = 23 bytes */
-	assert(ddcci_parse_edid_buf(&mon, buf, 22) == -1);
-	assert(ddcci_parse_edid_buf(&mon, buf, 0)  == -1);
-	assert(ddcci_parse_edid_buf(&mon, buf, -1) == -1);
+	/* Need at least DDCCI_EDID_MIN_PARSE_LEN bytes */
+	CHECK(ddcci_parse_edid_buf(&mon, buf, DDCCI_EDID_MIN_PARSE_LEN - 1) == -1);
+	CHECK(ddcci_parse_edid_buf(&mon, buf, 0) == -1);
+	CHECK(ddcci_parse_edid_buf(&mon, buf, -1) == -1);
 }
 
 static void test_exact_minimum_length_accepted(void)
@@ -71,7 +81,7 @@ static void test_exact_minimum_length_accepted(void)
 	unsigned char buf[128];
 	struct monitor mon = make_mon();
 	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x00);
-	assert(ddcci_parse_edid_buf(&mon, buf, 0x17) == 0);
+	CHECK(ddcci_parse_edid_buf(&mon, buf, DDCCI_EDID_MIN_PARSE_LEN) == 0);
 }
 
 static void test_wrong_first_byte_rejected(void)
@@ -80,7 +90,7 @@ static void test_wrong_first_byte_rejected(void)
 	struct monitor mon = make_mon();
 	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x00);
 	buf[0] = 0x01;
-	assert(ddcci_parse_edid_buf(&mon, buf, 128) == -1);
+	CHECK(ddcci_parse_edid_buf(&mon, buf, 128) == -1);
 }
 
 static void test_wrong_last_header_byte_rejected(void)
@@ -89,7 +99,7 @@ static void test_wrong_last_header_byte_rejected(void)
 	struct monitor mon = make_mon();
 	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x00);
 	buf[7] = 0x01;
-	assert(ddcci_parse_edid_buf(&mon, buf, 128) == -1);
+	CHECK(ddcci_parse_edid_buf(&mon, buf, 128) == -1);
 }
 
 static void test_wrong_middle_header_byte_rejected(void)
@@ -100,7 +110,7 @@ static void test_wrong_middle_header_byte_rejected(void)
 	for (i = 1; i <= 6; i++) {
 		make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x00);
 		buf[i] = 0x00; /* should be 0xff */
-		assert(ddcci_parse_edid_buf(&mon, buf, 128) == -1);
+		CHECK(ddcci_parse_edid_buf(&mon, buf, 128) == -1);
 	}
 }
 
@@ -116,9 +126,9 @@ static void test_pnpid_samsung(void)
 	unsigned char buf[128];
 	struct monitor mon = make_mon();
 	make_edid(buf, 0x4c, 0x2d, 0xa1, 0x01, 0x00);
-	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	CHECK(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
 	/* product code little-endian: lo=0xa1 hi=0x01 -> printed as "01A1" */
-	assert(strcmp(mon.pnpid, "SAM01A1") == 0);
+	CHECK(strcmp(mon.pnpid, "SAM01A1") == 0);
 }
 
 /* Dell: manufacturer code DEL
@@ -131,8 +141,8 @@ static void test_pnpid_dell(void)
 	unsigned char buf[128];
 	struct monitor mon = make_mon();
 	make_edid(buf, 0x10, 0xac, 0x00, 0x00, 0x00);
-	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
-	assert(strcmp(mon.pnpid, "DEL0000") == 0);
+	CHECK(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	CHECK(strcmp(mon.pnpid, "DEL0000") == 0);
 }
 
 /* LG Electronics: manufacturer code GSM (as used in EDID)
@@ -145,8 +155,8 @@ static void test_pnpid_gsm(void)
 	unsigned char buf[128];
 	struct monitor mon = make_mon();
 	make_edid(buf, 0x1e, 0x6d, 0x00, 0x00, 0x00);
-	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
-	assert(strcmp(mon.pnpid, "GSM0000") == 0);
+	CHECK(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	CHECK(strcmp(mon.pnpid, "GSM0000") == 0);
 }
 
 static void test_pnpid_product_code_little_endian(void)
@@ -155,8 +165,8 @@ static void test_pnpid_product_code_little_endian(void)
 	struct monitor mon = make_mon();
 	/* SAM, product lo=0x34, hi=0x12 → printed as "1234" */
 	make_edid(buf, 0x4c, 0x2d, 0x34, 0x12, 0x00);
-	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
-	assert(strcmp(mon.pnpid, "SAM1234") == 0);
+	CHECK(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	CHECK(strcmp(mon.pnpid, "SAM1234") == 0);
 }
 
 static void test_pnpid_max_product_code(void)
@@ -165,8 +175,8 @@ static void test_pnpid_max_product_code(void)
 	struct monitor mon = make_mon();
 	/* product lo=0xFF, hi=0xFF → printed as "FFFF" */
 	make_edid(buf, 0x4c, 0x2d, 0xff, 0xff, 0x00);
-	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
-	assert(strcmp(mon.pnpid, "SAMFFFF") == 0);
+	CHECK(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	CHECK(strcmp(mon.pnpid, "SAMFFFF") == 0);
 }
 
 static void test_pnpid_zero_product_code(void)
@@ -174,8 +184,8 @@ static void test_pnpid_zero_product_code(void)
 	unsigned char buf[128];
 	struct monitor mon = make_mon();
 	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x00);
-	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
-	assert(strcmp(mon.pnpid, "SAM0000") == 0);
+	CHECK(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	CHECK(strcmp(mon.pnpid, "SAM0000") == 0);
 }
 
 /* ---- digital / analog flag ----------------------------------------------- */
@@ -185,8 +195,8 @@ static void test_digital_flag_set_when_bit7_high(void)
 	unsigned char buf[128];
 	struct monitor mon = make_mon();
 	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x80);
-	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
-	assert(mon.digital == 0x80);
+	CHECK(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	CHECK(mon.digital == 0x80);
 }
 
 static void test_digital_flag_clear_when_bit7_low(void)
@@ -194,8 +204,8 @@ static void test_digital_flag_clear_when_bit7_low(void)
 	unsigned char buf[128];
 	struct monitor mon = make_mon();
 	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x00);
-	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
-	assert(mon.digital == 0x00);
+	CHECK(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	CHECK(mon.digital == 0x00);
 }
 
 static void test_digital_flag_ignores_lower_bits(void)
@@ -204,12 +214,12 @@ static void test_digital_flag_ignores_lower_bits(void)
 	struct monitor mon = make_mon();
 	/* Only bit 7 matters */
 	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x7f);
-	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
-	assert(mon.digital == 0x00);
+	CHECK(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	CHECK(mon.digital == 0x00);
 
 	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0xff);
-	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
-	assert(mon.digital == 0x80);
+	CHECK(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	CHECK(mon.digital == 0x80);
 }
 
 /* ---- idempotence / repeated calls --------------------------------------- */
@@ -220,15 +230,15 @@ static void test_successive_calls_overwrite_fields(void)
 	struct monitor mon = make_mon();
 
 	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x80);
-	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
-	assert(mon.digital == 0x80);
-	assert(strcmp(mon.pnpid, "SAM0000") == 0);
+	CHECK(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	CHECK(mon.digital == 0x80);
+	CHECK(strcmp(mon.pnpid, "SAM0000") == 0);
 
 	/* Second call with different data overwrites */
 	make_edid(buf, 0x10, 0xac, 0xab, 0xcd, 0x00);
-	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
-	assert(mon.digital == 0x00);
-	assert(strcmp(mon.pnpid, "DELCDAB") == 0);
+	CHECK(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	CHECK(mon.digital == 0x00);
+	CHECK(strcmp(mon.pnpid, "DELCDAB") == 0);
 }
 
 int main(void)
@@ -251,5 +261,5 @@ int main(void)
 	test_digital_flag_clear_when_bit7_low();
 	test_digital_flag_ignores_lower_bits();
 	test_successive_calls_overwrite_fields();
-	return 0;
+	return failures ? 1 : 0;
 }

--- a/src/lib/tests/test_edid.c
+++ b/src/lib/tests/test_edid.c
@@ -1,0 +1,247 @@
+#include "../ddcci.h"
+
+#include <assert.h>
+#include <string.h>
+
+/* Build a minimal valid 128-byte EDID buffer with the given manufacturer bytes,
+ * product code (little-endian), and video input definition byte (0x14). */
+static void make_edid(unsigned char buf[128], unsigned char b8, unsigned char b9,
+                      unsigned char prod_lo, unsigned char prod_hi,
+                      unsigned char vid_input)
+{
+	memset(buf, 0, 128);
+	/* Standard EDID header */
+	buf[0] = 0x00;
+	buf[1] = 0xff; buf[2] = 0xff; buf[3] = 0xff;
+	buf[4] = 0xff; buf[5] = 0xff; buf[6] = 0xff;
+	buf[7] = 0x00;
+	/* Manufacturer ID bytes */
+	buf[8] = b8;
+	buf[9] = b9;
+	/* Product code (little-endian) */
+	buf[10] = prod_lo;
+	buf[11] = prod_hi;
+	/* Video input definition */
+	buf[0x14] = vid_input;
+}
+
+static struct monitor make_mon(void)
+{
+	struct monitor mon;
+	memset(&mon, 0, sizeof(mon));
+	return mon;
+}
+
+/* ---- header validation -------------------------------------------------- */
+
+static void test_valid_header_returns_zero(void)
+{
+	unsigned char buf[128];
+	struct monitor mon = make_mon();
+	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x00);
+	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+}
+
+static void test_null_buffer_returns_error(void)
+{
+	struct monitor mon = make_mon();
+	assert(ddcci_parse_edid_buf(&mon, NULL, 128) == -1);
+}
+
+static void test_buffer_too_short_returns_error(void)
+{
+	unsigned char buf[128];
+	struct monitor mon = make_mon();
+	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x00);
+	/* Need at least 0x17 = 23 bytes */
+	assert(ddcci_parse_edid_buf(&mon, buf, 22) == -1);
+	assert(ddcci_parse_edid_buf(&mon, buf, 0)  == -1);
+	assert(ddcci_parse_edid_buf(&mon, buf, -1) == -1);
+}
+
+static void test_exact_minimum_length_accepted(void)
+{
+	unsigned char buf[128];
+	struct monitor mon = make_mon();
+	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x00);
+	assert(ddcci_parse_edid_buf(&mon, buf, 0x17) == 0);
+}
+
+static void test_wrong_first_byte_rejected(void)
+{
+	unsigned char buf[128];
+	struct monitor mon = make_mon();
+	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x00);
+	buf[0] = 0x01;
+	assert(ddcci_parse_edid_buf(&mon, buf, 128) == -1);
+}
+
+static void test_wrong_last_header_byte_rejected(void)
+{
+	unsigned char buf[128];
+	struct monitor mon = make_mon();
+	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x00);
+	buf[7] = 0x01;
+	assert(ddcci_parse_edid_buf(&mon, buf, 128) == -1);
+}
+
+static void test_wrong_middle_header_byte_rejected(void)
+{
+	unsigned char buf[128];
+	struct monitor mon = make_mon();
+	int i;
+	for (i = 1; i <= 6; i++) {
+		make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x00);
+		buf[i] = 0x00; /* should be 0xff */
+		assert(ddcci_parse_edid_buf(&mon, buf, 128) == -1);
+	}
+}
+
+/* ---- PNP ID parsing ------------------------------------------------------ */
+
+/* Samsung: manufacturer code SAM
+ *   S = 19, A = 1, M = 13
+ *   buf[8] = (19<<2) | (1>>3) = 76 = 0x4C
+ *   buf[9] = ((1&7)<<5) | 13 = 32|13 = 45 = 0x2D
+ */
+static void test_pnpid_samsung(void)
+{
+	unsigned char buf[128];
+	struct monitor mon = make_mon();
+	make_edid(buf, 0x4c, 0x2d, 0xa1, 0x01, 0x00);
+	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	/* product code little-endian: lo=0xa1 hi=0x01 -> printed as "01A1" */
+	assert(strcmp(mon.pnpid, "SAM01A1") == 0);
+}
+
+/* Dell: manufacturer code DEL
+ *   D=4, E=5, L=12
+ *   buf[8] = (4<<2)|(5>>3) = 16|0 = 0x10
+ *   buf[9] = ((5&7)<<5)|12 = 160|12 = 172 = 0xAC
+ */
+static void test_pnpid_dell(void)
+{
+	unsigned char buf[128];
+	struct monitor mon = make_mon();
+	make_edid(buf, 0x10, 0xac, 0x00, 0x00, 0x00);
+	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	assert(strcmp(mon.pnpid, "DEL0000") == 0);
+}
+
+/* LG Electronics: manufacturer code GSM (as used in EDID)
+ *   G=7, S=19, M=13
+ *   buf[8] = (7<<2)|(19>>3) = 28|2 = 0x1E
+ *   buf[9] = ((19&7)<<5)|13 = (3<<5)|13 = 96|13 = 109 = 0x6D
+ */
+static void test_pnpid_gsm(void)
+{
+	unsigned char buf[128];
+	struct monitor mon = make_mon();
+	make_edid(buf, 0x1e, 0x6d, 0x00, 0x00, 0x00);
+	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	assert(strcmp(mon.pnpid, "GSM0000") == 0);
+}
+
+static void test_pnpid_product_code_little_endian(void)
+{
+	unsigned char buf[128];
+	struct monitor mon = make_mon();
+	/* SAM, product lo=0x34, hi=0x12 → printed as "1234" */
+	make_edid(buf, 0x4c, 0x2d, 0x34, 0x12, 0x00);
+	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	assert(strcmp(mon.pnpid, "SAM1234") == 0);
+}
+
+static void test_pnpid_max_product_code(void)
+{
+	unsigned char buf[128];
+	struct monitor mon = make_mon();
+	/* product lo=0xFF, hi=0xFF → printed as "FFFF" */
+	make_edid(buf, 0x4c, 0x2d, 0xff, 0xff, 0x00);
+	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	assert(strcmp(mon.pnpid, "SAMFFFF") == 0);
+}
+
+static void test_pnpid_zero_product_code(void)
+{
+	unsigned char buf[128];
+	struct monitor mon = make_mon();
+	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x00);
+	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	assert(strcmp(mon.pnpid, "SAM0000") == 0);
+}
+
+/* ---- digital / analog flag ----------------------------------------------- */
+
+static void test_digital_flag_set_when_bit7_high(void)
+{
+	unsigned char buf[128];
+	struct monitor mon = make_mon();
+	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x80);
+	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	assert(mon.digital == 0x80);
+}
+
+static void test_digital_flag_clear_when_bit7_low(void)
+{
+	unsigned char buf[128];
+	struct monitor mon = make_mon();
+	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x00);
+	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	assert(mon.digital == 0x00);
+}
+
+static void test_digital_flag_ignores_lower_bits(void)
+{
+	unsigned char buf[128];
+	struct monitor mon = make_mon();
+	/* Only bit 7 matters */
+	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x7f);
+	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	assert(mon.digital == 0x00);
+
+	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0xff);
+	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	assert(mon.digital == 0x80);
+}
+
+/* ---- idempotence / repeated calls --------------------------------------- */
+
+static void test_successive_calls_overwrite_fields(void)
+{
+	unsigned char buf[128];
+	struct monitor mon = make_mon();
+
+	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x80);
+	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	assert(mon.digital == 0x80);
+	assert(strcmp(mon.pnpid, "SAM0000") == 0);
+
+	/* Second call with different data overwrites */
+	make_edid(buf, 0x10, 0xac, 0xab, 0xcd, 0x00);
+	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	assert(mon.digital == 0x00);
+	assert(strcmp(mon.pnpid, "DELCDAB") == 0);
+}
+
+int main(void)
+{
+	test_valid_header_returns_zero();
+	test_null_buffer_returns_error();
+	test_buffer_too_short_returns_error();
+	test_exact_minimum_length_accepted();
+	test_wrong_first_byte_rejected();
+	test_wrong_last_header_byte_rejected();
+	test_wrong_middle_header_byte_rejected();
+	test_pnpid_samsung();
+	test_pnpid_dell();
+	test_pnpid_gsm();
+	test_pnpid_product_code_little_endian();
+	test_pnpid_max_product_code();
+	test_pnpid_zero_product_code();
+	test_digital_flag_set_when_bit7_high();
+	test_digital_flag_clear_when_bit7_low();
+	test_digital_flag_ignores_lower_bits();
+	test_successive_calls_overwrite_fields();
+	return 0;
+}

--- a/src/lib/tests/test_edid.c
+++ b/src/lib/tests/test_edid.c
@@ -42,6 +42,13 @@ static void test_valid_header_returns_zero(void)
 	assert(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
 }
 
+static void test_null_monitor_returns_error(void)
+{
+	unsigned char buf[128];
+	make_edid(buf, 0x4c, 0x2d, 0x00, 0x00, 0x00);
+	assert(ddcci_parse_edid_buf(NULL, buf, 128) == -1);
+}
+
 static void test_null_buffer_returns_error(void)
 {
 	struct monitor mon = make_mon();
@@ -227,6 +234,7 @@ static void test_successive_calls_overwrite_fields(void)
 int main(void)
 {
 	test_valid_header_returns_zero();
+	test_null_monitor_returns_error();
 	test_null_buffer_returns_error();
 	test_buffer_too_short_returns_error();
 	test_exact_minimum_length_accepted();


### PR DESCRIPTION
## Summary
- extract EDID parsing logic into `ddcci_parse_edid_buf()`
- keep `ddcci_read_edid()` behavior, now calling the shared parser
- add `src/lib/tests/test_edid.c` with focused unit tests for:
  - EDID header validation
  - PNP ID + product code parsing
  - digital/analog flag handling
  - repeated-call overwrite behavior
- register `test_edid` in `src/lib/Makefile.am`
- ignore generated `test_edid` artifacts in `.gitignore`

## Validation
- `make -C src/lib check`