### PR TITLE
fix: Add escape syntax to un-break missing XML message

### DIFF
--- a/src/gddccontrol/stack.c
+++ b/src/gddccontrol/stack.c
@@ -912,7 +912,7 @@ void create_monitor_manager(struct monitorlist* monitor)
 				"version, please open a github issue:\n"
 				"https://github.com/ddccontrol/ddccontrol-db/issues/new?template=unsupported-monitor.yml"
 				"\nThen attach the resulting report file of the following command:\n"),
-				"\n<tt>LANG=C LC_ALL=C ddccontrol -p -c -d &> /tmp/ddccontrol-report.txt</tt>\n\n",
+				"\n<tt>LANG=C LC_ALL=C ddccontrol -p -c -d &amp;> /tmp/ddccontrol-report.txt</tt>\n\n",
 				_("Thank you.\n"), NULL);
 		gtk_widget_show(monitor_manager);
 		set_message_ok(tmp, 1);


### PR DESCRIPTION
Fix a regression introduced recently.

Prior to this fix, the dialog would not show up because of an XML markup parsing error. Instead, the "Loading profiles" message would kept stuck, looking like the application didn't finish loading profiles.

This bug is visible to the users, it would be good to put it into a patch release soon.