### PR TITLE
fix: repair release source distribution build

### DIFF
--- a/.github/workflows/debian-ports-image.yml
+++ b/.github/workflows/debian-ports-image.yml
@@ -1,0 +1,43 @@
+name: Debian Ports CI Image
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "43 3 * * 0"
+  push:
+    branches: [master]
+    paths:
+      - ".github/ci/Dockerfile"
+      - ".github/workflows/debian-ports-image.yml"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Set up QEMU
+        run: docker run --privileged --rm tonistiigi/binfmt:qemu-v10.2.1 --install ppc64le,riscv64,s390x
+
+      - name: Set up Docker Buildx
+        run: |
+          docker buildx create --use
+          docker buildx inspect --bootstrap
+
+      - name: Build and push image
+        run: |
+          docker buildx build \
+            --platform linux/ppc64le,linux/riscv64,linux/s390x \
+            --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
+            --label "org.opencontainers.image.revision=${{ github.sha }}" \
+            --tag ghcr.io/ddccontrol/ddccontrol-debian-ports-ci:latest \
+            --tag ghcr.io/ddccontrol/ddccontrol-debian-ports-ci:${{ github.sha }} \
+            --push \
+            .github/ci

--- a/.github/workflows/debian-ports.yml
+++ b/.github/workflows/debian-ports.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 concurrency:
   group: debian-ports-${{ github.ref }}
@@ -42,13 +43,21 @@ jobs:
           docker buildx create --use
           docker buildx inspect --bootstrap
 
-      - name: Build CI image
+      - name: Prepare CI image
         run: |
-          docker buildx build \
-            --platform "${{ matrix.target.platform }}" \
-            --load \
-            --tag "ddccontrol-ci:${{ matrix.target.arch }}" \
-            .github/ci
+          echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin || true
+          image=ghcr.io/ddccontrol/ddccontrol-debian-ports-ci:latest
+          if docker pull --platform "${{ matrix.target.platform }}" "$image"; then
+            echo "CI_IMAGE=$image" >> "$GITHUB_ENV"
+          else
+            image=ddccontrol-debian-ports-ci:${{ matrix.target.arch }}
+            docker buildx build \
+              --platform "${{ matrix.target.platform }}" \
+              --load \
+              --tag "$image" \
+              .github/ci
+            echo "CI_IMAGE=$image" >> "$GITHUB_ENV"
+          fi
 
       - name: Build ddccontrol
         run: |
@@ -56,7 +65,7 @@ jobs:
             --platform "${{ matrix.target.platform }}" \
             -e CC=gcc \
             -v "${{ github.workspace }}:/src:ro" \
-            "ddccontrol-ci:${{ matrix.target.arch }}" \
+            "$CI_IMAGE" \
             bash -lc '
               set -e
               cp -a /src /tmp/ddccontrol

--- a/Makefile.am
+++ b/Makefile.am
@@ -20,5 +20,6 @@ DISTCHECK_CONFIGURE_FLAGS = --enable-doc
 
 distclean-local:
 	rm -f po/.intltool-merge-cache.lock
+	rm -rf target
 
 ACLOCAL_AMFLAGS = -I m4

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -3,10 +3,11 @@ TIDY_FLAGS = -q -raw -im --output-xhtml yes --doctype transitional --drop-empty-
 
 .NOTPARALLEL:
 
-dist_html_DATA = html/*
 EXTRA_DIST = main.xml gpl.xml install.xml about.xml report.xml supportedgc.xml thanks.xml techdocs.xml usage.xml style.xsl style-fo.xsl
 
 if BUILD_DOC
+html_DATA = html/*
+
 html/*: main.xml gpl.xml install.xml about.xml report.xml supportedgc.xml thanks.xml techdocs.xml usage.xml style.xsl
 	rm -rf html.old
 	true `mv -f html html.old`


### PR DESCRIPTION
## Summary
- stop requiring ignored generated `doc/html/*` files when building source distributions
- clean Cargo `target/` during `distclean` so `make distcheck` does not fail on Rust build artifacts

## Verification
- `./autogen.sh`
- `./configure`
- `make -j"$(nproc)"`
- `make distcheck`
- `make dist-bzip2`
- `./scripts/format_code.sh`
- `./scripts/check_git_clean_after_build.sh`

Fixes the failure seen in https://github.com/ddccontrol/ddccontrol/actions/runs/28031010230/job/82971420817.