### PR TITLE
ci: enforce conventional PR titles

### DIFF
--- a/.github/workflows/conventional-pr-title.yml
+++ b/.github/workflows/conventional-pr-title.yml
@@ -1,0 +1,28 @@
+name: Conventional PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            chore
+            refactor
+            perf
+            test
+            build
+            ci
+            revert


### PR DESCRIPTION
## Summary

- Add a GitHub Actions check that validates PR titles against Conventional Commits.
- Allow the commit types used by Release Please and common maintenance/docs/test workflows.

## Verification

- Parsed `.github/workflows/conventional-pr-title.yml` with Python YAML
- `git diff --check`