### PR TITLE
fix: trust successful DDC/CI capability reads

### DIFF
--- a/src/lib/ddcci.c
+++ b/src/lib/ddcci.c
@@ -191,8 +191,8 @@ static int i2c_write(struct monitor* mon, unsigned int addr, unsigned char *buf,
 	}
 }
 
-/* read at most len bytes from i2c address addr, to buf */
-/* return -1 on failure */
+/* read len bytes from i2c address addr into buf */
+/* return len on success, -1 on failure */
 static int i2c_read(struct monitor* mon, unsigned int addr, unsigned char *buf, unsigned char len)
 {
 	switch (mon->type) {
@@ -201,7 +201,7 @@ static int i2c_read(struct monitor* mon, unsigned int addr, unsigned char *buf, 
 	{
 		struct i2c_rdwr_ioctl_data msg_rdwr;
 		struct i2c_msg             i2cmsg;
-		int i;
+		int i, read_len;
 	
 		memset(&msg_rdwr, 0, sizeof(msg_rdwr));
 		memset(&i2cmsg, 0, sizeof(i2cmsg));
@@ -217,7 +217,9 @@ static int i2c_read(struct monitor* mon, unsigned int addr, unsigned char *buf, 
 		i2cmsg.len   = len;
 		i2cmsg.buf   = buf;
 	
-		if ((i = ioctl(mon->fd, I2C_RDWR, &msg_rdwr)) < 0)
+		i = ioctl(mon->fd, I2C_RDWR, &msg_rdwr);
+		read_len = ddcci_i2c_read_length(i, len);
+		if (read_len < 0)
 		{
 			if (!mon->probing || verbosity) {
 				perror("ioctl()");
@@ -227,14 +229,10 @@ static int i2c_read(struct monitor* mon, unsigned int addr, unsigned char *buf, 
 		}
 
 		if (verbosity > 1) {
-			dumphex(stderr, "Recv", buf, i);
+			dumphex(stderr, "Recv", buf, read_len);
 		}
 
-#ifdef __FreeBSD__
-		i = len; // FreeBSD ioctl() returns 0
-#endif
-
-		return i;
+		return read_len;
 	}
 #endif
 	default:
@@ -697,6 +695,8 @@ int ddcci_read_edid(struct monitor* mon, int addr)
 */
 static int ddcci_open_with_addr(struct monitor* mon, const char* filename, int addr, int edid, int probing) 
 {
+	int caps_result;
+
 	memset(mon, 0, sizeof(struct monitor));
 	
 	mon->probing = probing;
@@ -720,7 +720,7 @@ static int ddcci_open_with_addr(struct monitor* mon, const char* filename, int a
 		return -2;
 	}
 	
-	ddcci_caps(mon);
+	caps_result = ddcci_caps(mon);
 	mon->db = ddcci_create_db(mon->pnpid, &mon->caps, 1);
 	mon->fallback = 0; /* No fallback */
 	
@@ -756,7 +756,7 @@ static int ddcci_open_with_addr(struct monitor* mon, const char* filename, int a
 			return -1;
 		}
 	}
-	else {
+	else if (!ddcci_caps_prove_support(caps_result)) {
 		if (ddcci_command(mon, DDCCI_COMMAND_PRESENCE) < 0) {
 			return -1;
 		}

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -51,7 +51,11 @@ static inline int ddcci_caps_prove_support(int caps_result)
  * single-message buffer. */
 static inline int ddcci_i2c_read_length(int ioctl_result, unsigned char requested_len)
 {
-	return ioctl_result < 0 ? -1 : requested_len;
+#ifdef __FreeBSD__
+	return ioctl_result == 0 ? requested_len : -1;
+#else
+	return ioctl_result == 1 ? requested_len : -1;
+#endif
 }
 
 #endif //DDCCI_INTERNAL_H

--- a/src/lib/internal.h
+++ b/src/lib/internal.h
@@ -39,4 +39,19 @@ struct monitor_vtable {
 	int (*close)(struct monitor* mon);
 };
 
+/* A complete, parsed capabilities exchange is itself proof of DDC/CI support.
+ * The legacy presence command is only needed when that exchange fails. */
+static inline int ddcci_caps_prove_support(int caps_result)
+{
+	return caps_result >= 0;
+}
+
+/* I2C_RDWR reports completed messages on Linux and zero on FreeBSD, not the
+ * number of bytes transferred. A successful read completes the requested
+ * single-message buffer. */
+static inline int ddcci_i2c_read_length(int ioctl_result, unsigned char requested_len)
+{
+	return ioctl_result < 0 ? -1 : requested_len;
+}
+
 #endif //DDCCI_INTERNAL_H

--- a/src/lib/tests/test_parse_caps.c
+++ b/src/lib/tests/test_parse_caps.c
@@ -3,6 +3,7 @@
 */
 
 #include "../ddcci.h"
+#include "../internal.h"
 
 #include <assert.h>
 #include <stdlib.h>
@@ -24,6 +25,18 @@ static void test_valid_caps(void) {
 	memset(&caps, 0, sizeof(caps));
 	assert(ddcci_parse_caps("(vcp(10 12))", &caps, 1) == 2);
 	free_caps_entries(&caps);
+}
+
+static void test_caps_result_proves_ddcci_support(void) {
+	assert(ddcci_caps_prove_support(0));
+	assert(ddcci_caps_prove_support(1));
+	assert(!ddcci_caps_prove_support(-1));
+}
+
+static void test_i2c_read_length_uses_requested_byte_count(void) {
+	assert(ddcci_i2c_read_length(1, 67) == 67);
+	assert(ddcci_i2c_read_length(0, 128) == 128);
+	assert(ddcci_i2c_read_length(-1, 67) == -1);
 }
 
 static void test_rejects_overlong_value_token(void) {
@@ -261,6 +274,8 @@ static void test_repeated_same_control_in_single_string(void) {
 
 int main(void) {
 	test_valid_caps();
+	test_caps_result_proves_ddcci_support();
+	test_i2c_read_length_uses_requested_byte_count();
 	test_rejects_overlong_value_token();
 	test_rejects_unterminated_token();
 	test_uppercase_lcd_type();

--- a/src/lib/tests/test_parse_caps.c
+++ b/src/lib/tests/test_parse_caps.c
@@ -34,8 +34,13 @@ static void test_caps_result_proves_ddcci_support(void) {
 }
 
 static void test_i2c_read_length_uses_requested_byte_count(void) {
-	assert(ddcci_i2c_read_length(1, 67) == 67);
+#ifdef __FreeBSD__
 	assert(ddcci_i2c_read_length(0, 128) == 128);
+	assert(ddcci_i2c_read_length(1, 128) == -1);
+#else
+	assert(ddcci_i2c_read_length(1, 67) == 67);
+	assert(ddcci_i2c_read_length(0, 67) == -1);
+#endif
 	assert(ddcci_i2c_read_length(-1, 67) == -1);
 }
 


### PR DESCRIPTION
## Summary

- treat a complete, parsed capabilities exchange as proof of DDC/CI support
- use the legacy `0xF7` presence command only when capabilities cannot be read
- report the requested byte count after successful `I2C_RDWR` reads so verbose `Recv` output is no longer truncated to the first byte
- cover the capability and I2C return-value boundaries with regression tests

## Root cause

The Asus ROG Swift PG278Q returns valid MCCS capabilities and supports VCP reads and writes, but it does not advertise or accept the legacy `0xF7` presence command. `ddcci_open_with_addr()` ignored the successful capabilities result and unconditionally required `0xF7`, causing a false `DDC/CI supported: No` result after the write failed with `EIO`.

Separately, Linux `I2C_RDWR` returns the number of completed I2C messages rather than the number of bytes read. Passing that return value to `dumphex()` caused successful reads to be displayed as only `Recv: 6e`.

## Impact

Monitors that provide valid capabilities but reject `0xF7` can now be detected as supported. Older monitors that do not return capabilities retain the legacy presence check as a fallback. Samsung-specific initialization remains unchanged.

Verbose receive diagnostics now display the full requested read buffer on Linux and FreeBSD without changing DDC/CI frame parsing.

## Related issues

Fixes #309.

Monitor database follow-up: ddccontrol/ddccontrol-db#399.

## Validation

- `make -j$(nproc)`
- `make -C src/lib check`
  - 4/4 C tests passed
  - 32/32 Rust tests passed
- `./scripts/format_code.sh`
- `./scripts/check_git_clean_after_build.sh`
- `git diff --check`

Hardware verification on an Asus PG278Q is still recommended before marking the draft ready for review.
