### PR TITLE
fix: handle real database compatibility cases

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,6 +14,10 @@ EXTRA_DIST = config.rpath intltool-extract.in intltool-merge.in intltool-update.
 	crates/ddccontrol-caps/src/lib.rs \
 	crates/ddccontrol-db/Cargo.toml \
 	crates/ddccontrol-db/README.md \
+	crates/ddccontrol-db/fixtures/compat-db/options.xml \
+	crates/ddccontrol-db/fixtures/compat-db/monitor/compat-common.xml \
+	crates/ddccontrol-db/fixtures/compat-db/monitor/compat-monitor.xml \
+	crates/ddccontrol-db/src/monitor_db/compatibility_tests.rs \
 	crates/ddccontrol-db/src/lib.rs
 DISTCLEANFILES = intltool-extract intltool-merge intltool-update
 DISTCHECK_CONFIGURE_FLAGS = --enable-doc --with-systemdsystemunitdir='$${prefix}/lib/systemd/system'

--- a/crates/ddccontrol-caps/src/lib.rs
+++ b/crates/ddccontrol-caps/src/lib.rs
@@ -277,6 +277,20 @@ impl<'a> Parser<'a> {
                     return Ok(());
                 }
                 Some(b'(') => return Err(self.err(ErrorKind::ValueWithoutVcpCode)),
+                Some(byte) if is_name_byte(byte) && !byte.is_ascii_hexdigit() => {
+                    let name_position = self.pos;
+                    let name = self.take_name();
+                    self.skip_spaces();
+                    if self.consume(b'(') {
+                        if name.eq_ignore_ascii_case("vcp") {
+                            self.parse_vcp(parsed)?;
+                        } else {
+                            self.skip_balanced()?;
+                        }
+                    } else {
+                        return Err(self.err_at(ErrorKind::InvalidHex, name_position));
+                    }
+                }
                 Some(_) => {
                     let code_position = self.pos;
                     let code = self.take_vcp_code(code_position)?;
@@ -585,6 +599,18 @@ mod tests {
         );
         assert_eq!(caps.vcp(0x12).unwrap().values(), None);
         assert_eq!(caps.vcp(0x14).unwrap().values(), Some([0x0a].as_slice()));
+    }
+
+    #[test]
+    fn accepts_nested_database_vcp_sections() {
+        let caps = Caps::parse("type(lcd)vcp(vcp(10 14(01 05) C8 C9))").unwrap();
+
+        assert_eq!(caps.monitor_type(), MonitorType::Lcd);
+        assert_eq!(caps.vcp_codes().collect::<Vec<_>>(), vec![0x10, 0x14, 0xc8, 0xc9]);
+        assert_eq!(
+            caps.vcp(0x14).unwrap().values(),
+            Some([0x01, 0x05].as_slice())
+        );
     }
 
     #[test]

--- a/crates/ddccontrol-db/README.md
+++ b/crates/ddccontrol-db/README.md
@@ -25,3 +25,15 @@ anything other than the documented C cleanup function.
 The Rust mirror structs are `#[repr(C)]`. Keep the Rust layout tests and the C
 `test_abi_layout` test in sync with `src/lib/ddcci.h`, `src/lib/monitor_db.h`,
 and `src/lib/monitor_db_internal.h`.
+
+## Compatibility Tests
+
+The normal test suite includes a golden monitor database fixture under
+`fixtures/compat-db`. To smoke-test a real `ddccontrol-db` checkout as well,
+set `DDCCONTROL_DB_TEST_DATADIR` to either the checkout root or the `db`
+directory that contains `options.xml` and `monitor/` before running
+`cargo test`.
+
+By default the real database test loads the first 25 monitor profiles in sorted
+order. Set `DDCCONTROL_DB_TEST_PROFILES` to a comma-separated profile list to
+select specific profiles.

--- a/crates/ddccontrol-db/fixtures/compat-db/monitor/compat-common.xml
+++ b/crates/ddccontrol-db/fixtures/compat-db/monitor/compat-common.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<monitor name="Included Compatibility Controls">
+  <controls>
+    <control id="brightness" address="0x10" delay="120"/>
+    <control id="input" address="0x60">
+      <value id="hdmi1" value="0x11"/>
+      <value id="displayport" value="0x0f"/>
+    </control>
+    <control id="factory_reset" address="0x04"/>
+  </controls>
+</monitor>

--- a/crates/ddccontrol-db/fixtures/compat-db/monitor/compat-monitor.xml
+++ b/crates/ddccontrol-db/fixtures/compat-db/monitor/compat-monitor.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<monitor name="Compatibility Fixture Monitor" init="standard">
+  <caps remove="vcp(04)"/>
+  <caps add="vcp(C8(02 1234))"/>
+  <include file="compat-common"/>
+  <controls>
+    <control id="color_preset" address="0xC8">
+      <value id="srgb" value="0x1234"/>
+      <value id="native" value="0002"/>
+    </control>
+  </controls>
+</monitor>

--- a/crates/ddccontrol-db/fixtures/compat-db/options.xml
+++ b/crates/ddccontrol-db/fixtures/compat-db/options.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<options dbversion="3" date="2026-06-26">
+  <group name="Image">
+    <subgroup name="Picture" pattern="image">
+      <control id="brightness" name="Brightness" type="value" refresh="all"/>
+      <control id="input" name="Input Source" type="list">
+        <value id="hdmi1" name="HDMI 1"/>
+        <value id="displayport" name="DisplayPort"/>
+      </control>
+      <control id="factory_reset" name="Factory Reset" type="command"/>
+    </subgroup>
+  </group>
+  <group name="Color">
+    <subgroup name="Presets" pattern="color">
+      <control id="color_preset" name="Color Preset" type="list">
+        <value id="srgb" name="sRGB"/>
+        <value id="native" name="Native"/>
+      </control>
+    </subgroup>
+  </group>
+</options>

--- a/crates/ddccontrol-db/src/lib.rs
+++ b/crates/ddccontrol-db/src/lib.rs
@@ -889,16 +889,6 @@ mod monitor_db {
         let mut values = Vec::new();
         let mut matched = vec![false; monitor_control.values.len()];
 
-        for monitor_value in monitor_control
-            .values
-            .iter()
-            .filter(|value| value.element_name == "value")
-        {
-            if monitor_value.id.is_none() {
-                return Err(DbError::new("Can't find id property.".to_string()));
-            }
-        }
-
         for option_value in &option_control.values {
             if let Some((monitor_index, monitor_value)) = monitor_control
                 .values
@@ -1402,6 +1392,9 @@ mod monitor_db {
     }
 
     #[cfg(test)]
+    mod compatibility_tests;
+
+    #[cfg(test)]
     mod tests {
         use super::*;
         use std::mem::{align_of, size_of};
@@ -1570,7 +1563,7 @@ mod monitor_db {
         }
 
         #[test]
-        fn matched_monitor_values_require_id() {
+        fn monitor_values_without_id_use_unmatched_validation() {
             let option_control = OptionControl {
                 id: "input".to_string(),
                 name: "Input".to_string(),
@@ -1594,7 +1587,8 @@ mod monitor_db {
                 child_index: 0,
             };
 
-            assert!(get_value_list(&option_control, &monitor_control, true).is_err());
+            assert!(get_value_list(&option_control, &monitor_control, false).is_err());
+            assert!(get_value_list(&option_control, &monitor_control, true).is_ok());
         }
 
         #[test]

--- a/crates/ddccontrol-db/src/monitor_db/compatibility_tests.rs
+++ b/crates/ddccontrol-db/src/monitor_db/compatibility_tests.rs
@@ -1,0 +1,300 @@
+use crate::{ddccontrol_caps_parse, free_c_vcp_entries, CCaps, CVcpEntry};
+
+use super::*;
+use libc::{c_char, c_int, c_uchar, malloc};
+use std::ffi::{CStr, CString};
+use std::mem::size_of;
+use std::path::{Path, PathBuf};
+use std::{env, fs, ptr};
+
+static TEST_DB_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[test]
+fn compatibility_fixture_matches_golden_database_tree() {
+    let _context = DbTestContext::init(&fixture_datadir());
+
+    let mut caps = OwnedCaps::from_str("(prot(monitor)type(LCD)vcp(04 10 60))");
+    let monitor = OwnedMonitor::create("compat-monitor", &mut caps, false).unwrap();
+    let snapshot = monitor.snapshot();
+
+    assert_eq!(
+        snapshot,
+        "\
+monitor name=Compatibility Fixture Monitor init=1
+group name=Image
+  subgroup name=Picture pattern=image
+    control id=brightness name=Brightness address=0x10 delay=120 type=0 refresh=1
+    control id=input name=Input Source address=0x60 delay=-1 type=2 refresh=0
+      value id=hdmi1 name=HDMI 1 value=0x11 value16=0x0011
+      value id=displayport name=DisplayPort value=0x0F value16=0x000F
+group name=Color
+  subgroup name=Presets pattern=color
+    control id=color_preset name=Color Preset address=0xC8 delay=-1 type=2 refresh=0
+      value id=srgb name=sRGB value=0x34 value16=0x1234
+      value id=native name=Native value=0x02 value16=0x0002
+"
+    );
+}
+
+#[test]
+fn real_database_checkout_profiles_load_when_configured() {
+    let Some(datadir) = env::var_os("DDCCONTROL_DB_TEST_DATADIR") else {
+        return;
+    };
+    let datadir = resolve_real_database_datadir(PathBuf::from(datadir));
+    let profiles = real_database_profiles(&datadir);
+    assert!(
+        !profiles.is_empty(),
+        "no monitor profiles found in {}",
+        datadir.join("monitor").display()
+    );
+
+    let _context = DbTestContext::init(&datadir);
+
+    for profile in profiles {
+        let mut caps = OwnedCaps::with_all_vcp_codes();
+        let monitor = OwnedMonitor::create(&profile, &mut caps, true);
+        assert!(
+            monitor.is_some(),
+            "failed to load monitor profile {profile}"
+        );
+    }
+}
+
+fn fixture_datadir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/compat-db")
+}
+
+fn resolve_real_database_datadir(path: PathBuf) -> PathBuf {
+    if is_database_datadir(&path) {
+        return path;
+    }
+
+    let db_path = path.join("db");
+    if is_database_datadir(&db_path) {
+        return db_path;
+    }
+
+    panic!(
+        "DDCCONTROL_DB_TEST_DATADIR must point to a directory containing options.xml \
+         and monitor/, or to a ddccontrol-db checkout with a db/ directory: {}",
+        path.display()
+    );
+}
+
+fn is_database_datadir(path: &Path) -> bool {
+    path.join("options.xml").is_file() && path.join("monitor").is_dir()
+}
+
+fn real_database_profiles(datadir: &Path) -> Vec<String> {
+    if let Ok(profiles) = env::var("DDCCONTROL_DB_TEST_PROFILES") {
+        return profiles
+            .split(',')
+            .map(str::trim)
+            .filter(|profile| !profile.is_empty())
+            .map(ToString::to_string)
+            .collect();
+    }
+
+    let mut profiles: Vec<_> = fs::read_dir(datadir.join("monitor"))
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let path = entry.path();
+            (path.extension().and_then(|ext| ext.to_str()) == Some("xml"))
+                .then(|| path.file_stem()?.to_str().map(ToString::to_string))?
+        })
+        .collect();
+    profiles.sort();
+    profiles.truncate(25);
+    profiles
+}
+
+fn path_to_cstring(path: &Path) -> CString {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+
+        CString::new(path.as_os_str().as_bytes()).unwrap()
+    }
+    #[cfg(not(unix))]
+    {
+        CString::new(path.to_string_lossy().as_bytes()).unwrap()
+    }
+}
+
+struct DbTestContext {
+    _guard: std::sync::MutexGuard<'static, ()>,
+}
+
+impl DbTestContext {
+    fn init(datadir: &Path) -> Self {
+        let guard = TEST_DB_LOCK.lock().unwrap();
+        let datadir = path_to_cstring(datadir);
+        assert_eq!(unsafe { ddcci_init_db(datadir.as_ptr() as *mut c_char) }, 1);
+        Self { _guard: guard }
+    }
+}
+
+impl Drop for DbTestContext {
+    fn drop(&mut self) {
+        unsafe {
+            ddcci_release_db();
+        }
+    }
+}
+
+struct OwnedCaps(CCaps);
+
+impl OwnedCaps {
+    fn empty() -> Self {
+        Self(CCaps {
+            vcp: [ptr::null_mut(); 256],
+            monitor_type: 0,
+            raw_caps: ptr::null_mut(),
+        })
+    }
+
+    fn from_str(input: &str) -> Self {
+        let mut caps = Self::empty();
+        let input = CString::new(input).unwrap();
+        assert!(unsafe { ddccontrol_caps_parse(input.as_ptr(), &mut caps.0, 1) } > 0);
+        caps
+    }
+
+    fn with_all_vcp_codes() -> Self {
+        let mut caps = Self::empty();
+        caps.0.monitor_type = 1;
+        for entry in &mut caps.0.vcp {
+            let c_entry = unsafe { malloc(size_of::<CVcpEntry>()) as *mut CVcpEntry };
+            assert!(!c_entry.is_null());
+            unsafe {
+                ptr::write(
+                    c_entry,
+                    CVcpEntry {
+                        values_len: -1,
+                        values: ptr::null_mut(),
+                    },
+                );
+            }
+            *entry = c_entry;
+        }
+        caps
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut CCaps {
+        &mut self.0
+    }
+}
+
+impl Drop for OwnedCaps {
+    fn drop(&mut self) {
+        unsafe {
+            free_c_vcp_entries(&mut self.0);
+        }
+    }
+}
+
+struct OwnedMonitor(*mut CMonitorDb);
+
+impl OwnedMonitor {
+    fn create(profile: &str, caps: &mut OwnedCaps, faulttolerance: bool) -> Option<Self> {
+        let profile = CString::new(profile).unwrap();
+        let monitor = unsafe {
+            ddcci_create_db(
+                profile.as_ptr(),
+                caps.as_mut_ptr(),
+                c_int::from(faulttolerance),
+            )
+        };
+        (!monitor.is_null()).then_some(Self(monitor))
+    }
+
+    fn snapshot(&self) -> String {
+        snapshot_monitor(self.0)
+    }
+}
+
+impl Drop for OwnedMonitor {
+    fn drop(&mut self) {
+        unsafe {
+            ddcci_free_db(self.0);
+        }
+    }
+}
+
+fn snapshot_monitor(monitor: *mut CMonitorDb) -> String {
+    let mut snapshot = String::new();
+    let monitor_ref = unsafe { &*monitor };
+    snapshot.push_str(&format!(
+        "monitor name={} init={}\n",
+        c_xml_string(monitor_ref.name),
+        monitor_ref.init
+    ));
+
+    let mut group = monitor_ref.group_list;
+    while !group.is_null() {
+        let group_ref = unsafe { &*group };
+        snapshot.push_str(&format!("group name={}\n", c_xml_string(group_ref.name)));
+
+        let mut subgroup = group_ref.subgroup_list;
+        while !subgroup.is_null() {
+            let subgroup_ref = unsafe { &*subgroup };
+            let pattern = if subgroup_ref.pattern.is_null() {
+                String::new()
+            } else {
+                c_xml_string(subgroup_ref.pattern)
+            };
+            snapshot.push_str(&format!(
+                "  subgroup name={} pattern={}\n",
+                c_xml_string(subgroup_ref.name),
+                pattern
+            ));
+
+            let mut control = subgroup_ref.control_list;
+            while !control.is_null() {
+                let control_ref = unsafe { &*control };
+                snapshot.push_str(&format!(
+                    "    control id={} name={} address=0x{:02X} delay={} type={} refresh={}\n",
+                    c_xml_string(control_ref.id),
+                    c_xml_string(control_ref.name),
+                    control_ref.address,
+                    control_ref.delay,
+                    control_ref.control_type,
+                    control_ref.refresh
+                ));
+
+                let mut value = control_ref.value_list;
+                while !value.is_null() {
+                    let value_ref = unsafe { &*value };
+                    let private = value as *mut CValueDbPrivate;
+                    let private_ref = unsafe { &*private };
+                    snapshot.push_str(&format!(
+                        "      value id={} name={} value=0x{:02X} value16=0x{:04X}\n",
+                        c_xml_string(value_ref.id),
+                        c_xml_string(value_ref.name),
+                        value_ref.value,
+                        private_ref.value16
+                    ));
+                    value = value_ref.next;
+                }
+
+                control = control_ref.next;
+            }
+
+            subgroup = subgroup_ref.next;
+        }
+
+        group = group_ref.next;
+    }
+
+    snapshot
+}
+
+fn c_xml_string(ptr: *mut c_uchar) -> String {
+    unsafe {
+        CStr::from_ptr(ptr as *const c_char)
+            .to_string_lossy()
+            .into_owned()
+    }
+}


### PR DESCRIPTION
## Summary

- add a golden monitor database fixture for the Rust database parser
- verify the C ABI database tree produced by `ddcci_init_db` and `ddcci_create_db`
- cover includes, caps add/remove patches, grouped controls, values, and 16-bit value storage
- allow the opt-in real database smoke test to accept either a `ddccontrol-db` checkout root or its `db/` directory
- match legacy database behavior for nested `vcp(vcp(...))` caps patches and missing value ids in fault-tolerant mode
- document the real database test knobs and include the new fixtures in `EXTRA_DIST`

## Validation

- `cargo test --workspace`
- `DDCCONTROL_DB_TEST_DATADIR=/home/user/git/ddccontrol/ddccontrol-db cargo test -p ddccontrol-db`
- `make -C src/lib check`
- `./scripts/format_code.sh`
- `git diff --check`
- `./scripts/check_git_clean_after_build.sh`

Note: the remaining `unsafe` in the test support is intentionally isolated in RAII wrappers and pointer snapshot helpers so the high-level tests do not manage raw FFI resources directly.