### PR TITLE
feat(gddccontrol): show extended EDID information

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,5 +1,4 @@
 Nicolas:
- - Read EDID info, show it in gddccontrol
  - Add support for more than 2 monitors
  - See what to do with engineering VCP.
  - Better handling of --enable-doc.

--- a/src/daemon/dbus_client.c
+++ b/src/daemon/dbus_client.c
@@ -120,9 +120,7 @@ int ddcci_dbus_open(DDCControl *proxy, struct monitor **_mon, const char *filena
 		return -1;
 	}
 
-
-	gboolean result = ddccontrol_call_open_monitor_sync(proxy, filename, &pnpid, &mon->caps.raw_caps,
-	                  &v_edid, NULL, &error);
+	gboolean result = ddccontrol_call_open_monitor_sync(proxy, filename, &pnpid, &mon->caps.raw_caps, NULL, &error);
 	if (result == FALSE) {
 		fprintf(stderr, _("Open monitor failed: %s\n."), error->message);
 		g_clear_error(&error);
@@ -141,6 +139,10 @@ int ddcci_dbus_open(DDCControl *proxy, struct monitor **_mon, const char *filena
 	mon->pnpid[7] = 0;
 	g_free(pnpid);
 
+	result = ddccontrol_call_get_edid_sync(proxy, filename, &v_edid, NULL, &error);
+	if (result == FALSE) {
+		g_clear_error(&error);
+	}
 	if (v_edid != NULL) {
 		gsize edid_len = 0;
 		const unsigned char *edid = g_variant_get_fixed_array(v_edid, &edid_len, sizeof(guchar));

--- a/src/daemon/dbus_client.c
+++ b/src/daemon/dbus_client.c
@@ -100,6 +100,7 @@ static int looks_like_caps(const char *value)
 int ddcci_dbus_open(DDCControl *proxy, struct monitor **_mon, const char *filename)
 {
 	char *pnpid = NULL;
+	GVariant *v_edid = NULL;
 	GError *error = NULL;
 
 	struct dbus_monitor *dbus_mon;
@@ -120,7 +121,8 @@ int ddcci_dbus_open(DDCControl *proxy, struct monitor **_mon, const char *filena
 	}
 
 
-	gboolean result = ddccontrol_call_open_monitor_sync(proxy, filename, &pnpid, &mon->caps.raw_caps, NULL, &error);
+	gboolean result = ddccontrol_call_open_monitor_sync(proxy, filename, &pnpid, &mon->caps.raw_caps,
+	                  &v_edid, NULL, &error);
 	if (result == FALSE) {
 		fprintf(stderr, _("Open monitor failed: %s\n."), error->message);
 		g_clear_error(&error);
@@ -138,6 +140,15 @@ int ddcci_dbus_open(DDCControl *proxy, struct monitor **_mon, const char *filena
 	strncpy((char *)&mon->pnpid, pnpid, 7);
 	mon->pnpid[7] = 0;
 	g_free(pnpid);
+
+	if (v_edid != NULL) {
+		gsize edid_len = 0;
+		const unsigned char *edid = g_variant_get_fixed_array(v_edid, &edid_len, sizeof(guchar));
+		if (edid != NULL && ddcci_parse_edid_buf(mon, edid, edid_len) < 0) {
+			mon->edid_len = 0;
+		}
+		g_variant_unref(v_edid);
+	}
 
 	if (ddcci_parse_caps(mon->caps.raw_caps, &mon->caps, 1) < 0) {
 		mon->caps.type = unk;

--- a/src/daemon/ddccontrol.DDCControl.xml
+++ b/src/daemon/ddccontrol.DDCControl.xml
@@ -18,6 +18,9 @@
       <arg name="device"  type="s" direction="in"  />
       <arg name="pnpid"   type="s" direction="out" />
       <arg name="caps"    type="s" direction="out" />
+    </method>
+    <method name="GetEdid">
+      <arg name="device"  type="s" direction="in"  />
       <arg name="edid"    type="ay" direction="out">
         <annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
       </arg>

--- a/src/daemon/ddccontrol.DDCControl.xml
+++ b/src/daemon/ddccontrol.DDCControl.xml
@@ -18,6 +18,9 @@
       <arg name="device"  type="s" direction="in"  />
       <arg name="pnpid"   type="s" direction="out" />
       <arg name="caps"    type="s" direction="out" />
+      <arg name="edid"    type="ay" direction="out">
+        <annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
+      </arg>
     </method>
     <method name="GetControl">
       <arg name="device"  type="s" direction="in"  />

--- a/src/daemon/service.c
+++ b/src/daemon/service.c
@@ -301,7 +301,13 @@ static gboolean handle_open_monitor(DDCControl *skeleton, GDBusMethodInvocation 
 		return TRUE;
 	}
 
-	ddccontrol_complete_open_monitor(skeleton, invocation, mon->pnpid, mon->caps.raw_caps);
+	ddccontrol_complete_open_monitor(
+	    skeleton,
+	    invocation,
+	    mon->pnpid,
+	    mon->caps.raw_caps,
+	    g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, mon->edid, mon->edid_len, sizeof(guchar))
+	);
 	return TRUE;
 }
 

--- a/src/daemon/service.c
+++ b/src/daemon/service.c
@@ -305,7 +305,38 @@ static gboolean handle_open_monitor(DDCControl *skeleton, GDBusMethodInvocation 
 	    skeleton,
 	    invocation,
 	    mon->pnpid,
-	    mon->caps.raw_caps,
+	    mon->caps.raw_caps
+	);
+	return TRUE;
+}
+
+static gboolean handle_get_edid(DDCControl *skeleton, GDBusMethodInvocation *invocation,
+                                gchar *device)
+{
+	int ret;
+	struct monitor *mon;
+
+	if (can_open_device(device) == FALSE) {
+		g_dbus_method_invocation_return_dbus_error(
+		    invocation,
+		    DC_BUS_ERROR_INVALID_DEVICE,
+		    "only detected devices are allowed"
+		);
+		return TRUE;
+	}
+
+	if ((ret = open_monitor(&mon, device)) < 0) {
+		g_dbus_method_invocation_return_dbus_error(
+		    invocation,
+		    DC_BUS_ERROR_OPEN_FAILED,
+		    "Failed to open monitor"
+		);
+		return TRUE;
+	}
+
+	ddccontrol_complete_get_edid(
+	    skeleton,
+	    invocation,
 	    g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, mon->edid, mon->edid_len, sizeof(guchar))
 	);
 	return TRUE;
@@ -401,6 +432,7 @@ static void on_name_acquired(GDBusConnection *connection, const gchar *name, gpo
 	g_signal_connect(skeleton, "handle-get-monitors", G_CALLBACK(handle_get_monitors), NULL);
 	g_signal_connect(skeleton, "handle-rescan-monitors", G_CALLBACK(handle_rescan_monitors), NULL);
 	g_signal_connect(skeleton, "handle-open-monitor", G_CALLBACK(handle_open_monitor), NULL);
+	g_signal_connect(skeleton, "handle-get-edid", G_CALLBACK(handle_get_edid), NULL);
 	g_signal_connect(skeleton, "handle-get-control",  G_CALLBACK(handle_get_control), NULL);
 	g_signal_connect(skeleton, "handle-set-control",  G_CALLBACK(handle_set_control), NULL);
 

--- a/src/gddccontrol/gui.h
+++ b/src/gddccontrol/gui.h
@@ -85,6 +85,7 @@ void set_message_ok(char* message, int with_ok);
 GtkWidget *button_from_icon_name(const gchar * icon_name, const gchar *label_text, const gchar *tool_tip);
 
 extern GtkWidget* profile_manager_button;
+extern GtkWidget* edid_info_button;
 extern GtkWidget* saveprofile_button;
 extern GtkWidget* cancelprofile_button;
 extern GtkWidget* refresh_controls_button;

--- a/src/gddccontrol/main.c
+++ b/src/gddccontrol/main.c
@@ -54,6 +54,7 @@ GtkWidget* monitor_manager = NULL;
 GtkWidget* profile_manager = NULL;
 
 GtkWidget* profile_manager_button = NULL;
+GtkWidget* edid_info_button = NULL;
 GtkWidget* saveprofile_button = NULL;
 GtkWidget* cancelprofile_button = NULL;
 GtkWidget* refresh_controls_button = NULL;
@@ -246,6 +247,7 @@ static void widgets_set_sensitive(gboolean sensitive)
 	gtk_widget_set_sensitive(refresh_controls_button, sensitive && (current_main_component == 0));
 	gtk_widget_set_sensitive(close_button, sensitive);
 	gtk_widget_set_sensitive(profile_manager_button, sensitive && (current_main_component == 0));
+	gtk_widget_set_sensitive(edid_info_button, sensitive && (current_main_component == 0));
 	gtk_widget_set_sensitive(saveprofile_button, sensitive);
 	gtk_widget_set_sensitive(cancelprofile_button, sensitive);
 }
@@ -263,12 +265,14 @@ void set_current_main_component(int component) {
 		gtk_widget_hide(profile_manager);
 		gtk_widget_set_sensitive(refresh_controls_button, TRUE);
 		gtk_widget_set_sensitive(profile_manager_button, TRUE);
+		gtk_widget_set_sensitive(edid_info_button, TRUE);
 	}
 	else if (current_main_component == 1) {
 		gtk_widget_hide(monitor_manager);
 		gtk_widget_show(profile_manager);
 		gtk_widget_set_sensitive(refresh_controls_button, FALSE);
 		gtk_widget_set_sensitive(profile_manager_button, FALSE);
+		gtk_widget_set_sensitive(edid_info_button, FALSE);
 	}
 }
 
@@ -560,6 +564,12 @@ int main( int argc, char *argv[] )
 	gtk_box_pack_start(GTK_BOX(profile_hbox), profile_manager_button, 0, 0, 0);
 	gtk_widget_show (profile_manager_button);
 	gtk_widget_set_sensitive(profile_manager_button, FALSE);
+
+	edid_info_button = button_from_icon_name("dialog-information", _("EDID information"),
+	                   _("Show EDID information for the current monitor"));
+	gtk_box_pack_start(GTK_BOX(profile_hbox), edid_info_button, 0, 0, 0);
+	gtk_widget_show (edid_info_button);
+	gtk_widget_set_sensitive(edid_info_button, FALSE);
 	
 	saveprofile_button = button_from_icon_name("document-save", _("Save profile"), NULL);
 	g_signal_connect(G_OBJECT(saveprofile_button), "clicked", G_CALLBACK(saveprofile_callback), NULL);

--- a/src/gddccontrol/main.c
+++ b/src/gddccontrol/main.c
@@ -99,6 +99,12 @@ static gboolean parse_verbosity_option(const gchar *option_name, const gchar *va
 	return TRUE;
 }
 
+static gboolean can_toggle_edid_info(void)
+{
+	return edid_info_button &&
+	       GPOINTER_TO_INT(g_object_get_data(G_OBJECT(edid_info_button), "ddc_edid_info_available"));
+}
+
 static int can_use_dbus_daemon(void)
 {
 	const char *disable_envvar = getenv("DDCCONTROL_NO_DAEMON");
@@ -247,7 +253,7 @@ static void widgets_set_sensitive(gboolean sensitive)
 	gtk_widget_set_sensitive(refresh_controls_button, sensitive && (current_main_component == 0));
 	gtk_widget_set_sensitive(close_button, sensitive);
 	gtk_widget_set_sensitive(profile_manager_button, sensitive && (current_main_component == 0));
-	gtk_widget_set_sensitive(edid_info_button, sensitive && (current_main_component == 0));
+	gtk_widget_set_sensitive(edid_info_button, sensitive && (current_main_component == 0) && can_toggle_edid_info());
 	gtk_widget_set_sensitive(saveprofile_button, sensitive);
 	gtk_widget_set_sensitive(cancelprofile_button, sensitive);
 }
@@ -265,7 +271,7 @@ void set_current_main_component(int component) {
 		gtk_widget_hide(profile_manager);
 		gtk_widget_set_sensitive(refresh_controls_button, TRUE);
 		gtk_widget_set_sensitive(profile_manager_button, TRUE);
-		gtk_widget_set_sensitive(edid_info_button, TRUE);
+		gtk_widget_set_sensitive(edid_info_button, can_toggle_edid_info());
 	}
 	else if (current_main_component == 1) {
 		gtk_widget_hide(monitor_manager);

--- a/src/gddccontrol/main.c
+++ b/src/gddccontrol/main.c
@@ -253,7 +253,8 @@ static void widgets_set_sensitive(gboolean sensitive)
 	gtk_widget_set_sensitive(refresh_controls_button, sensitive && (current_main_component == 0));
 	gtk_widget_set_sensitive(close_button, sensitive);
 	gtk_widget_set_sensitive(profile_manager_button, sensitive && (current_main_component == 0));
-	gtk_widget_set_sensitive(edid_info_button, sensitive && (current_main_component == 0) && can_toggle_edid_info());
+	if (edid_info_button)
+		gtk_widget_set_sensitive(edid_info_button, sensitive && (current_main_component == 0) && can_toggle_edid_info());
 	gtk_widget_set_sensitive(saveprofile_button, sensitive);
 	gtk_widget_set_sensitive(cancelprofile_button, sensitive);
 }
@@ -271,14 +272,16 @@ void set_current_main_component(int component) {
 		gtk_widget_hide(profile_manager);
 		gtk_widget_set_sensitive(refresh_controls_button, TRUE);
 		gtk_widget_set_sensitive(profile_manager_button, TRUE);
-		gtk_widget_set_sensitive(edid_info_button, can_toggle_edid_info());
+		if (edid_info_button)
+			gtk_widget_set_sensitive(edid_info_button, can_toggle_edid_info());
 	}
 	else if (current_main_component == 1) {
 		gtk_widget_hide(monitor_manager);
 		gtk_widget_show(profile_manager);
 		gtk_widget_set_sensitive(refresh_controls_button, FALSE);
 		gtk_widget_set_sensitive(profile_manager_button, FALSE);
-		gtk_widget_set_sensitive(edid_info_button, FALSE);
+		if (edid_info_button)
+			gtk_widget_set_sensitive(edid_info_button, FALSE);
 	}
 }
 

--- a/src/gddccontrol/stack.c
+++ b/src/gddccontrol/stack.c
@@ -104,6 +104,7 @@ static void reset_edid_info_button(void)
 
 	g_signal_handlers_disconnect_matched(G_OBJECT(edid_info_button), G_SIGNAL_MATCH_FUNC,
 	                                     0, 0, NULL, G_CALLBACK(toggle_edid_info), NULL);
+	g_object_set_data(G_OBJECT(edid_info_button), "ddc_edid_info_available", GINT_TO_POINTER(FALSE));
 	set_edid_info_button_label(FALSE);
 	gtk_widget_set_sensitive(edid_info_button, FALSE);
 }
@@ -1006,6 +1007,7 @@ void create_monitor_manager(struct monitorlist* monitor)
 	GtkWidget *edid_info = create_edid_info(monitor);
 	reset_edid_info_button();
 	g_signal_connect(G_OBJECT(edid_info_button), "clicked", G_CALLBACK(toggle_edid_info), edid_info);
+	g_object_set_data(G_OBJECT(edid_info_button), "ddc_edid_info_available", GINT_TO_POINTER(TRUE));
 	gtk_widget_set_sensitive(edid_info_button, TRUE);
 	gtk_grid_attach(GTK_GRID(grid), edid_info, 0, 0, 3, 1);
 	gtk_widget_hide(edid_info);

--- a/src/gddccontrol/stack.c
+++ b/src/gddccontrol/stack.c
@@ -50,6 +50,7 @@ enum
 // Protos
 ////////////////////
 static void change_control_value(GtkWidget *widget, gpointer nval);
+static void toggle_edid_info(GtkButton *button, gpointer data);
 
 // Globals
 ////////////////////
@@ -82,6 +83,38 @@ static gboolean is_control_updating(GtkWidget *widget)
 static void set_control_updating(GtkWidget *widget, gboolean updating)
 {
 	g_object_set_data(G_OBJECT(widget), "ddc_updating", GINT_TO_POINTER(updating));
+}
+
+static void set_edid_info_button_label(gboolean visible)
+{
+	GtkWidget *label = (GtkWidget*)g_object_get_data(G_OBJECT(edid_info_button), "button_label");
+
+	if (label) {
+		gtk_label_set_text(GTK_LABEL(label), visible ? _("Hide EDID information") : _("EDID information"));
+	}
+	gtk_widget_set_tooltip_text(edid_info_button,
+	                            visible ? _("Hide EDID information for the current monitor")
+	                            : _("Show EDID information for the current monitor"));
+}
+
+static void reset_edid_info_button(void)
+{
+	if (!edid_info_button)
+		return;
+
+	g_signal_handlers_disconnect_matched(G_OBJECT(edid_info_button), G_SIGNAL_MATCH_FUNC,
+	                                     0, 0, NULL, G_CALLBACK(toggle_edid_info), NULL);
+	set_edid_info_button_label(FALSE);
+	gtk_widget_set_sensitive(edid_info_button, FALSE);
+}
+
+static void toggle_edid_info(GtkButton *button, gpointer data)
+{
+	GtkWidget *edid_info = GTK_WIDGET(data);
+	gboolean visible = !gtk_widget_get_visible(edid_info);
+
+	gtk_widget_set_visible(edid_info, visible);
+	set_edid_info_button_label(visible);
 }
 
 static void attach_info_row(GtkWidget *grid, int row, const gchar *name, const gchar *value)
@@ -150,7 +183,6 @@ static GtkWidget *create_edid_info(const struct monitorlist *monitor)
 	gtk_container_add(GTK_CONTAINER(frame), grid);
 	gtk_widget_set_hexpand(frame, TRUE);
 	gtk_widget_show(grid);
-	gtk_widget_show(frame);
 
 	g_free(serial_number);
 	g_free(manufactured);
@@ -972,7 +1004,11 @@ void create_monitor_manager(struct monitorlist* monitor)
 	gtk_grid_set_row_spacing(GTK_GRID(grid), 6);
 
 	GtkWidget *edid_info = create_edid_info(monitor);
+	reset_edid_info_button();
+	g_signal_connect(G_OBJECT(edid_info_button), "clicked", G_CALLBACK(toggle_edid_info), edid_info);
+	gtk_widget_set_sensitive(edid_info_button, TRUE);
 	gtk_grid_attach(GTK_GRID(grid), edid_info, 0, 0, 3, 1);
+	gtk_widget_hide(edid_info);
 
 	gtk_widget_show (tree);
 	gtk_grid_attach(GTK_GRID(grid), tree, 0, 1, 1, 1);
@@ -1045,6 +1081,8 @@ void create_monitor_manager(struct monitorlist* monitor)
 	
 void delete_monitor_manager()
 {
+	reset_edid_info_button();
+
 	if (mon) {
 		int needs_free = (mon->__vtable == NULL);
 		if (modified && needs_free)

--- a/src/gddccontrol/stack.c
+++ b/src/gddccontrol/stack.c
@@ -84,6 +84,82 @@ static void set_control_updating(GtkWidget *widget, gboolean updating)
 	g_object_set_data(G_OBJECT(widget), "ddc_updating", GINT_TO_POINTER(updating));
 }
 
+static void attach_info_row(GtkWidget *grid, int row, const gchar *name, const gchar *value)
+{
+	GtkWidget *name_label = gtk_label_new(name);
+	GtkWidget *value_label = gtk_label_new(value && value[0] ? value : _("Unknown"));
+
+	gtk_widget_set_halign(name_label, GTK_ALIGN_START);
+	gtk_widget_set_valign(name_label, GTK_ALIGN_START);
+	gtk_widget_set_halign(value_label, GTK_ALIGN_START);
+	gtk_widget_set_valign(value_label, GTK_ALIGN_START);
+	gtk_label_set_selectable(GTK_LABEL(value_label), TRUE);
+	gtk_label_set_line_wrap(GTK_LABEL(value_label), TRUE);
+
+	gtk_grid_attach(GTK_GRID(grid), name_label, 0, row, 1, 1);
+	gtk_grid_attach(GTK_GRID(grid), value_label, 1, row, 1, 1);
+	gtk_widget_show(name_label);
+	gtk_widget_show(value_label);
+}
+
+static GtkWidget *create_edid_info(const struct monitorlist *monitor)
+{
+	GtkWidget *frame = gtk_frame_new(_("EDID information"));
+	GtkWidget *grid = gtk_grid_new();
+	const char *profile_name = mon->db ? (const char *)mon->db->name : NULL;
+	const struct edid_info *edid = &mon->edid_info;
+	gboolean digital = mon->digital || (monitor && monitor->digital);
+	gchar *serial_number = NULL;
+	gchar *manufactured = NULL;
+	gchar *edid_version = NULL;
+	gchar *max_size = NULL;
+	int row = 0;
+
+	gtk_grid_set_row_spacing(GTK_GRID(grid), 3);
+	gtk_grid_set_column_spacing(GTK_GRID(grid), 12);
+	gtk_container_set_border_width(GTK_CONTAINER(grid), 6);
+
+	if (edid->monitor_name[0])
+		attach_info_row(grid, row++, _("Monitor name:"), edid->monitor_name);
+	attach_info_row(grid, row++, _("Plug and Play ID:"), mon->pnpid);
+	attach_info_row(grid, row++, _("Monitor profile:"), profile_name);
+	attach_info_row(grid, row++, _("Input type:"), digital ? _("Digital") : _("Analog"));
+	if (edid->serial_ascii[0])
+		attach_info_row(grid, row++, _("Serial text:"), edid->serial_ascii);
+	if (edid->serial_number > 0) {
+		serial_number = g_strdup_printf("%u", edid->serial_number);
+		attach_info_row(grid, row++, _("Serial number:"), serial_number);
+	}
+	if (edid->manufacture_year > 0) {
+		if (edid->manufacture_week > 0)
+			manufactured = g_strdup_printf(_("Week %d, %d"), edid->manufacture_week, edid->manufacture_year);
+		else
+			manufactured = g_strdup_printf("%d", edid->manufacture_year);
+		attach_info_row(grid, row++, _("Manufactured:"), manufactured);
+	}
+	if (edid->version > 0) {
+		edid_version = g_strdup_printf("%d.%d", edid->version, edid->revision);
+		attach_info_row(grid, row++, _("EDID version:"), edid_version);
+	}
+	if (edid->max_width_cm > 0 || edid->max_height_cm > 0) {
+		max_size = g_strdup_printf(_("%d x %d cm"), edid->max_width_cm, edid->max_height_cm);
+		attach_info_row(grid, row++, _("Maximum size:"), max_size);
+	}
+	attach_info_row(grid, row++, _("Device:"), monitor ? monitor->filename : NULL);
+
+	gtk_container_add(GTK_CONTAINER(frame), grid);
+	gtk_widget_set_hexpand(frame, TRUE);
+	gtk_widget_show(grid);
+	gtk_widget_show(frame);
+
+	g_free(serial_number);
+	g_free(manufactured);
+	g_free(edid_version);
+	g_free(max_size);
+
+	return frame;
+}
+
 static guint digits_for_step(double step)
 {
 	guint digits = 0;
@@ -893,8 +969,13 @@ void create_monitor_manager(struct monitorlist* monitor)
 	GtkWidget *tree = createTreeAndPages(stack);
 	
 	GtkWidget* grid = gtk_grid_new();
+	gtk_grid_set_row_spacing(GTK_GRID(grid), 6);
+
+	GtkWidget *edid_info = create_edid_info(monitor);
+	gtk_grid_attach(GTK_GRID(grid), edid_info, 0, 0, 3, 1);
+
 	gtk_widget_show (tree);
-	gtk_grid_attach(GTK_GRID(grid), tree, 0, 0, 1, 1);
+	gtk_grid_attach(GTK_GRID(grid), tree, 0, 1, 1, 1);
 	gtk_widget_set_vexpand(tree, TRUE);
 	gtk_widget_set_margin_top(tree, 3);
 	gtk_widget_set_margin_bottom(tree, 0);
@@ -903,10 +984,10 @@ void create_monitor_manager(struct monitorlist* monitor)
 	gtk_widget_show (stack);
 	
 	GtkWidget* separator = gtk_separator_new(GTK_ORIENTATION_VERTICAL);
-	gtk_grid_attach(GTK_GRID(grid), separator, 1, 0, 1, 1);
+	gtk_grid_attach(GTK_GRID(grid), separator, 1, 1, 1, 1);
 	gtk_widget_show(separator);
 	
-	gtk_grid_attach(GTK_GRID(grid), stack, 2, 0, 1, 1);
+	gtk_grid_attach(GTK_GRID(grid), stack, 2, 1, 1, 1);
 	gtk_widget_set_hexpand(stack, TRUE);
 	gtk_widget_set_vexpand(stack, TRUE);
 	gtk_widget_set_margin_top(stack, 3);

--- a/src/lib/ddcci.c
+++ b/src/lib/ddcci.c
@@ -608,7 +608,15 @@ static void ddcci_parse_edid_descriptors(struct monitor* mon, const unsigned cha
  * Returns 0 on success, -1 on failure. */
 int ddcci_parse_edid_buf(struct monitor* mon, const unsigned char* buf, int len)
 {
-	if (!mon || !buf || len < DDCCI_EDID_MIN_PARSE_LEN)
+	if (!mon)
+		return -1;
+
+	mon->digital = 0;
+	mon->edid_len = 0;
+	memset(mon->edid, 0, sizeof(mon->edid));
+	memset(&mon->edid_info, 0, sizeof(mon->edid_info));
+
+	if (!buf || len < DDCCI_EDID_MIN_PARSE_LEN)
 		return -1;
 
 	if (buf[0] != 0 || buf[1] != 0xff || buf[2] != 0xff || buf[3] != 0xff ||
@@ -621,7 +629,6 @@ int ddcci_parse_edid_buf(struct monitor* mon, const unsigned char* buf, int len)
 	         (buf[9] & 31) + 'A' - 1, buf[11], buf[10]);
 
 	mon->digital = (buf[0x14] & 0x80);
-	memset(&mon->edid_info, 0, sizeof(mon->edid_info));
 	mon->edid_info.serial_number = (unsigned int)buf[0xc] |
 	                               ((unsigned int)buf[0xd] << 8) |
 	                               ((unsigned int)buf[0xe] << 16) |

--- a/src/lib/ddcci.c
+++ b/src/lib/ddcci.c
@@ -557,7 +557,53 @@ int ddcci_command(struct monitor* mon, unsigned char cmd)
 	return ddcci_write(mon, _buf, sizeof(_buf));
 }
 
-/* Parse an EDID buffer and fill in mon->pnpid and mon->digital.
+static void ddcci_copy_edid_text(char *dest, size_t dest_len, const unsigned char *src, size_t src_len)
+{
+	size_t len = 0;
+
+	if (!dest || dest_len == 0)
+		return;
+
+	while (len < src_len && len + 1 < dest_len && src[len] != '\n' && src[len] != '\r') {
+		dest[len] = (src[len] >= ' ' && src[len] < 127) ? (char)src[len] : ' ';
+		len++;
+	}
+
+	while (len > 0 && dest[len - 1] == ' ')
+		len--;
+
+	dest[len] = 0;
+}
+
+static void ddcci_parse_edid_descriptors(struct monitor* mon, const unsigned char* buf, int len)
+{
+	int descriptor;
+
+	if (len < DDCCI_EDID_BLOCK_LEN)
+		return;
+
+	for (descriptor = 0; descriptor < 4; descriptor++) {
+		const unsigned char *desc = buf + 0x36 + descriptor * 18;
+
+		if (desc[0] != 0 || desc[1] != 0 || desc[2] != 0 || desc[4] != 0)
+			continue;
+
+		switch (desc[3]) {
+		case 0xfc:
+			ddcci_copy_edid_text(mon->edid_info.monitor_name, sizeof(mon->edid_info.monitor_name),
+			                     desc + 5, 13);
+			break;
+		case 0xff:
+			ddcci_copy_edid_text(mon->edid_info.serial_ascii, sizeof(mon->edid_info.serial_ascii),
+			                     desc + 5, 13);
+			break;
+		default:
+			break;
+		}
+	}
+}
+
+/* Parse an EDID buffer and fill in mon->pnpid, mon->digital, mon->edid, and mon->edid_info.
  * Requires at least DDCCI_EDID_MIN_PARSE_LEN bytes and a valid EDID header.
  * Returns 0 on success, -1 on failure. */
 int ddcci_parse_edid_buf(struct monitor* mon, const unsigned char* buf, int len)
@@ -574,26 +620,35 @@ int ddcci_parse_edid_buf(struct monitor* mon, const unsigned char* buf, int len)
 	         ((buf[8] & 3) << 3) + (buf[9] >> 5) + 'A' - 1,
 	         (buf[9] & 31) + 'A' - 1, buf[11], buf[10]);
 
-	if (!mon->probing && verbosity) {
-		unsigned int sn = (unsigned int)buf[0xc] |
-		                  ((unsigned int)buf[0xd] << 8) |
-		                  ((unsigned int)buf[0xe] << 16) |
-		                  ((unsigned int)buf[0xf] << 24);
-		printf(_("Serial number: %u\n"), sn);
-		int week = buf[0x10];
-		int year = buf[0x11] + 1990;
-		printf(_("Manufactured: Week %d, %d\n"), week, year);
-		int ver = buf[0x12];
-		int rev = buf[0x13];
-		printf(_("EDID version: %d.%d\n"), ver, rev);
-		int maxwidth = buf[0x15];
-		int maxheight = buf[0x16];
-		printf(_("Maximum size: %d x %d (cm)\n"), maxwidth, maxheight);
-
-		/* Parse more infos... */
-	}
-
 	mon->digital = (buf[0x14] & 0x80);
+	memset(&mon->edid_info, 0, sizeof(mon->edid_info));
+	mon->edid_info.serial_number = (unsigned int)buf[0xc] |
+	                               ((unsigned int)buf[0xd] << 8) |
+	                               ((unsigned int)buf[0xe] << 16) |
+	                               ((unsigned int)buf[0xf] << 24);
+	mon->edid_info.manufacture_week = buf[0x10];
+	mon->edid_info.manufacture_year = buf[0x11] + 1990;
+	mon->edid_info.version = buf[0x12];
+	mon->edid_info.revision = buf[0x13];
+	mon->edid_info.max_width_cm = buf[0x15];
+	mon->edid_info.max_height_cm = buf[0x16];
+	ddcci_parse_edid_descriptors(mon, buf, len);
+
+	mon->edid_len = len >= DDCCI_EDID_BLOCK_LEN ? DDCCI_EDID_BLOCK_LEN : len;
+	memcpy(mon->edid, buf, mon->edid_len);
+
+	if (!mon->probing && verbosity) {
+		printf(_("Serial number: %u\n"), mon->edid_info.serial_number);
+		printf(_("Manufactured: Week %d, %d\n"),
+		       mon->edid_info.manufacture_week, mon->edid_info.manufacture_year);
+		printf(_("EDID version: %d.%d\n"), mon->edid_info.version, mon->edid_info.revision);
+		printf(_("Maximum size: %d x %d (cm)\n"),
+		       mon->edid_info.max_width_cm, mon->edid_info.max_height_cm);
+		if (mon->edid_info.monitor_name[0])
+			printf(_("Monitor name: %s\n"), mon->edid_info.monitor_name);
+		if (mon->edid_info.serial_ascii[0])
+			printf(_("Serial text: %s\n"), mon->edid_info.serial_ascii);
+	}
 
 	return 0;
 }

--- a/src/lib/ddcci.h
+++ b/src/lib/ddcci.h
@@ -54,6 +54,25 @@ typedef struct caps Caps;
 
 #include "monitor_db.h"
 
+enum {
+	DDCCI_EDID_BLOCK_LEN = 128,
+	DDCCI_EDID_TEXT_LEN = 14,
+	DDCCI_EDID_MIN_PARSE_LEN = 0x17
+};
+
+struct edid_info {
+	unsigned int serial_number;
+	int manufacture_week;
+	int manufacture_year;
+	int version;
+	int revision;
+	int max_width_cm;
+	int max_height_cm;
+	char monitor_name[DDCCI_EDID_TEXT_LEN];
+	char serial_ascii[DDCCI_EDID_TEXT_LEN];
+};
+typedef struct edid_info EdidInfo;
+
 struct monitor {
 	const struct monitor_vtable *__vtable;
 
@@ -61,6 +80,9 @@ struct monitor {
 	unsigned int addr;
 	char pnpid[8];
 	unsigned char digital; /* 0x80 - digital, 0x00 - analog */
+	unsigned char edid[DDCCI_EDID_BLOCK_LEN];
+	int edid_len;
+	struct edid_info edid_info;
 	struct timeval last;
 	struct monitor_db* db;
 	struct caps caps;
@@ -111,11 +133,7 @@ int ddcci_writectrl(struct monitor* mon, unsigned char ctrl, unsigned short valu
 int ddcci_readctrl(struct monitor* mon, unsigned char ctrl, 
 	unsigned short *value, unsigned short *maximum);
 
-enum {
-	DDCCI_EDID_MIN_PARSE_LEN = 0x17
-};
-
-/* Parse an EDID buffer into mon->pnpid and mon->digital (0x80 for digital, 0x00 for analog).
+/* Parse an EDID buffer into mon->pnpid, mon->digital, mon->edid, and mon->edid_info.
  * The buffer must be at least DDCCI_EDID_MIN_PARSE_LEN bytes and contain a valid EDID header.
  * Returns 0 on success, -1 on failure. */
 int ddcci_parse_edid_buf(struct monitor* mon, const unsigned char* buf, int len);

--- a/src/lib/tests/test_edid.c
+++ b/src/lib/tests/test_edid.c
@@ -39,6 +39,19 @@ static void make_edid(unsigned char buf[128], unsigned char b8, unsigned char b9
 	buf[0x14] = vid_input;
 }
 
+static void set_descriptor_text(unsigned char buf[128], int descriptor, unsigned char type, const char *text)
+{
+	unsigned char *desc = buf + 0x36 + descriptor * 18;
+	size_t i;
+
+	memset(desc, 0, 18);
+	desc[3] = type;
+	for (i = 0; i < 13 && text[i] != 0; i++)
+		desc[5 + i] = (unsigned char)text[i];
+	if (i < 13)
+		desc[5 + i] = '\n';
+}
+
 static struct monitor make_mon(void)
 {
 	struct monitor mon;
@@ -226,6 +239,41 @@ static void test_digital_flag_ignores_lower_bits(void)
 	CHECK(mon.digital == 0x80);
 }
 
+/* ---- extended EDID fields ----------------------------------------------- */
+
+static void test_extended_edid_fields(void)
+{
+	unsigned char buf[128];
+	struct monitor mon = make_mon();
+
+	make_edid(buf, 0x4c, 0x2d, 0x34, 0x12, 0x80);
+	buf[0x0c] = 0x78;
+	buf[0x0d] = 0x56;
+	buf[0x0e] = 0x34;
+	buf[0x0f] = 0x12;
+	buf[0x10] = 22;
+	buf[0x11] = 30;
+	buf[0x12] = 1;
+	buf[0x13] = 4;
+	buf[0x15] = 60;
+	buf[0x16] = 34;
+	set_descriptor_text(buf, 0, 0xfc, "Panel 27");
+	set_descriptor_text(buf, 1, 0xff, "ABC123");
+
+	CHECK(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	CHECK(mon.edid_len == 128);
+	CHECK(memcmp(mon.edid, buf, 128) == 0);
+	CHECK(mon.edid_info.serial_number == 0x12345678);
+	CHECK(mon.edid_info.manufacture_week == 22);
+	CHECK(mon.edid_info.manufacture_year == 2020);
+	CHECK(mon.edid_info.version == 1);
+	CHECK(mon.edid_info.revision == 4);
+	CHECK(mon.edid_info.max_width_cm == 60);
+	CHECK(mon.edid_info.max_height_cm == 34);
+	CHECK(strcmp(mon.edid_info.monitor_name, "Panel 27") == 0);
+	CHECK(strcmp(mon.edid_info.serial_ascii, "ABC123") == 0);
+}
+
 /* ---- idempotence / repeated calls --------------------------------------- */
 
 static void test_successive_calls_overwrite_fields(void)
@@ -243,6 +291,8 @@ static void test_successive_calls_overwrite_fields(void)
 	CHECK(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
 	CHECK(mon.digital == 0x00);
 	CHECK(strcmp(mon.pnpid, "DELCDAB") == 0);
+	CHECK(mon.edid_info.monitor_name[0] == 0);
+	CHECK(mon.edid_info.serial_ascii[0] == 0);
 }
 
 int main(void)
@@ -264,6 +314,7 @@ int main(void)
 	test_digital_flag_set_when_bit7_high();
 	test_digital_flag_clear_when_bit7_low();
 	test_digital_flag_ignores_lower_bits();
+	test_extended_edid_fields();
 	test_successive_calls_overwrite_fields();
 	return failures ? 1 : 0;
 }

--- a/src/lib/tests/test_edid.c
+++ b/src/lib/tests/test_edid.c
@@ -295,6 +295,26 @@ static void test_successive_calls_overwrite_fields(void)
 	CHECK(mon.edid_info.serial_ascii[0] == 0);
 }
 
+static void test_invalid_call_clears_edid_fields(void)
+{
+	unsigned char buf[128];
+	struct monitor mon = make_mon();
+
+	make_edid(buf, 0x4c, 0x2d, 0x34, 0x12, 0x80);
+	set_descriptor_text(buf, 0, 0xfc, "Panel 27");
+	CHECK(ddcci_parse_edid_buf(&mon, buf, 128) == 0);
+	CHECK(mon.digital == 0x80);
+	CHECK(mon.edid_len == 128);
+	CHECK(mon.edid_info.monitor_name[0] != 0);
+
+	buf[0] = 0x01;
+	CHECK(ddcci_parse_edid_buf(&mon, buf, 128) == -1);
+	CHECK(mon.digital == 0x00);
+	CHECK(mon.edid_len == 0);
+	CHECK(mon.edid_info.monitor_name[0] == 0);
+	CHECK(mon.edid_info.serial_ascii[0] == 0);
+}
+
 int main(void)
 {
 	test_valid_header_returns_zero();
@@ -316,5 +336,6 @@ int main(void)
 	test_digital_flag_ignores_lower_bits();
 	test_extended_edid_fields();
 	test_successive_calls_overwrite_fields();
+	test_invalid_call_clears_edid_fields();
 	return failures ? 1 : 0;
 }


### PR DESCRIPTION
## Summary
- parse and store additional EDID fields, including monitor name, serial text, serial number, manufacture date, EDID version, physical size, and raw EDID bytes
- keep the existing `OpenMonitor` D-Bus response stable and expose raw EDID through a separate `GetEdid` method
- show the extended EDID details in gddccontrol from a toolbar toggle and remove the completed TODO item

## Testing
- `make -j$(nproc)`
- `make check`
- `./scripts/format_code.sh`
- `./scripts/check_git_clean_after_build.sh`