### PR TITLE
Deprecate AMD ADL and legacy PCI backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - GNOME Shell top-bar brightness menu extension example in `contrib/gnome-shell-extension`
 
+### Changed
+
+- Deprecate AMD ADL and legacy direct PCI backends, disable both by default,
+  and require explicit configure flags to build them.
+
 ### Fixed
 
 - fix drop-down monitor identity bug: non-deterministic directory

--- a/README.md
+++ b/README.md
@@ -33,10 +33,17 @@ You might need to restart your system after installing `i2c-tools`.
 
 Install build dependencies:
 
-* on Ubuntu: `sudo apt install intltool i2c-tools libxml2-dev libpci-dev libgtk3.0-dev liblzma-dev`
+* on Ubuntu: `sudo apt install intltool i2c-tools libxml2-dev libgtk3.0-dev liblzma-dev`
 * on Solus: `sudo eopkg install -c system.devel`  
- `sudo eopkg install autoconf automake intltool i2c-tools m4 diffutils libtool-devel xz-devel pciutils-devel libxml2-devel libgtk-3-devel`
+ `sudo eopkg install autoconf automake intltool i2c-tools m4 diffutils libtool-devel xz-devel libxml2-devel libgtk-3-devel`
 * on others: `TODO`
+
+Deprecated AMD ADL and legacy direct PCI backends are disabled by default.
+Use `/dev/i2c-N` devices through `i2c-dev` instead. Builds that explicitly
+enable the deprecated AMD ADL backend with `--enable-amd-adl` or the
+deprecated legacy PCI backend with `--enable-legacy-pci` still require their
+extra development packages. For legacy PCI, that means the pciutils development
+package, for example `libpci-dev` on Ubuntu or `pciutils-devel` on Solus.
 
 Clone, build and install built version:
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Install build dependencies:
 
 * on Ubuntu: `sudo apt install intltool i2c-tools libxml2-dev libgtk3.0-dev liblzma-dev`
 * on Solus: `sudo eopkg install -c system.devel`  
- `sudo eopkg install autoconf automake intltool i2c-tools m4 diffutils libtool-devel xz-devel libxml2-devel libgtk-3-devel`
+  `sudo eopkg install autoconf automake intltool i2c-tools m4 diffutils libtool-devel xz-devel libxml2-devel libgtk-3-devel`
 * on others: `TODO`
 
 Deprecated AMD ADL and legacy direct PCI backends are disabled by default.

--- a/configure.ac
+++ b/configure.ac
@@ -90,16 +90,22 @@ AC_SEARCH_LIBS([round],[m])
 # libxml2 check
 PKG_CHECK_MODULES([LIBXML2], [libxml-2.0])
 
-# Direct PCI memory access check
-support_ddcpci=yes
+# Deprecated direct PCI memory access check
+support_ddcpci=no
+AC_ARG_ENABLE(legacy-pci,
+  [AS_HELP_STRING([--enable-legacy-pci],[enable deprecated legacy direct PCI memory access (disabled)])],
+  [if test x$enableval = xyes; then
+    support_ddcpci=yes
+  fi])
 AC_ARG_ENABLE(ddcpci,
-  [AS_HELP_STRING([--disable-ddcpci],[enable direct PCI memory access (enabled)])],
-  [if test x$enableval = xno; then
-    support_ddcpci=no
+  [AS_HELP_STRING([--enable-ddcpci],[alias for --enable-legacy-pci])],
+  [if test x$enableval = xyes; then
+    support_ddcpci=yes
   fi])
 
 DDCPCI=
 if test x$support_ddcpci = xyes; then
+   AC_MSG_WARN([Legacy direct PCI DDC/CI access is deprecated and will be removed in a future release. Use /dev/i2c-* instead.])
    AC_CHECK_HEADERS([pci/pci.h], [], [AC_MSG_ERROR([PCI utils headers not found, please install pci-utils.], [1])], [])
    AC_CHECK_LIB([pci], [pci_alloc], [], [
       AC_CHECK_LIB([z], [gzopen], [], [AC_MSG_ERROR([PCI utils library not found, please install pci-utils.], [1])])
@@ -114,31 +120,28 @@ AC_SUBST([DDCPCI])
 AC_CHECK_HEADERS([sys/io.h])
 AM_CONDITIONAL(HAVE_SYS_IO, [test x$ac_cv_header_sys_io_h = xyes])
 
-# AMD ADL support check
-support_amdadl=
+# Deprecated AMD ADL support check
+support_amdadl=no
+AC_ARG_ENABLE(amd-adl,
+  [AS_HELP_STRING([--enable-amd-adl],[enable deprecated AMD Display Library support (disabled)])],
+  [if test x$enableval = xyes; then
+    support_amdadl=yes
+  fi])
 AC_ARG_ENABLE(amdadl,
-  [AS_HELP_STRING([--enable-amdadl],[enable AMD Display Library support (autodetect)])],
-  [if test x$enableval = xno; then
-    support_amdadl=no
-  else
+  [AS_HELP_STRING([--enable-amdadl],[alias for --enable-amd-adl])],
+  [if test x$enableval = xyes; then
     support_amdadl=yes
   fi])
 
 AMDADL=
 if test x$support_amdadl = xyes; then
+   AC_MSG_WARN([AMD ADL support is deprecated and will be removed in a future release. Use /dev/i2c-* instead.])
    AC_CHECK_HEADERS([ADL/adl_sdk.h], [], [AC_MSG_ERROR([ADL headers not found, but ADL support requested.], [1])],
    [#ifndef __stdcall
     #define __stdcall
     #endif
     ])
    AMDADL=amdadl
-elif test x$support_amdadl = x; then
-   AC_CHECK_HEADERS([ADL/adl_sdk.h], [
-     AMDADL=amdadl
-   ], [], [#ifndef __stdcall
-           #define __stdcall
-           #endif
-           ])
 fi
 
 if test x$AMDADL = xamdadl; then

--- a/doc/install.xml
+++ b/doc/install.xml
@@ -24,9 +24,13 @@ will also need <filename>gnome-panel-devel</filename> package.
 </para>
 <note>
 <para>
-You only need pci-utils if you explicitly enable the deprecated direct PCI
-memory access backend, and you don't need gtk+ if you don't plan to use the
-Gnome GUI.
+You only need PCI support if you explicitly enable the deprecated direct PCI
+memory access backend at configure time with <option>--enable-legacy-pci</option>
+or <option>--enable-ddcpci</option>. In that case, you will also need the PCI
+development package for your distribution, for example
+<filename>libpci-dev</filename> on Debian-based systems or
+<filename>pciutils-devel</filename> on Fedora/RHEL-based systems. You don't need
+gtk+ if you don't plan to use the Gnome GUI.
 </para>
 </note>
 </sect1>

--- a/doc/install.xml
+++ b/doc/install.xml
@@ -12,27 +12,21 @@
 </listitem>
 <listitem>
 <para>
-<ulink url="http://atrey.karlin.mff.cuni.cz/~mj/pciutils.shtml">pci-utils</ulink>
-</para>
-</listitem>
-<listitem>
-<para>
 <ulink url="http://www.gtk.org/">gtk+&gt;=2.4</ulink>
 </para>
 </listitem>
 </itemizedlist>
 <para>In addition to the library packages, you also need the development
 packages, which are not usually installed. For example, on Debian, their names
-are <filename>libxml2-dev</filename>, <filename>pciutils-dev</filename> and
-<filename>libgtk-3-dev</filename>. Other distributions probably have similar
-package names. On Fedora Core 5, you will also need
-<filename>gnome-panel-devel</filename> package.
+are <filename>libxml2-dev</filename> and <filename>libgtk-3-dev</filename>.
+Other distributions probably have similar package names. On Fedora Core 5, you
+will also need <filename>gnome-panel-devel</filename> package.
 </para>
 <note>
 <para>
-You don't need pci-utils if you don't use direct PCI memory access, and you 
-don't need gtk+ if you don't plan to use the Gnome GUI. Usually, this is not the
-case, so you will almost certainly want these packages for compiling ddccontrol.
+You only need pci-utils if you explicitly enable the deprecated direct PCI
+memory access backend, and you don't need gtk+ if you don't plan to use the
+Gnome GUI.
 </para>
 </note>
 </sect1>


### PR DESCRIPTION
## Summary
- Disable AMD ADL and legacy direct PCI backends by default
- Add explicit deprecated backend configure flags with compatibility aliases
- Update README, install docs, and changelog to point users at i2c-dev by default

## Verification
- `./autogen.sh`
- `./configure`
- `make -j$(nproc)`
- `./scripts/format_code.sh`
- `./scripts/check_git_clean_after_build.sh`
- `git diff --check`

## Review
- Performed two local self-review passes; the first found and fixed stale `pci-utils` install documentation, and the second found no additional changes.