### PR TITLE
docs: document DDCCONTROL_NO_DAEMON

### DIFF
--- a/TODO
+++ b/TODO
@@ -12,6 +12,3 @@ BUGS:
  - Fix Samsung 720T (not detected as LCD as type is "LCD CM")
  - Fix Samsung 740BF (not detected as LCD)
  - Fix Mitsubishi DiamondPro 930SB (not detected as CRT (type(CRT_AG)))
-
-Features to document:
- - envvar DDCCONTROL_NO_DAEMON

--- a/doc/usage.xml
+++ b/doc/usage.xml
@@ -130,4 +130,18 @@ Control 0x10: +/70/100 [Brightness]
 </sect3>
 </sect2>
 </sect1>
+<sect1>
+<title>Environment variables</title>
+<variablelist>
+<varlistentry>
+<term><envar>DDCCONTROL_NO_DAEMON</envar></term>
+<listitem>
+<para>When set to a non-empty value, <command>ddccontrol</command> and
+<command>gddccontrol</command> bypass the D-Bus daemon and access
+<filename>/dev/i2c-*</filename> devices directly. This can be useful for
+testing, debugging, or working around a daemon startup or connection problem.</para>
+</listitem>
+</varlistentry>
+</variablelist>
+</sect1>
 </chapter>

--- a/man/ddccontrol.1
+++ b/man/ddccontrol.1
@@ -98,6 +98,12 @@ verbosity (specify more to increase)
 .TP
 .B \-b
 ddccontrol-db directory (if other than /usr/share/ddccontrol-db)
+.SH ENVIRONMENT
+.TP
+.B DDCCONTROL_NO_DAEMON
+When set to a non-empty value, \fBddccontrol\fP bypasses the D-Bus daemon and
+accesses \fB/dev/i2c-*\fP devices directly. This can be useful for testing,
+debugging, or working around a daemon startup or connection problem.
 .SH SEE ALSO
 The program is documented fully in
 .br

--- a/man/gddccontrol.1
+++ b/man/gddccontrol.1
@@ -2,7 +2,7 @@
 .\" First parameter, NAME, should be all caps
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
 .\" other parameters are allowed: see man(7), man(1)
-.TH GDDCCONTROL 1 "July 26, 2006"
+.TH GDDCCONTROL 1 "June 11, 2026"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .\" Some roff macros, for reference:
@@ -38,6 +38,11 @@ Do not show the warning banner for unsupported monitors when a fallback profile 
 \fB\-v\fP, \fB\-\-verbose\fP
 Increase verbosity. Repeat (e.g. \fB\-vv\fP) for more detailed output.
 .SH ENVIRONMENT
+.TP
+\fBDDCCONTROL_NO_DAEMON\fP
+When set to a non-empty value, \fBgddccontrol\fP bypasses the D-Bus daemon and
+accesses \fB/dev/i2c-*\fP devices directly. This can be useful for testing,
+debugging, or working around a daemon startup or connection problem.
 .TP
 \fBGTK_THEME\fP
 Override the GTK theme for this launch. For example, run


### PR DESCRIPTION
## Summary
- document `DDCCONTROL_NO_DAEMON` in the CLI and GTK man pages
- add the environment variable to the DocBook usage documentation
- remove the completed TODO entry

## Tests
- `xmllint --noout doc/usage.xml`
- `nroff -man man/ddccontrol.1 >/dev/null && nroff -man man/gddccontrol.1 >/dev/null`
- `git diff --check`