### PR TITLE
Update docs for userspace I2C-only backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ DDCcontrol consists of:
 * `ddccontrol` - command-line tool for monitor parameters control
 * `gddccontrol` - GUI tool for monitor parameters control
 
+DDCcontrol communicates with monitors from userspace through the Linux
+`i2c-dev` interface (`/dev/i2c-N`). AMD ADL and legacy direct PCI backends have
+been removed. For directly connected displays this uses the same kernel
+userspace I2C path as `ddcutil`; USB-connected DDC/CI displays are not supported
+yet.
+
 ## Installation
 
 The most convenient way to install DDCcontrol is to use packages from official distribution repositories.
@@ -25,7 +31,7 @@ DDCcontrol tools, `ddccontrol` and `gddccontrol` can be installed from official 
 
 * on Ubuntu/Debian: `sudo apt install ddccontrol gddccontrol ddccontrol-db i2c-tools`
 * on Fedora: `sudo dnf install ddccontrol ddccontrol-gtk`
-* on openSUSE: `sudo zypper in ddccontrol`
+* on openSUSE: `sudo zypper in ddccontrol i2c-tools`
 
 You might need to restart your system after installing `i2c-tools`.
 
@@ -36,10 +42,9 @@ Install build dependencies:
 * on Ubuntu: `sudo apt install intltool i2c-tools libxml2-dev libgtk3.0-dev liblzma-dev`
 * on Solus: `sudo eopkg install -c system.devel`  
   `sudo eopkg install autoconf automake intltool i2c-tools m4 diffutils libtool-devel xz-devel libxml2-devel libgtk-3-devel`
-* on others: `TODO`
-
-AMD ADL and legacy direct PCI backends have been removed. Use `/dev/i2c-N`
-devices through `i2c-dev` instead.
+* on others: install autotools, intltool, i2c-tools, libxml2 development files,
+  GTK 3 development files and xz/lzma development files using your
+  distribution's package manager.
 
 Clone, build and install built version:
 
@@ -66,7 +71,10 @@ It often merely involves adapting a few standard capabilities as many [pull requ
 
 `gddccontrol` is a graphical utility for monitor configuration. It is called **Monitor Settings** in list of applications.
 
-Following configuration is needed to allow non-root user to use `gddccontrol`:
+DDCcontrol needs readable and writable `/dev/i2c-*` devices. Most
+distributions provide this through the `i2c-dev` kernel module and an `i2c`
+group. Following configuration is needed to allow a non-root user to use
+`gddccontrol`:
 
 ```shell
 sudo adduser $USER i2c

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ DDCcontrol consists of:
 * `gddccontrol` - GUI tool for monitor parameters control
 
 DDCcontrol communicates with monitors from userspace through the Linux
-`i2c-dev` interface (`/dev/i2c-N`). AMD ADL and legacy direct PCI backends have
-been removed. For directly connected displays this uses the same kernel
+`i2c-dev` interface (`/dev/i2c-*`). AMD ADL and legacy direct PCI backends have
+been removed. For directly connected displays, this uses the same kernel
 userspace I2C path as `ddcutil`; USB-connected DDC/CI displays are not supported
 yet.
 

--- a/doc/about.xml
+++ b/doc/about.xml
@@ -15,8 +15,8 @@ user-friendly Gnome GUI.</para>
  
 <sect1 id="ddcci">
 <title>DDC/CI</title>
-<para>DDC/CI is a protocol designed by VESA to configure monitor by software,
-using an I2C bus carried by display connectors such as VGA, DVI, HDMI and
+<para>DDC/CI is a protocol designed by VESA to configure a monitor by software,
+using an I2C bus carried by display connectors such as VGA, DVI, HDMI, and
 DisplayPort.</para>
 <para>DDCcontrol accesses that bus from userspace through the operating
 system's <filename>/dev/i2c-*</filename> devices. Legacy direct PCI memory

--- a/doc/about.xml
+++ b/doc/about.xml
@@ -16,7 +16,12 @@ user-friendly Gnome GUI.</para>
 <sect1 id="ddcci">
 <title>DDC/CI</title>
 <para>DDC/CI is a protocol designed by VESA to configure monitor by software,
-using two wires on the VGA or DVI cables, which forms an I2C bus.</para>
+using an I2C bus carried by display connectors such as VGA, DVI, HDMI and
+DisplayPort.</para>
+<para>DDCcontrol accesses that bus from userspace through the operating
+system's <filename>/dev/i2c-*</filename> devices. Legacy direct PCI memory
+access and AMD ADL backends have been removed. USB-connected DDC/CI displays are
+not supported yet.</para>
 </sect1>
 
 </chapter>

--- a/doc/install.xml
+++ b/doc/install.xml
@@ -70,35 +70,33 @@ package, you must set it to the same value when configuring the other.</para>
 
 <sect1 id="kerneli2c">
 <title>Configure <filename>/dev/i2c-*</filename> devices</title>
-<note><filename>/dev/i2c-*</filename> devices are only working with kernel 2.6
-or greater.</note>
-<para>If your graphics card is supported by <filename>/dev/i2c-*</filename> 
-devices (see <xref linkend="supportedgc"/>), you must load the <filename>i2c-dev</filename>
-module by typing, as root:</para>
+<para>DDCcontrol only uses userspace I2C access through
+<filename>/dev/i2c-*</filename> devices. Legacy direct PCI memory access and AMD
+ADL support have been removed, and USB-connected DDC/CI displays are not
+supported yet.</para>
+<para>The kernel graphics driver must expose the monitor DDC bus as an I2C
+adapter, and the <filename>i2c-dev</filename> module must be loaded. To load it
+manually, type as root:</para>
 <screen format="linespecific">
 # modprobe i2c-dev
 </screen>
-<para>You must also load your graphics card framebuffer driver (for
-card-specific instructions see <xref linkend="supportedgc"/>).</para>
-<para>If you want to automatically load these modules when Linux starts, see 
-your distribution's documentation.</para>
-<para>On systems not using devfs, even after loading framebuffer and i2c-dev modules,
-the devices <filename>/dev/i2c/*</filename> or <filename>/dev/i2c-*</filename> does not
-exist. On Debian, these devices are created using this command :</para>
-<screen format="linespecific">
-# /sbin/MAKEDEV i2c
-</screen>
-<para>To allow standard (i.e. non-root) users to use DDCcontrol, you must change
-permissions on <filename>/dev/i2c-*</filename>. This is done by typing, as 
-root:</para>
+<para>If you want to automatically load this module when Linux starts, see your
+distribution's documentation. DDCcontrol also installs a
+<filename>modules-load.d</filename> configuration file for this purpose on
+systems that use systemd.</para>
+<para>To allow standard (i.e. non-root) users to use DDCcontrol, grant read and
+write access to the relevant <filename>/dev/i2c-*</filename> devices. Many
+distributions do this with an <filename>i2c</filename> group, for example by
+adding your user to that group. For quick local testing, this can also be done
+by typing as root:</para>
 <screen format="linespecific">
 # chmod a+rw /dev/i2c-*
 </screen>
 <sect2>
 <title>Kernel configuration options</title>
-<para>If <filename>i2c-dev</filename> or your graphics card's framebuffer
-modules are not available with your kernel, you can build your own kernel with
-the following options turned on (with recommend to build them as modules):
+<para>If <filename>i2c-dev</filename> or the relevant graphics driver support is
+not available with your kernel, you can build your own kernel with the
+following options turned on (we recommend building them as modules):
 </para>
 <itemizedlist mark='bullet'>
 <listitem>
@@ -118,11 +116,11 @@ the following options turned on (with recommend to build them as modules):
 <menuchoice>
   <guimenu>Devices drivers</guimenu>
   <guimenuitem>Graphics support</guimenuitem>
-  <guimenuitem>Framebuffer support</guimenuitem>
+  <guimenuitem>Direct Rendering Manager</guimenuitem>
 </menuchoice>.
 </listitem>
 <listitem>
-and a specific driver for your graphic card (see <xref linkend="supportedgc"/>).
+and a specific driver for your graphics card.
 </listitem>
 </itemizedlist>
 </sect2>

--- a/doc/install.xml
+++ b/doc/install.xml
@@ -90,7 +90,8 @@ distributions do this with an <filename>i2c</filename> group, for example by
 adding your user to that group. For quick local testing, this can also be done
 by typing as root:</para>
 <screen format="linespecific">
-# chmod a+rw /dev/i2c-*
+# chgrp i2c /dev/i2c-*
+# chmod g+rw /dev/i2c-*
 </screen>
 <sect2>
 <title>Kernel configuration options</title>

--- a/doc/supportedgc.xml
+++ b/doc/supportedgc.xml
@@ -1,12 +1,15 @@
 <appendix id="supportedgc">
-<title>Supported graphics cards</title>
+<title>Display bus access</title>
 <sect1>
-<title><filename>/dev/i2c-*</filename> devices support</title>
-<para>DDCcontrol accesses monitor DDC/CI busses through
-<filename>/dev/i2c-*</filename> devices provided by the operating system.</para>
+<title><filename>/dev/i2c-*</filename> userspace I2C support</title>
+<para>DDCcontrol accesses monitor DDC/CI busses only through
+<filename>/dev/i2c-*</filename> devices provided by the operating system. This
+matches the same kernel userspace I2C path used by tools such as
+<filename>ddcutil</filename> for directly connected displays.</para>
 <para>Legacy direct PCI memory access and AMD ADL support have been removed.
 Use the kernel graphics driver and <filename>i2c-dev</filename> support to
 expose monitor DDC busses as <filename>/dev/i2c-*</filename> devices.</para>
+<para>USB-connected DDC/CI displays are not supported yet.</para>
 <sect2>
 <title>Using NVIDIA proprietary drivers</title>
 <para>The NVIDIA proprietary driver exposes the I2C bus through the standard

--- a/doc/supportedgc.xml
+++ b/doc/supportedgc.xml
@@ -4,7 +4,7 @@
 <title><filename>/dev/i2c-*</filename> userspace I2C support</title>
 <para>DDCcontrol accesses monitor DDC/CI busses only through
 <filename>/dev/i2c-*</filename> devices provided by the operating system. This
-matches the same kernel userspace I2C path used by tools such as
+uses the same kernel userspace I2C path as tools such as
 <filename>ddcutil</filename> for directly connected displays.</para>
 <para>Legacy direct PCI memory access and AMD ADL support have been removed.
 Use the kernel graphics driver and <filename>i2c-dev</filename> support to

--- a/man/ddccontrol.1
+++ b/man/ddccontrol.1
@@ -2,7 +2,7 @@
 .\" First parameter, NAME, should be all caps
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
 .\" other parameters are allowed: see man(7), man(1)
-.TH DDCCONTROL 1 "October 5, 2018"
+.TH DDCCONTROL 1 "May 28, 2026"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .\" Some roff macros, for reference:
@@ -54,6 +54,8 @@ command.
 .\" \fI<whatever>\fP escape sequences to invode bold face and italics, 
 .\" respectively.
 \fBddccontrol\fP is an open source utility which allows controlling monitor parameters via software.
+It communicates with monitors through userspace I2C using \fB/dev/i2c-*\fP devices.
+Legacy direct PCI memory access and AMD ADL backends have been removed, and USB-connected DDC/CI displays are not supported yet.
 .SH OPTIONS
 A summary of options is included below.
 .TP
@@ -62,7 +64,7 @@ a device specifier, for example: \fBdev:/dev/i2c-0\fP, or a monitor selector str
 Use \fBselector\fP to select all matching (DDC/CI-supported) monitors and \fBselector/N\fP (for example \fBSAM083C/0\fP) to select one match by zero-based index.
 .TP
 .B \-p
-probe I2C devices to find monitor buses
+probe /dev/i2c-* devices to find monitor buses
 .TP
 .B \-c
 query capability

--- a/src/daemon/README.md
+++ b/src/daemon/README.md
@@ -1,5 +1,10 @@
 # DDCControl D-Bus daemon
 
+The daemon exposes the same monitor access path as the command-line and GTK
+tools: DDC/CI over userspace I2C through `/dev/i2c-*`. Legacy direct PCI memory
+access and AMD ADL backends have been removed. USB-connected DDC/CI displays are
+not supported yet.
+
 ## Installation
 
 Build and install the daemon:


### PR DESCRIPTION
## Summary
- document that DDCcontrol now uses userspace I2C through /dev/i2c-* only
- remove stale install guidance around legacy PCI/framebuffer-era setup
- note parity with ddcutil for directly connected displays and the remaining lack of USB DDC/CI support

## Verification
- git diff --check origin/master...HEAD
- xmllint --noout doc/main.xml
- man --warnings -l man/ddccontrol.1