### PR TITLE
ci: rebuild website after ddccontrol releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -92,3 +92,26 @@ jobs:
           files: |
             ${{ runner.temp }}/release-artifacts/ddccontrol-*.tar.bz2
             ${{ runner.temp }}/release-artifacts/ddccontrol-*-vendor.tar.gz
+
+  notify-website:
+    needs: [release-please, release-artifacts]
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    env:
+      WEBSITE_DISPATCH_TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
+    steps:
+      - name: Trigger website rebuild
+        if: ${{ env.WEBSITE_DISPATCH_TOKEN != '' }}
+        env:
+          GH_TOKEN: ${{ env.WEBSITE_DISPATCH_TOKEN }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          gh api --method POST repos/ddccontrol/ddccontrol.github.io/dispatches \
+            --field event_type=ddccontrol-release \
+            --field "client_payload[tag]=$TAG_NAME"
+
+      - name: Report missing website token
+        if: ${{ env.WEBSITE_DISPATCH_TOKEN == '' }}
+        run: echo "WEBSITE_DISPATCH_TOKEN is not configured; the scheduled website build will pick up this release."


### PR DESCRIPTION
## Summary

- add a post-release job that dispatches `ddccontrol-release` to `ddccontrol/ddccontrol.github.io`
- include the released tag in the dispatch payload
- skip the dispatch cleanly when `WEBSITE_DISPATCH_TOKEN` is not configured

## Why

Publishing a DDCcontrol release currently does not notify the project website. Without this signal, the website can only discover the release through its scheduled fallback build.

## Impact

Once `WEBSITE_DISPATCH_TOKEN` is configured, a successful release artifact build triggers an immediate website rebuild. Release publishing still succeeds when the token is absent.

## Validation

- branched from the current `origin/master`
- confirmed the GitHub diff contains only `.github/workflows/release-please.yml`
- ran `actionlint` and `git diff --check`

## Configuration

Add a repository secret named `WEBSITE_DISPATCH_TOKEN` with permission to dispatch workflows in `ddccontrol/ddccontrol.github.io`.
