### PR TITLE
fix: keep distcheck systemd install under prefix

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ EXTRA_DIST = config.rpath intltool-extract.in intltool-merge.in intltool-update.
 	crates/ddccontrol-db/README.md \
 	crates/ddccontrol-db/src/lib.rs
 DISTCLEANFILES = intltool-extract intltool-merge intltool-update
-DISTCHECK_CONFIGURE_FLAGS = --enable-doc
+DISTCHECK_CONFIGURE_FLAGS = --enable-doc --with-systemdsystemunitdir='$${prefix}/lib/systemd/system'
 
 distclean-local:
 	rm -f po/.intltool-merge-cache.lock

--- a/src/daemon/data/Makefile.am
+++ b/src/daemon/data/Makefile.am
@@ -8,22 +8,21 @@ dist_dbusconf_DATA = ddccontrol.DDCControl.conf
 dbusservicedir       = $(datadir)/dbus-1/system-services
 dbusservice_in_files = ddccontrol.DDCControl.service.in
 dbusservice_DATA     = $(dbusservice_in_files:.service.in=.service)
+systemdservice_in_files = ddccontrol.service.in
 
 $(dbusservice_DATA): $(dbusservice_in_files) Makefile
 	@sed -e "s|\@servicedir\@|$(pkglibexecdir)|" $< > $@
 
-EXTRA_DIST     = $(dbusservice_in_files)
+EXTRA_DIST     = $(dbusservice_in_files) $(systemdservice_in_files)
 DISTCLEANFILES = $(dbusservice_DATA)
 
 
 # systemd service file
 if HAVE_SYSTEMD
 systemdservicedir       = $(systemdsystemunitdir)
-systemdservice_in_files = ddccontrol.service.in
 systemdservice_DATA     = $(systemdservice_in_files:.service.in=.service)
 $(systemdservice_DATA): $(systemdservice_in_files) Makefile
 	@sed -e "s|\@servicedir\@|$(pkglibexecdir)|" $< > $@
-	
-EXTRA_DIST     += $(systemdservice_in_files)
+
 DISTCLEANFILES += $(systemdservice_DATA)
 endif


### PR DESCRIPTION
## Summary
- configure `make distcheck` to install systemd units under the temporary distcheck prefix
- always include `ddccontrol.service.in` in source distributions so systemd-enabled distcheck builds can generate the unit file

## Verification
- `./autogen.sh`
- `./configure`
- `make -j$(nproc)`
- `make distcheck`
- `make dist-bzip2`
- `./scripts/format_code.sh`
- `./scripts/check_git_clean_after_build.sh` (reports only pre-existing local `AGENTS.md` plus intentional source edits before commit)

Fixes the failure seen in https://github.com/ddccontrol/ddccontrol/actions/runs/28032494215/job/82976773976.