### PR TITLE
chore: build docs in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
               git config --global --add safe.directory /tmp/ddccontrol
               git clean -fdX
               ./autogen.sh
-              ./configure CFLAGS="$CFLAGS"
+              ./configure --enable-doc CFLAGS="$CFLAGS"
               make -j$(nproc)
               make -C src/lib check
               ./scripts/format_code.sh

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ target/
 /configure
 /test-driver
 /doc/html/
+/doc/html.old/
 /doc/main.xml
 /depcomp
 /install-sh

--- a/CheckList
+++ b/CheckList
@@ -13,11 +13,12 @@ Pre-release checks
   - run `make update-po` in `po/`
   - review updated `.po` files, especially `po/fr.po`
   - commit the translation updates before the release PR
-- If documentation changed, make sure the generated docs still build:
+- If documentation changed, make sure the generated PDF still builds locally:
   - `./autogen.sh`
   - `./configure --enable-doc`
-  - `make -C doc all pdf`
-- Let normal CI pass on `master`.
+  - `make -C doc pdf`
+- Let normal CI pass on `master`; CI builds the generated HTML docs with
+  `--enable-doc`.
 
 Release Please PR
 -----------------
@@ -27,8 +28,6 @@ Release Please PR
 - Confirm the release version in `configure.ac`.
 - Confirm any other release-versioned files listed in
   `.github/release-please-config.json` were updated.
-- If `doc/main.xml` is still versioned, make sure it matches the release
-  version generated from `doc/main.xml.in`.
 - Merge the Release Please PR after CI passes.
 
 Automated by Release Please


### PR DESCRIPTION
## Summary
- enable `--enable-doc` in the normal CI build so generated HTML docs are built automatically
- ignore `doc/html.old/`, which the doc build can leave behind
- update `CheckList` so only PDF generation remains a local documentation check

## Verification
- `python3` YAML parse check for `.github/workflows/ci.yml`
- `git diff --check`
- `./autogen.sh && ./configure --enable-doc && make -C doc all`
- `./scripts/format_code.sh`
- `./scripts/check_git_clean_after_build.sh`