### PR TITLE
style(ddccontrol): stabilize version banner formatting

### DIFF
--- a/.github/workflows/conventional-pr-title.yml
+++ b/.github/workflows/conventional-pr-title.yml
@@ -19,6 +19,7 @@ jobs:
             feat
             fix
             docs
+            style
             chore
             refactor
             perf

--- a/src/ddccontrol/main.c
+++ b/src/ddccontrol/main.c
@@ -304,14 +304,13 @@ int main(int argc, char **argv)
 	textdomain(PACKAGE);
 #endif
 
-	fprintf(stdout,
-	        _("ddccontrol version %s\n"
-	          "Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)\n"
-	          "Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)\n"
-	          "Copyright 2004-2026 DDCcontrol authors and "
-	          "contributors (see AUTHORS and CONTRIBUTORS)\n"
-	          "This program comes with ABSOLUTELY NO WARRANTY.\n"
-	          "You may redistribute copies of this program under the terms of the GNU General Public License.\n\n"), VERSION);
+	fprintf(stdout, _("ddccontrol version %s\n"
+	                  "Copyright 2004-2005 Oleg I. Vdovikin (oleg@cs.msu.su)\n"
+	                  "Copyright 2004-2006 Nicolas Boichat (nicolas@boichat.ch)\n"
+	                  "Copyright 2004-2026 DDCcontrol authors and "
+	                  "contributors (see AUTHORS and CONTRIBUTORS)\n"
+	                  "This program comes with ABSOLUTELY NO WARRANTY.\n"
+	                  "You may redistribute copies of this program under the terms of the GNU General Public License.\n\n"), VERSION);
 
 	while ((i = getopt(argc, argv, "hdr:w:W:t:csfvpb:i:l:S")) >= 0) {
 		switch (i) {


### PR DESCRIPTION
## Summary
- keep the version banner `fprintf` in a form that `astyle` leaves unchanged
- preserve the existing gettext `_()` wrapping and output text

## Verification
- `./scripts/format_code.sh`
- `xgettext --language=C --keyword=_ --output=- src/ddccontrol/main.c | rg -n -A8 -B2 "ddccontrol version"`