### PR TITLE
ci: update CodeQL Action to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: c-cpp
           build-mode: manual
@@ -46,6 +46,6 @@ jobs:
           make -j$(nproc)
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:c-cpp"


### PR DESCRIPTION
## Summary

- update CodeQL initialization from v3 to v4
- update CodeQL analysis from v3 to v4

## Why

CodeQL Action v3 uses the deprecated Node.js 20 runtime and is scheduled for deprecation in December 2026. CodeQL Action v4 runs on Node.js 24 and removes the runner warnings.

## Impact

CodeQL continues to analyze the C/C++ build with the existing configuration, now using the supported Node.js runtime. There is no change to the project build or runtime behavior.

## Validation

- `actionlint -shellcheck='' .github/workflows/codeql.yml`
- `git diff --check`
- verified that no CodeQL Action v3 references remain under `.github`
