### PR TITLE
ci: prebuild Debian ports CI image

### DIFF
--- a/.github/workflows/debian-ports-image.yml
+++ b/.github/workflows/debian-ports-image.yml
@@ -1,0 +1,43 @@
+name: Debian Ports CI Image
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "43 3 * * 0"
+  push:
+    branches: [master]
+    paths:
+      - ".github/ci/Dockerfile"
+      - ".github/workflows/debian-ports-image.yml"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Set up QEMU
+        run: docker run --privileged --rm tonistiigi/binfmt:qemu-v10.2.1 --install ppc64le,riscv64,s390x
+
+      - name: Set up Docker Buildx
+        run: |
+          docker buildx create --use
+          docker buildx inspect --bootstrap
+
+      - name: Build and push image
+        run: |
+          docker buildx build \
+            --platform linux/ppc64le,linux/riscv64,linux/s390x \
+            --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
+            --label "org.opencontainers.image.revision=${{ github.sha }}" \
+            --tag ghcr.io/ddccontrol/ddccontrol-debian-ports-ci:latest \
+            --tag ghcr.io/ddccontrol/ddccontrol-debian-ports-ci:${{ github.sha }} \
+            --push \
+            .github/ci

--- a/.github/workflows/debian-ports.yml
+++ b/.github/workflows/debian-ports.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 concurrency:
   group: debian-ports-${{ github.ref }}
@@ -42,13 +43,21 @@ jobs:
           docker buildx create --use
           docker buildx inspect --bootstrap
 
-      - name: Build CI image
+      - name: Prepare CI image
         run: |
-          docker buildx build \
-            --platform "${{ matrix.target.platform }}" \
-            --load \
-            --tag "ddccontrol-ci:${{ matrix.target.arch }}" \
-            .github/ci
+          echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin || true
+          image=ghcr.io/ddccontrol/ddccontrol-debian-ports-ci:latest
+          if docker pull --platform "${{ matrix.target.platform }}" "$image"; then
+            echo "CI_IMAGE=$image" >> "$GITHUB_ENV"
+          else
+            image=ddccontrol-debian-ports-ci:${{ matrix.target.arch }}
+            docker buildx build \
+              --platform "${{ matrix.target.platform }}" \
+              --load \
+              --tag "$image" \
+              .github/ci
+            echo "CI_IMAGE=$image" >> "$GITHUB_ENV"
+          fi
 
       - name: Build ddccontrol
         run: |
@@ -56,7 +65,7 @@ jobs:
             --platform "${{ matrix.target.platform }}" \
             -e CC=gcc \
             -v "${{ github.workspace }}:/src:ro" \
-            "ddccontrol-ci:${{ matrix.target.arch }}" \
+            "$CI_IMAGE" \
             bash -lc '
               set -e
               cp -a /src /tmp/ddccontrol


### PR DESCRIPTION
## Summary
- add a scheduled/manual CI image workflow for Debian ports architectures
- publish a prebuilt GHCR image for `linux/ppc64le`, `linux/riscv64`, and `linux/s390x`
- update the Debian Ports build workflow to pull the prebuilt image and only build locally as a fallback

## Testing
- Ran `./scripts/format_code.sh`
- Ran `git diff --check`
- Parsed both workflow YAML files with local Python/PyYAML
- Did not run the emulated Docker builds locally; the new image workflow is intended to handle dependency installation periodically on GitHub Actions