### PR TITLE
Credit contributors in copyright notices

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,47 @@
-vdovikin:Oleg I. Vdovikin <oleg@cs.msu.su>
-nboichat:Nicolas Boichat <nicolas@boichat.ch>
-cs123:Christian Schilling <cschilling@gmx.de>
-el_cubano:Roberto C. Sanchez <roberto@connexer.com>
-kravemir:Miroslav Kravec <kravec.miroslav@gmail.com>
+DDCcontrol authors
+==================
+
+The following people have authored non-trivial code, documentation,
+translation, build-system, packaging, or project-maintenance changes in the
+DDCcontrol git history.  Some historical commits used aliases or older email
+addresses; this file uses a single canonical entry per person where known.
+
+Adrian Bunk <bunk@stusta.de>
+Antoine Beaupré <anarcat@debian.org>
+Barak A. Pearlmutter <barak+git@pearlmutter.net>
+Barry deFreese <bdefreese@debian.org>
+Bastian Germann <bage@debian.org>
+Benjamin R. Haskell <c@benizi.com>
+Bill Seremetis <bill@seremetis.net>
+Christian Schilling <cschilling@gmx.de>
+Christian Stadelmann <dev@genodeftest.de>
+Colin Kinloch <colin@kinlo.ch>
+Eduard Bloch <blade@debian.org>
+Ekaterine Papava <papava.e@gtu.ge>
+Enno <Konfekt@users.noreply.github.com>
+Erik Bročko <eb.skola@gmail.com>
+F David <flodavid@users.noreply.github.com>
+Fritz Reichwald <reichwald@b1-systems.de>
+Gluttton <gluttton@ukr.net>
+Henry Hu <henry.hu.sh@gmail.com>
+Hugo Chinchilla Carbonell <hugochinchilla@users.noreply.github.com>
+Igor Vlasenko <viy@altlinux.org>
+Ilya Orlov <iorlov@rzn.dlink.ru>
+Jaroslav Škarvada <jskarvad@redhat.com>
+Lars Tobias Skjong-Børsting <larstobi@relatime.no>
+Mike Frysinger <vapier@gentoo.org>
+Miroslav Kravec <kravec.miroslav@gmail.com>
+Nicolas Boichat <nicolas@boichat.ch>
+Ondřej Budai <ondrej@budai.cz>
+Oleg I. Vdovikin <oleg@cs.msu.su>
+parke <parke.nexus@gmail.com>
+Pavel Palát <pavel.palat@devsoft.cz>
+Robert Munteanu <robert.munteanu@gmail.com>
+Roberto C. Sánchez <roberto@connexer.com>
+Roberto Mansoni <roberto@users.sourceforge.net>
+Rodney Lorrimar <dev@rodney.id.au>
+Stanislav Brabec <sbrabec@suse.cz>
+Tomasz Kłoczko <31284574+kloczek@users.noreply.github.com>
+Vitaly V. Bursov <vitaly@bursov.com>
+William Ollivier <guneemwelloeux@users.sourceforge.net>
+mazepone <mazepone@mailinator.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,89 @@
+DDCcontrol contributors
+=======================
+
+The people below are credited in the project history for reports, monitor
+profiles, externally supplied patches, or other smaller contributions that were
+committed by someone else.
+
+Alex V Breger
+Alexadre Lissy
+Alexander McLeay
+Arno Lepisk
+Artur Flinta
+Aurobinda Maharana
+Ben Skeggs
+Carsten Raehder
+Christian Abegg
+Daniel
+David Chang
+David R Mulligan
+David R. Piegdon
+Den Jean
+Dmitry Artamonow
+Emil F.
+Emil Florea
+Erik Martens
+Evan Innis
+Evgeniy
+Evgeny Stambulchik
+Fabien Salvi
+François Blasin
+Francois
+Gavin Dunse
+Gergely Nagy
+Grzegorz Kurtyka
+Guryanov Dmitry
+Hubai Tamas
+Jakub Bogusz
+Jamil Djadala
+Jan Dumon
+Jan Wagner
+Janne Himanka
+Jason Ellefson
+Joerg Ditzel
+Johann Leonhardmair
+Johannes Deisenhofer
+Johannes Raspe
+John Kent
+Judit Nagy
+Jörg Evers
+Leonardo Fontenelle
+Luis Augusto Perles
+Mark
+Martin Kalkman
+Mateusz Drach
+Mega MoiX
+Michael G. Hansen
+Michael Vogt
+Miguel
+Nicolas Damgaard Larsen
+Norbert Kamenicky
+Olaf Tauber
+Oleg Artamonov
+Paweł Wasylewicz
+Peter
+Pieter De Wit
+Piotr
+Ramadhian Moestafa
+Radoslaw Marcinkowski
+Raymond Tau
+Robert Schedel
+Robert Siemer
+Serge Fedotov
+Sergei Epiphanov
+Sergey Lenkov
+Thomas Raffler
+Tobias Niemann
+Tomasz Moń
+Ulrich Mierendorff
+William Hollingworth
+Willi Wurstig
+Wolfgang Frisch
+basic
+bman
+gpe92
+lardhan
+lekma
+podolany
+rkoumis
+waq_cn

--- a/contrib/gnome-shell-extension/extension.js
+++ b/contrib/gnome-shell-extension/extension.js
@@ -1,3 +1,5 @@
+// Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
+
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';

--- a/data/90-nvidia-i2c.conf
+++ b/data/90-nvidia-i2c.conf
@@ -1,3 +1,5 @@
+# Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
+#
 # Xorg configuration to enable I2C/DDC access on NVIDIA proprietary driver
 #
 # The NVIDIA proprietary driver may fail to expose /dev/i2c-* devices for

--- a/doc/main.xml.in
+++ b/doc/main.xml.in
@@ -35,6 +35,10 @@
 <year>2005-2006</year>
 <holder>Nicolas Boichat</holder>
 </copyright>
+<copyright>
+<year>2004-2026</year>
+<holder>DDCcontrol authors and contributors</holder>
+</copyright>
 
 <releaseinfo role="meta">
 @PACKAGE@-@VERSION@

--- a/doc/usage.xml
+++ b/doc/usage.xml
@@ -39,6 +39,7 @@ and lists controls supported by it. This should give you an output like this
 ddccontrol version 0.1
 Copyright 2004 Oleg I. Vdovikin (oleg-at-cs.msu.su)
 Copyright 2004 Nicolas Boichat (nicolas-at-boichat.ch)
+Copyright 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 This program comes with ABSOLUTELY NO WARRANTY.
 You may redistribute copies of this program under the terms of the GNU General Public License.
 

--- a/man/ddccontrol.1
+++ b/man/ddccontrol.1
@@ -110,5 +110,7 @@ ddccontrol was written by Oleg I. Vdovikin and Nicolas Boichat.
 Copyright 2004\-2005 Oleg I. Vdovikin (oleg@cs.msu.su)
 .br
 Copyright 2004\-2006 Nicolas Boichat (nicolas@boichat.ch)
+.br
+Copyright 2004\-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 .PP
 This manual page was written by Roberto C. Sanchez <roberto@connexer.com>.

--- a/man/gddccontrol.1
+++ b/man/gddccontrol.1
@@ -56,5 +56,7 @@ ddccontrol was written by Oleg I. Vdovikin and Nicolas Boichat.
 Copyright 2004\-2005 Oleg I. Vdovikin (oleg@cs.msu.su)
 .br
 Copyright 2004\-2006 Nicolas Boichat (nicolas@boichat.ch)
+.br
+Copyright 2004\-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 .PP
 This manual page was written by Roberto C. Sanchez <roberto@familiasanchez.net>.

--- a/po/Makevars
+++ b/po/Makevars
@@ -18,7 +18,7 @@ XGETTEXT_OPTIONS = --keyword=_ --keyword=N_
 # or entity, or to disclaim their copyright.  The empty string stands for
 # the public domain; in this case the translators are expected to disclaim
 # their copyright.
-COPYRIGHT_HOLDER = Oleg I. Vdovikin and Nicolas Boichat
+COPYRIGHT_HOLDER = DDCcontrol authors and contributors
 
 # This tells whether or not to prepend "GNU " prefix to the package
 # name that gets inserted into the header of the $(DOMAIN).pot file.

--- a/po/cs.po
+++ b/po/cs.po
@@ -1,4 +1,5 @@
 # Czech translation for ddccontrol.
+# Copyright (C) 2004-2026 DDCcontrol authors and contributors.
 # This file is distributed under the same license as the ddccontrol package.
 # Stanislav Brabec <sbrabec@suse.cz>, 2010. INCOMPLETE.
 #
@@ -69,6 +70,7 @@ msgid ""
 "ddccontrol version %s\n"
 "Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)\n"
 "Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)\n"
+"Copyright 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)\n"
 "This program comes with ABSOLUTELY NO WARRANTY.\n"
 "You may redistribute copies of this program under the terms of the GNU "
 "General Public License.\n"
@@ -77,6 +79,7 @@ msgstr ""
 "ddccontrol verze %s\n"
 "Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)\n"
 "Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)\n"
+"Copyright 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)\n"
 "Tento program je šířen ABSOLUTNĚ BEZ ZÁRUKY.\n"
 "Můžete šířit kopie tohoto programu za dodržení podmínek GNU General Public "
 "License.\n"

--- a/po/de.po
+++ b/po/de.po
@@ -1,5 +1,6 @@
 # German translation of ddccontrol.
 # Copyright (C) 2004-2006 Nicolas Boichat,Oleg I. Vdovikin,
+# Copyright (C) 2004-2026 DDCcontrol authors and contributors.
 # This file is distributed under the same license as the ddccontrol package.
 # Christian Schilling <cschilling@gmx.de>, 2005.
 # Chris Leick <c.leick@vollbio.de>, 2010.
@@ -71,6 +72,7 @@ msgid ""
 "ddccontrol version %s\n"
 "Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)\n"
 "Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)\n"
+"Copyright 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)\n"
 "This program comes with ABSOLUTELY NO WARRANTY.\n"
 "You may redistribute copies of this program under the terms of the GNU "
 "General Public License.\n"
@@ -79,6 +81,7 @@ msgstr ""
 "Ddccontrol-Version %s\n"
 "Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)\n"
 "Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)\n"
+"Copyright 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)\n"
 "Für dieses Programm gibt es ABSOLUT KEINE GEWÄHRLEISTUNG.\n"
 "Sie können Kopien dieses Programms unter den Bestimmungen der »GNU General "
 "Public License« weitergeben.\n"

--- a/po/es.po
+++ b/po/es.po
@@ -1,5 +1,6 @@
 # ddccontrol
 # Copyright (C) 2007 Roberto C. Sánchez
+# Copyright (C) 2004-2026 DDCcontrol authors and contributors.
 # This file is distributed under the same license as the ddcontrol package.
 # Roberto C. Sánchez <roberto@connexer.com>, 2007
 #
@@ -70,6 +71,7 @@ msgid ""
 "ddccontrol version %s\n"
 "Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)\n"
 "Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)\n"
+"Copyright 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)\n"
 "This program comes with ABSOLUTELY NO WARRANTY.\n"
 "You may redistribute copies of this program under the terms of the GNU "
 "General Public License.\n"
@@ -78,6 +80,7 @@ msgstr ""
 "ddccontrol versión %s\n"
 "Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)\n"
 "Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)\n"
+"Copyright 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)\n"
 "Este programa trae NINGUNA GARANTIA.\n"
 "Puedes redistribuir copias de este programa bajo los términos del GNU "
 "General Public License.\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,6 +1,7 @@
 # French translations for DDC/CI control tool package
 # Traduction anglaise du package DDC/CI control tool.
 # Copyright (C) 2004 Oleg I. Vdovikin and Nicolas Boichat
+# Copyright (C) 2004-2026 DDCcontrol authors and contributors.
 # This file is distributed under the same license as the DDC/CI control tool package.
 #  <nicolas@boichat.ch>, 2004.
 #
@@ -71,6 +72,7 @@ msgid ""
 "ddccontrol version %s\n"
 "Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)\n"
 "Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)\n"
+"Copyright 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)\n"
 "This program comes with ABSOLUTELY NO WARRANTY.\n"
 "You may redistribute copies of this program under the terms of the GNU "
 "General Public License.\n"
@@ -79,6 +81,7 @@ msgstr ""
 "ddccontrol, version %s\n"
 "Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)\n"
 "Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)\n"
+"Copyright 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)\n"
 "Ce programme est livré SANS AUCUNE GARANTIE.\n"
 "Vous pouvez redistribuer des copies de ce programme sous les termes de la "
 "licence générale publique de GNU (GNU General Public License).\n"

--- a/po/ka.po
+++ b/po/ka.po
@@ -1,5 +1,6 @@
 # Georgian translation for ddcontrol.
 # Copyright (C) 2026 ddcontrol's authors.
+# Copyright (C) 2004-2026 DDCcontrol authors and contributors.
 # This file is distributed under the same license as the ddcontrol package.
 # Ekaterine Papava <papava.e@gtu.ge>, 2026.
 #
@@ -74,6 +75,7 @@ msgid ""
 "ddccontrol version %s\n"
 "Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)\n"
 "Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)\n"
+"Copyright 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)\n"
 "This program comes with ABSOLUTELY NO WARRANTY.\n"
 "You may redistribute copies of this program under the terms of the GNU "
 "General Public License.\n"
@@ -82,6 +84,7 @@ msgstr ""
 "ddccontrol ვერსია %s\n"
 "Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)\n"
 "Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)\n"
+"Copyright 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)\n"
 "This program comes with ABSOLUTELY NO WARRANTY.\n"
 "You may redistribute copies of this program under the terms of the GNU "
 "General Public License.\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -1,5 +1,6 @@
 # Polish translations for DDC/CI control tool package.
 # Copyright (C) 2005 Oleg I. Vdovikin and Nicolas Boichat
+# Copyright (C) 2004-2026 DDCcontrol authors and contributors.
 # This file is distributed under the same license as the DDC/CI control tool package.
 # Radek Marcinkowski <radek@cbk.waw.pl>, 2005.
 # Jakub Bogusz <qboosh@pld-linux.org>, 2006.
@@ -73,6 +74,7 @@ msgid ""
 "ddccontrol version %s\n"
 "Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)\n"
 "Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)\n"
+"Copyright 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)\n"
 "This program comes with ABSOLUTELY NO WARRANTY.\n"
 "You may redistribute copies of this program under the terms of the GNU "
 "General Public License.\n"
@@ -81,6 +83,7 @@ msgstr ""
 "ddccontrol wersja %s\n"
 "Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)\n"
 "Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)\n"
+"Copyright 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)\n"
 "Ten program jest dostarczany BEZ JAKIEJKOLWIEK GWARANCJI.\n"
 "Mo¿na go rozprowadzaæ na warunkach Powszechnej Licencji Publicznej GNU\n"
 "(General Public License).\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -1,5 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Oleg I. Vdovikin and Nicolas Boichat
+# Copyright (C) 2004-2026 DDCcontrol authors and contributors.
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
@@ -69,6 +70,7 @@ msgid ""
 "ddccontrol version %s\n"
 "Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)\n"
 "Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)\n"
+"Copyright 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)\n"
 "This program comes with ABSOLUTELY NO WARRANTY.\n"
 "You may redistribute copies of this program under the terms of the GNU "
 "General Public License.\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,5 +1,6 @@
 # Chinese for ddccontrol
 # Copyright (C) YEAR Oleg I. Vdovikin and Nicolas Boichat
+# Copyright (C) 2004-2026 DDCcontrol authors and contributors.
 # This file is distributed under the same license as the PACKAGE package.
 # Wu Songhai waq@21cn.com 2005
 #
@@ -69,6 +70,7 @@ msgid ""
 "ddccontrol version %s\n"
 "Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)\n"
 "Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)\n"
+"Copyright 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)\n"
 "This program comes with ABSOLUTELY NO WARRANTY.\n"
 "You may redistribute copies of this program under the terms of the GNU "
 "General Public License.\n"

--- a/scripts/build_gnome_supp.sh
+++ b/scripts/build_gnome_supp.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright(c) 2018 Miroslav Kravec (kravec.miroslav@gmail.com)
+# Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 # SPDX-License-Identifier: GPL-2.0
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/scripts/check_git_clean_after_build.sh
+++ b/scripts/check_git_clean_after_build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
+
 if [[ "$(git status -s)" == "" ]];
 then
     echo -e "\033[1;32mGOOD:\033[0;32m git files are unchanged after build.\033[0m"

--- a/scripts/common/suppressions.sh
+++ b/scripts/common/suppressions.sh
@@ -1,4 +1,5 @@
 # Copyright(c) 2018 Miroslav Kravec (kravec.miroslav@gmail.com)
+# Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 # SPDX-License-Identifier: GPL-2.0
 
 SUPPRESSIONS=( $(pwd)/scripts/tmp/GNOME.supp/build/{base,gio,glib,gtk,gtk3}.supp /usr/share/glib-2.0/valgrind/glib.supp )

--- a/scripts/common_launcher.sh
+++ b/scripts/common_launcher.sh
@@ -1,4 +1,5 @@
 # Copyright(c) 2018 Miroslav Kravec (kravec.miroslav@gmail.com)
+# Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 # SPDX-License-Identifier: GPL-2.0
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/scripts/common_test.sh
+++ b/scripts/common_test.sh
@@ -1,4 +1,5 @@
 # Copyright(c) 2018 Miroslav Kravec (kravec.miroslav@gmail.com)
+# Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 # SPDX-License-Identifier: GPL-2.0
 
 if [ "$EUID" -ne 0 ];

--- a/scripts/format_code.sh
+++ b/scripts/format_code.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PROJECT_DIR="$( dirname "$DIR" )"
 

--- a/scripts/valgrind_dbus_service_test.sh
+++ b/scripts/valgrind_dbus_service_test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright(c) 2018 Miroslav Kravec (kravec.miroslav@gmail.com)
+# Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 # SPDX-License-Identifier: GPL-2.0
 
 source "$(dirname "$0")/common_test.sh"

--- a/scripts/valgrind_dbus_service_test_launcher.sh
+++ b/scripts/valgrind_dbus_service_test_launcher.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright(c) 2018 Miroslav Kravec (kravec.miroslav@gmail.com)
+# Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 # SPDX-License-Identifier: GPL-2.0
 
 source "$(dirname "$0")/common_launcher.sh"

--- a/scripts/valgrind_ddccontrol_test.sh
+++ b/scripts/valgrind_ddccontrol_test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright(c) 2018 Miroslav Kravec (kravec.miroslav@gmail.com)
+# Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 # SPDX-License-Identifier: GPL-2.0
 
 source "$(dirname "$0")/common_test.sh"

--- a/scripts/valgrind_ddccontrol_test_launcher.sh
+++ b/scripts/valgrind_ddccontrol_test_launcher.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright(c) 2018 Miroslav Kravec (kravec.miroslav@gmail.com)
+# Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 # SPDX-License-Identifier: GPL-2.0
 
 source "$(dirname "$0")/common_launcher.sh"

--- a/src/daemon/dbus_client.c
+++ b/src/daemon/dbus_client.c
@@ -2,6 +2,7 @@
     ddc/ci D-Bus client library implementation
 
     Copyright(c) 2018 Miroslav Kravec (kravec.miroslav@gmail.com)
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/daemon/dbus_client.h
+++ b/src/daemon/dbus_client.h
@@ -2,6 +2,7 @@
     ddc/ci D-Bus client library headers
 
     Copyright(c) 2018 Miroslav Kravec (kravec.miroslav@gmail.com)
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/daemon/ddccontrol.DDCControl.xml
+++ b/src/daemon/ddccontrol.DDCControl.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!-- Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS) -->
 <node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
   <interface name="ddccontrol.DDCControl">
     <method name="GetMonitors">

--- a/src/daemon/service.c
+++ b/src/daemon/service.c
@@ -1,6 +1,7 @@
 /*
     ddc/ci command line tool
     Copyright(c) 2018 Miroslav Kravec (kravec.miroslav@gmail.com)
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/ddccontrol/ddccontrol.h
+++ b/src/ddccontrol/ddccontrol.h
@@ -1,6 +1,7 @@
 /*
     ddc/ci internal functions header for command line tool
     Copyright(c) 2018 Miroslav Kravec (kravec.miroslav@gmail.com)
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/ddccontrol/main.c
+++ b/src/ddccontrol/main.c
@@ -2,6 +2,7 @@
     ddc/ci command line tool
     Copyright(c) 2004 Oleg I. Vdovikin (oleg@cs.msu.su)
     Copyright(c) 2004-2006 Nicolas Boichat (nicolas@boichat.ch)
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -200,7 +201,7 @@ static int parse_selector_index(const char *selector, char **base_selector, int 
 
 	suffix = slash + 1;
 	for (const char *p = suffix; *p != '\0'; p++) {
-		if (!isdigit((unsigned char)*p)) {
+		if (!isdigit((unsigned char) * p)) {
 			/* Treat as a literal selector containing '/', not selector/index. */
 			return 1;
 		}
@@ -306,6 +307,8 @@ int main(int argc, char **argv)
 	        _("ddccontrol version %s\n"
 	          "Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)\n"
 	          "Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)\n"
+	          "Copyright 2004-2026 DDCcontrol authors and "
+	          "contributors (see AUTHORS and CONTRIBUTORS)\n"
 	          "This program comes with ABSOLUTELY NO WARRANTY.\n"
 	          "You may redistribute copies of this program under the terms of the GNU General Public License.\n\n"), VERSION);
 

--- a/src/ddccontrol/printing.c
+++ b/src/ddccontrol/printing.c
@@ -3,6 +3,7 @@
     Copyright(c) 2004 Oleg I. Vdovikin (oleg@cs.msu.su)
     Copyright(c) 2004-2006 Nicolas Boichat (nicolas@boichat.ch)
     Copyright(c) 2018 Miroslav Kravec (kravec.miroslav@gmail.com)
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/gddccontrol/fspatterns.c
+++ b/src/gddccontrol/fspatterns.c
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2005 by Nicolas Boichat                                 *
+ *   Copyright (C) 2004-2026 by DDCcontrol authors and contributors        *
  *   nicolas@boichat.ch                                                    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/gddccontrol/gprofile.c
+++ b/src/gddccontrol/gprofile.c
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2005 by Nicolas Boichat                                 *
+ *   Copyright (C) 2004-2026 by DDCcontrol authors and contributors        *
  *   nicolas@boichat.ch                                                    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/gddccontrol/gui.h
+++ b/src/gddccontrol/gui.h
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2004-2005 by Nicolas Boichat                            *
+ *   Copyright (C) 2004-2026 by DDCcontrol authors and contributors        *
  *   nicolas@boichat.ch                                                    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/gddccontrol/main.c
+++ b/src/gddccontrol/main.c
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2004-2005 by Nicolas Boichat                            *
+ *   Copyright (C) 2004-2026 by DDCcontrol authors and contributors        *
  *   nicolas@boichat.ch                                                    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/gddccontrol/stack.c
+++ b/src/gddccontrol/stack.c
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2004-2005 by Nicolas Boichat                            *
+ *   Copyright (C) 2004-2026 by DDCcontrol authors and contributors        *
  *   nicolas@boichat.ch                                                    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/lib/conf.c
+++ b/src/lib/conf.c
@@ -1,6 +1,7 @@
 /*
     read/write configuration files in ~/.ddccontrol (profiles, cached monitor list)
     Copyright(c) 2005 Nicolas Boichat (nicolas@boichat.ch)
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/lib/conf.h
+++ b/src/lib/conf.h
@@ -1,6 +1,7 @@
 /*
     read/write configuration files in ~/.ddccontrol (profiles, cached monitor list)
     Copyright(c) 2005 Nicolas Boichat (nicolas@boichat.ch)
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/lib/ddcci.c
+++ b/src/lib/ddcci.c
@@ -2,6 +2,7 @@
     ddc/ci interface functions
     Copyright(c) 2004 Oleg I. Vdovikin (oleg@cs.msu.su)
     Copyright(c) 2004-2006 Nicolas Boichat (nicolas@boichat.ch)
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/lib/ddcci.h
+++ b/src/lib/ddcci.h
@@ -2,6 +2,7 @@
     ddc/ci interface functions header
     Copyright(c) 2004 Oleg I. Vdovikin (oleg@cs.msu.su)
     Copyright(c) 2004-2005 Nicolas Boichat (nicolas@boichat.ch)
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/lib/i2c-dev.h
+++ b/src/lib/i2c-dev.h
@@ -1,6 +1,7 @@
 /*
     ddc/ci i2c-dev header
     Copyright(c) 2004 Nicolas Boichat (nicolas@boichat.ch)
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
     Copyright (C) 1995-2000 Simon G. Vogl (original i2c.h headers)
 
     This program is free software; you can redistribute it and/or modify

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -2,6 +2,7 @@
     ddc/ci interface functions header
     Copyright(c) 2004 Oleg I. Vdovikin (oleg@cs.msu.su)
     Copyright(c) 2004-2005 Nicolas Boichat (nicolas@boichat.ch)
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/lib/issueurl.c
+++ b/src/lib/issueurl.c
@@ -1,3 +1,7 @@
+/*
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
+*/
+
 #include "issueurl.h"
 #include "urlencode.h"
 

--- a/src/lib/issueurl.h
+++ b/src/lib/issueurl.h
@@ -1,3 +1,7 @@
+/*
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
+*/
+
 #ifndef ISSUEURL_H
 #define ISSUEURL_H
 

--- a/src/lib/monitor_db.c
+++ b/src/lib/monitor_db.c
@@ -2,6 +2,7 @@
     ddc/ci interface functions
     Copyright(c) 2004-2005 Nicolas Boichat (nicolas@boichat.ch)
     Copyright(c) 2004 Oleg I. Vdovikin (oleg@cs.msu.su)
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/lib/monitor_db.h
+++ b/src/lib/monitor_db.h
@@ -2,6 +2,7 @@
     ddc/ci interface functions header
     Copyright(c) 2004 Nicolas Boichat (nicolas@boichat.ch)
     Copyright(c) 2004 Oleg I. Vdovikin (oleg@cs.msu.su)
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/lib/monitor_db_internal.h
+++ b/src/lib/monitor_db_internal.h
@@ -2,6 +2,7 @@
     ddc/ci monitor database internals
     Copyright(c) 2004-2005 Nicolas Boichat (nicolas@boichat.ch)
     Copyright(c) 2004 Oleg I. Vdovikin (oleg@cs.msu.su)
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/lib/tests/test_edid.c
+++ b/src/lib/tests/test_edid.c
@@ -1,3 +1,7 @@
+/*
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
+*/
+
 #include "../ddcci.h"
 
 #include <stdio.h>

--- a/src/lib/tests/test_issueurl.c
+++ b/src/lib/tests/test_issueurl.c
@@ -1,3 +1,7 @@
+/*
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
+*/
+
 #include "../issueurl.h"
 #include "../monitor_db.h"
 #include "../monitor_db_internal.h"

--- a/src/lib/tests/test_parse_caps.c
+++ b/src/lib/tests/test_parse_caps.c
@@ -1,3 +1,7 @@
+/*
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
+*/
+
 #include "../ddcci.h"
 
 #include <assert.h>

--- a/src/lib/urlencode.c
+++ b/src/lib/urlencode.c
@@ -1,3 +1,7 @@
+/*
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
+*/
+
 #include "urlencode.h"
 
 #include <ctype.h>

--- a/src/lib/urlencode.h
+++ b/src/lib/urlencode.h
@@ -1,3 +1,7 @@
+/*
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
+*/
+
 #ifndef URLENCODE_H
 #define URLENCODE_H
 


### PR DESCRIPTION
## Summary
- expand AUTHORS from git history and add CONTRIBUTORS for credited reports/profiles/smaller contributions
- add project-wide DDCcontrol authors/contributors copyright notices while preserving existing named notices
- update user-visible copyright strings, manpages, docs, scripts, gettext metadata, and source headers

## Validation
- ./scripts/format_code.sh
- git diff --check
- msgfmt -c for all po/*.po
- ./scripts/check_git_clean_after_build.sh

Note: msgfmt reports the existing po/zh_CN.po warning that the Language header still has its default value.