### PR TITLE
build: upload vendored release sources

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -60,7 +60,7 @@ jobs:
             docbook-xsl \
             xml-core
 
-      - name: Build source distribution
+      - name: Build source distributions
         run: |
           set -euo pipefail
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -70,14 +70,25 @@ jobs:
           make distcheck
           make dist-bzip2
           mkdir -p "$RUNNER_TEMP/release-artifacts"
-          mv ddccontrol-*.tar.bz2 "$RUNNER_TEMP/release-artifacts/"
-          rm -f ddccontrol-*.tar.gz
+          dist_archive="$(printf '%s\n' ddccontrol-*.tar.bz2 | head -n 1)"
+          dist_dir="${dist_archive%.tar.bz2}"
+          cp "$dist_archive" "$RUNNER_TEMP/release-artifacts/"
+          vendor_workdir="$(mktemp -d)"
+          tar -C "$vendor_workdir" -xf "$dist_archive"
+          (
+            cd "$vendor_workdir/$dist_dir"
+            cargo vendor --locked vendor
+          )
+          tar -C "$vendor_workdir" -czf "$RUNNER_TEMP/release-artifacts/${dist_dir}-vendor.tar.gz" "$dist_dir"
+          rm -f ddccontrol-*.tar.bz2 ddccontrol-*.tar.gz
           ./scripts/format_code.sh
           find . -name "*.orig" -exec rm -v {} \;
           ./scripts/check_git_clean_after_build.sh
 
-      - name: Upload source distribution
+      - name: Upload source distributions
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.release-please.outputs.tag_name }}
-          files: ${{ runner.temp }}/release-artifacts/ddccontrol-*.tar.bz2
+          files: |
+            ${{ runner.temp }}/release-artifacts/ddccontrol-*.tar.bz2
+            ${{ runner.temp }}/release-artifacts/ddccontrol-*-vendor.tar.gz

--- a/CheckList
+++ b/CheckList
@@ -39,12 +39,14 @@ Automated by Release Please
 - Create the release tag.
 - Create the GitHub release with generated release notes.
 - Build and test the source distribution archive.
-- Upload `ddccontrol-<version>.tar.bz2` to the GitHub release.
+- Upload `ddccontrol-<version>.tar.bz2` and
+  `ddccontrol-<version>-vendor.tar.gz` to the GitHub release.
 
 Release artifacts
 -----------------
 
-- Verify that the GitHub release contains `ddccontrol-<version>.tar.bz2`.
+- Verify that the GitHub release contains `ddccontrol-<version>.tar.bz2` and
+  `ddccontrol-<version>-vendor.tar.gz`.
 - If the artifact upload failed, rerun the Release Please workflow or build and
   upload the archive manually from the release tag.
 


### PR DESCRIPTION
## Summary

- build a vendored source archive during the Release Please release-artifacts job
- upload both the normal dist tarball and `ddccontrol-<version>-vendor.tar.gz` to the GitHub release
- document the new vendor artifact in the release checklist

## Why

Fedora builds need the vendored Cargo sources available as a release artifact or lookaside source. Without this, package maintainers have to regenerate the vendor archive manually for each update, and it cannot be generated during `%prep` in the Fedora build.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-please.yml"); puts "yaml ok"'`
- `git diff --check`
- manually generated a vendor archive from the existing 3.1.2 dist tarball with `cargo vendor --locked vendor`
