### PR TITLE
fix: improve doc build dependency handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ target/
 /test-driver
 /doc/html/
 /doc/html.old/
+/doc/ddccontrol.fo
+/doc/ddccontrol.pdf
 /doc/main.xml
 /depcomp
 /install-sh

--- a/configure.ac
+++ b/configure.ac
@@ -30,7 +30,7 @@ AC_CHECK_HEADERS([stdio.h unistd.h sys/time.h stdlib.h errno.h unistd.h string.h
 
 check_xsltproc=yes
 AC_ARG_ENABLE(xsltproc-check,
-  [AS_HELP_STRING([--disable-xsltproc-check],[omit check to see if xsltproc works (enabled)])],
+  [AS_HELP_STRING([--disable-xsltproc-check],[omit runtime check that xsltproc can process DocBook (enabled)])],
   [if test x$enableval = xno; then
     check_xsltproc=no
   fi])
@@ -136,7 +136,7 @@ PKG_CHECK_MODULES([GIO_UNIX], [gio-unix-2.0 >= 2.36.0],[CFLAGS="${GIO_UNIX_CFLAG
 # Doc check
 support_doc=no
 AC_ARG_ENABLE(doc,
-  AS_HELP_STRING([--enable-doc],[enable build of the documentation (disabled)]),
+  AS_HELP_STRING([--enable-doc],[enable documentation build; requires DocBook XML catalog and xsltproc (disabled)]),
   [if test x$enableval = xyes; then
     support_doc=yes
   fi])
@@ -145,6 +145,8 @@ AM_CONDITIONAL(BUILD_DOC, test x$support_doc = xyes)
 
 DOC=
 if test x$support_doc = xyes; then
+   DOC=doc
+
    # Docbook tests
    # Based on http://www.movement.uklinux.net/docs/docbook-autotools/configure.html
    # Copyright � 2003 John Levon
@@ -161,15 +163,11 @@ if test x$support_doc = xyes; then
          AC_MSG_ERROR([xsltproc not found, install it or disable doc building])
       fi
 
-      AC_PATH_PROG(SSH,ssh,ssh)
-      AC_PATH_PROG(SCP,scp,scp)
+      AC_PATH_PROG(SSH,ssh,no)
+      AC_PATH_PROG(SCP,scp,no)
       AC_PATH_PROG(ASPELL,aspell,no)
       AC_PATH_PROG(FOP,fop,no)
-
       AC_PATH_PROG(TIDY,tidy,no)
-      if test "x$TIDY" = "xno" ; then
-         AC_MSG_ERROR([tidy not found, install it or disable doc building])
-      fi
 
       if test x$check_xsltproc = xyes ; then
          AC_MSG_CHECKING([whether xsltproc works])
@@ -185,7 +183,6 @@ if test x$support_doc = xyes; then
 END
          if test "$?" = 0; then
             AC_MSG_RESULT(yes)
-            DOC=doc
          else
             AC_MSG_ERROR([xsltproc does not work, fix this problem or disable doc building])
          fi

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,4 +1,7 @@
 XHTML_STYLESHEET=style.xsl
+TIDY_FLAGS = -q -raw -im --output-xhtml yes --doctype transitional --drop-empty-elements no
+
+.NOTPARALLEL:
 
 dist_html_DATA = html/*
 EXTRA_DIST = main.xml gpl.xml install.xml about.xml report.xml supportedgc.xml thanks.xml techdocs.xml usage.xml style.xsl style-fo.xsl
@@ -9,7 +12,12 @@ html/*: main.xml gpl.xml install.xml about.xml report.xml supportedgc.xml thanks
 	true `mv -f html html.old`
 	$(MKDIR_P) html
 	$(XSLTPROC) $(XSLTPROC_FLAGS) -o html/ $(top_srcdir)/doc/$(XHTML_STYLESHEET) $<
-	-$(TIDY) -q -raw -im html/*.html
+	@if test "x$(TIDY)" != "xno"; then \
+		$(TIDY) $(TIDY_FLAGS) html/*.html || \
+			echo "tidy failed; leaving generated HTML unchanged"; \
+	else \
+		echo "tidy not found; skipping HTML cleanup"; \
+	fi
 
 publish: all
 	rm -rf $(abs_top_builddir)/docs/doc/latest
@@ -23,6 +31,10 @@ publish-release: all pdf
 	cp ddccontrol.pdf $(abs_top_builddir)/docs/doc/ddccontrol-$(VERSION).pdf
 
 spell:
+	@if test "x$(ASPELL)" = "xno"; then \
+		echo "aspell not found; cannot run spell target" >&2; \
+		exit 1; \
+	fi
 	$(ASPELL) --mode=sgml check main.xml
 
 clean-local:
@@ -32,12 +44,17 @@ MOSTLYCLEANFILES = ddccontrol.fo ddccontrol.pdf
 
 ddccontrol.fo: main.xml gpl.xml style-fo.xsl
 	$(XSLTPROC)  \
+		$(XSLTPROC_FLAGS) \
 		--output  ddccontrol.fo  \
 		--stringparam  paper.type  A4 \
 		style-fo.xsl  \
 		$<
 
 ddccontrol.pdf: ddccontrol.fo
+	@if test "x$(FOP)" = "xno"; then \
+		echo "fop not found; cannot build PDF documentation" >&2; \
+		exit 1; \
+	fi
 	$(FOP)  -fo  ddccontrol.fo  -pdf  ddccontrol.pdf
 
 pdf: ddccontrol.pdf

--- a/doc/style-fo.xsl
+++ b/doc/style-fo.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet  
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-<xsl:import href="https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl"/>
+<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/fo/docbook.xsl"/>
 
 <xsl:template match="sgmltag[@class='attvalue']">
   <xsl:call-template name="inline.monoseq">


### PR DESCRIPTION
## Summary
- keep `doc` in the build when `--enable-doc --disable-xsltproc-check` is used
- make required DocBook/xsltproc dependencies fail clearly while keeping `tidy`, `aspell`, `fop`, `ssh`, and `scp` optional
- make tidy validate generated XHTML successfully and make PDF generation resolve DocBook FO stylesheets through the local XML catalog

## Verification
- `./autogen.sh`
- `./configure --enable-doc --disable-xsltproc-check --disable-gnome`
- `make -j$(nproc)`
- `make -C doc`
- direct `tidy` on `doc/html/*.html`: `tidy_exit=0`
- `make -C doc pdf`
- simulated missing optional tools: `TIDY=no ASPELL=no FOP=no SSH=no SCP=no`
- simulated missing required `xsltproc` fails clearly
- `./scripts/format_code.sh`
- `./scripts/check_git_clean_after_build.sh`

Fixes #289