### PR TITLE
chore: upload release source artifacts

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,8 +17,67 @@ concurrency:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
+
+  release-artifacts:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            astyle \
+            autoconf \
+            build-essential \
+            cargo \
+            clang \
+            dh-autoreconf \
+            intltool \
+            libgtk-3-dev \
+            libpci-dev \
+            libxml2-dev \
+            pkg-config \
+            rustc \
+            xsltproc \
+            tidy \
+            docbook-xml \
+            docbook-xsl \
+            xml-core
+
+      - name: Build source distribution
+        run: |
+          set -euo pipefail
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          ./autogen.sh
+          ./configure
+          make -j"$(nproc)"
+          make distcheck
+          make dist-bzip2
+          mkdir -p "$RUNNER_TEMP/release-artifacts"
+          mv ddccontrol-*.tar.bz2 "$RUNNER_TEMP/release-artifacts/"
+          rm -f ddccontrol-*.tar.gz
+          ./scripts/format_code.sh
+          find . -name "*.orig" -exec rm -v {} \;
+          ./scripts/check_git_clean_after_build.sh
+
+      - name: Upload source distribution
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.release-please.outputs.tag_name }}
+          files: ${{ runner.temp }}/release-artifacts/ddccontrol-*.tar.bz2

--- a/CheckList
+++ b/CheckList
@@ -39,24 +39,15 @@ Automated by Release Please
 - Create the release commit.
 - Create the release tag.
 - Create the GitHub release with generated release notes.
+- Build and test the source distribution archive.
+- Upload `ddccontrol-<version>.tar.bz2` to the GitHub release.
 
 Release artifacts
 -----------------
 
-Until this is automated by a GitHub Actions release-artifact workflow:
-
-- Check out the release tag.
-- Build and test the distribution archive:
-  - `./autogen.sh`
-  - `./configure --enable-doc`
-  - `make clean all`
-  - `make distcheck`
-  - `make dist-bzip2`
-- Upload `ddccontrol-<version>.tar.bz2` to the GitHub release.
-- Verify the uploaded archive by unpacking it in a clean directory:
-  - `./configure`
-  - `make`
-  - `make install DESTDIR="$(mktemp -d)"`
+- Verify that the GitHub release contains `ddccontrol-<version>.tar.bz2`.
+- If the artifact upload failed, rerun the Release Please workflow or build and
+  upload the archive manually from the release tag.
 
 Documentation and website
 -------------------------


### PR DESCRIPTION
## Summary
- add a Release Please follow-up job that builds `make distcheck`/`make dist-bzip2` when a release is created
- upload `ddccontrol-*.tar.bz2` to the generated GitHub release
- update `CheckList` to mark source artifact upload as automated

## Verification
- `python3` YAML parse check for `.github/workflows/release-please.yml`
- `git diff --check`

Notes:
- Did not run the full release build locally; it is encoded in the new release-only workflow job.