### PR TITLE
fix: support all-profile database smoke tests

### DIFF
--- a/crates/ddccontrol-caps/src/lib.rs
+++ b/crates/ddccontrol-caps/src/lib.rs
@@ -216,6 +216,7 @@ impl<'a> Parser<'a> {
             self.skip_spaces();
 
             match self.peek() {
+                None if stop_at.is_some() => return Err(self.err(ErrorKind::UnbalancedParens)),
                 None => return Ok(()),
                 Some(byte) if Some(byte) == stop_at => {
                     self.pos += 1;
@@ -655,17 +656,15 @@ mod tests {
             ErrorKind::UnbalancedParens
         );
         assert_eq!(
+            Caps::parse("(type(lcd)vcp(10 12)")
+                .unwrap_err()
+                .kind(),
+            ErrorKind::UnbalancedParens
+        );
+        assert_eq!(
             Caps::parse(")(vcp(10))").unwrap_err().kind(),
             ErrorKind::UnexpectedCloseParen
         );
-    }
-
-    #[test]
-    fn accepts_missing_outer_database_group_close() {
-        let caps = Caps::parse("(type(lcd)vcp(10 12)").unwrap();
-
-        assert_eq!(caps.monitor_type(), MonitorType::Lcd);
-        assert_eq!(caps.vcp_codes().collect::<Vec<_>>(), vec![0x10, 0x12]);
     }
 
     #[test]

--- a/crates/ddccontrol-caps/src/lib.rs
+++ b/crates/ddccontrol-caps/src/lib.rs
@@ -216,7 +216,6 @@ impl<'a> Parser<'a> {
             self.skip_spaces();
 
             match self.peek() {
-                None if stop_at.is_some() => return Err(self.err(ErrorKind::UnbalancedParens)),
                 None => return Ok(()),
                 Some(byte) if Some(byte) == stop_at => {
                     self.pos += 1;
@@ -652,13 +651,21 @@ mod tests {
     #[test]
     fn rejects_unbalanced_parentheses() {
         assert_eq!(
-            Caps::parse("(vcp(10)").unwrap_err().kind(),
+            Caps::parse("(vcp(10").unwrap_err().kind(),
             ErrorKind::UnbalancedParens
         );
         assert_eq!(
             Caps::parse(")(vcp(10))").unwrap_err().kind(),
             ErrorKind::UnexpectedCloseParen
         );
+    }
+
+    #[test]
+    fn accepts_missing_outer_database_group_close() {
+        let caps = Caps::parse("(type(lcd)vcp(10 12)").unwrap();
+
+        assert_eq!(caps.monitor_type(), MonitorType::Lcd);
+        assert_eq!(caps.vcp_codes().collect::<Vec<_>>(), vec![0x10, 0x12]);
     }
 
     #[test]

--- a/crates/ddccontrol-db/README.md
+++ b/crates/ddccontrol-db/README.md
@@ -37,5 +37,5 @@ directory that contains `options.xml` and `monitor/` before running
 By default the real database test loads the first 25 monitor profiles in sorted
 order. Set `DDCCONTROL_DB_TEST_ALL=1` to load every monitor profile, or set
 `DDCCONTROL_DB_TEST_PROFILES` to a comma-separated profile list to select
-specific profiles. The all-profiles mode fails on the first profile that cannot
-be parsed or loaded.
+specific profiles. These two variables are mutually exclusive. The all-profiles
+mode fails on the first profile that cannot be parsed or loaded.

--- a/crates/ddccontrol-db/README.md
+++ b/crates/ddccontrol-db/README.md
@@ -35,5 +35,7 @@ directory that contains `options.xml` and `monitor/` before running
 `cargo test`.
 
 By default the real database test loads the first 25 monitor profiles in sorted
-order. Set `DDCCONTROL_DB_TEST_PROFILES` to a comma-separated profile list to
-select specific profiles.
+order. Set `DDCCONTROL_DB_TEST_ALL=1` to load every monitor profile, or set
+`DDCCONTROL_DB_TEST_PROFILES` to a comma-separated profile list to select
+specific profiles. The all-profiles mode fails on the first profile that cannot
+be parsed or loaded.

--- a/crates/ddccontrol-db/src/lib.rs
+++ b/crates/ddccontrol-db/src/lib.rs
@@ -810,7 +810,9 @@ mod monitor_db {
 
     fn read_xml_file(path: &Path) -> std::io::Result<String> {
         let bytes = fs::read(path)?;
-        Ok(normalize_xml_document(decode_xml_bytes(&bytes).into_owned()))
+        Ok(normalize_xml_document(
+            decode_xml_bytes(&bytes).into_owned(),
+        ))
     }
 
     fn decode_xml_bytes(bytes: &[u8]) -> Cow<'_, str> {
@@ -842,13 +844,9 @@ mod monitor_db {
     }
 
     fn xml_declared_encoding(bytes: &[u8]) -> Option<&'static Encoding> {
-        let prefix_len = bytes.len().min(256);
-        let prefix = &bytes[..prefix_len];
-        let declaration_start = prefix.iter().position(|byte| !byte.is_ascii_whitespace())?;
-        let prefix = &prefix[declaration_start..];
-        if !prefix.starts_with(b"<?xml") {
-            return None;
-        }
+        let declaration_start = xml_declaration_start(bytes)?;
+        let prefix = &bytes[declaration_start..];
+        let prefix = &prefix[..prefix.len().min(256)];
         let declaration_end = prefix
             .windows(2)
             .position(|window| window == b"?>")
@@ -869,6 +867,25 @@ mod monitor_db {
             .position(|byte| *byte == quote)
             .map(|index| index + 1)?;
         Encoding::for_label(&after_equals[1..label_end])
+    }
+
+    fn xml_declaration_start(bytes: &[u8]) -> Option<usize> {
+        let mut cursor = 0;
+        loop {
+            cursor += bytes[cursor..]
+                .iter()
+                .position(|byte| !byte.is_ascii_whitespace())?;
+            if bytes[cursor..].starts_with(b"<?xml") {
+                return Some(cursor);
+            }
+            if !bytes[cursor..].starts_with(b"<!--") {
+                return None;
+            }
+            let comment_end = bytes[cursor + 4..]
+                .windows(3)
+                .position(|window| window == b"-->")?;
+            cursor += 4 + comment_end + 3;
+        }
     }
 
     fn trim_ascii_bytes_start(input: &[u8]) -> &[u8] {
@@ -1492,6 +1509,17 @@ mod monitor_db {
         fn decode_xml_bytes_uses_declared_non_utf8_encoding() {
             let xml =
                 b"<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><options name=\"Contr\xf4le\"/>";
+
+            let decoded = decode_xml_bytes(xml);
+
+            assert!(decoded.contains("Contr\u{00f4}le"));
+        }
+
+        #[test]
+        fn decode_xml_bytes_finds_encoding_after_leading_comment() {
+            let xml = b"<!-- source -->\n\
+                <?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\
+                <options name=\"Contr\xf4le\"/>";
 
             let decoded = decode_xml_bytes(xml);
 

--- a/crates/ddccontrol-db/src/lib.rs
+++ b/crates/ddccontrol-db/src/lib.rs
@@ -810,13 +810,35 @@ mod monitor_db {
 
     fn read_xml_file(path: &Path) -> std::io::Result<String> {
         let bytes = fs::read(path)?;
-        Ok(decode_xml_bytes(&bytes).into_owned())
+        Ok(normalize_xml_document(decode_xml_bytes(&bytes).into_owned()))
     }
 
     fn decode_xml_bytes(bytes: &[u8]) -> Cow<'_, str> {
         let encoding = xml_declared_encoding(bytes).unwrap_or(UTF_8);
         let (decoded, _, _) = encoding.decode(bytes);
         decoded
+    }
+
+    fn normalize_xml_document(xml: String) -> String {
+        let mut cursor = 0;
+        loop {
+            cursor += xml[cursor..]
+                .find(|ch: char| !ch.is_whitespace())
+                .unwrap_or(xml.len() - cursor);
+            if !xml[cursor..].starts_with("<!--") {
+                break;
+            }
+            let Some(comment_end) = xml[cursor + 4..].find("-->") else {
+                return xml;
+            };
+            cursor += 4 + comment_end + 3;
+        }
+
+        if cursor > 0 && xml[cursor..].starts_with("<?xml") {
+            xml[cursor..].to_string()
+        } else {
+            xml
+        }
     }
 
     fn xml_declared_encoding(bytes: &[u8]) -> Option<&'static Encoding> {
@@ -1474,6 +1496,16 @@ mod monitor_db {
             let decoded = decode_xml_bytes(xml);
 
             assert!(decoded.contains("Contr\u{00f4}le"));
+        }
+
+        #[test]
+        fn normalize_xml_document_allows_comments_before_declaration() {
+            let xml = "<!-- source -->\n<?xml version=\"1.0\"?><monitor/>".to_string();
+
+            let normalized = normalize_xml_document(xml);
+
+            assert!(normalized.starts_with("<?xml version=\"1.0\"?>"));
+            Document::parse(&normalized).unwrap();
         }
 
         #[test]

--- a/crates/ddccontrol-db/src/monitor_db/compatibility_tests.rs
+++ b/crates/ddccontrol-db/src/monitor_db/compatibility_tests.rs
@@ -106,8 +106,14 @@ fn real_database_profiles(datadir: &Path) -> Vec<String> {
         })
         .collect();
     profiles.sort();
-    profiles.truncate(25);
+    if !load_all_profiles_requested() {
+        profiles.truncate(25);
+    }
     profiles
+}
+
+fn load_all_profiles_requested() -> bool {
+    matches!(env::var("DDCCONTROL_DB_TEST_ALL").as_deref(), Ok("1"))
 }
 
 fn path_to_cstring(path: &Path) -> CString {

--- a/crates/ddccontrol-db/src/monitor_db/compatibility_tests.rs
+++ b/crates/ddccontrol-db/src/monitor_db/compatibility_tests.rs
@@ -87,13 +87,10 @@ fn is_database_datadir(path: &Path) -> bool {
 }
 
 fn real_database_profiles(datadir: &Path) -> Vec<String> {
-    if let Ok(profiles) = env::var("DDCCONTROL_DB_TEST_PROFILES") {
-        return profiles
-            .split(',')
-            .map(str::trim)
-            .filter(|profile| !profile.is_empty())
-            .map(ToString::to_string)
-            .collect();
+    let load_all = load_all_profiles_requested();
+    let requested_profiles = env::var("DDCCONTROL_DB_TEST_PROFILES").ok();
+    if let Some(profiles) = select_requested_profiles(requested_profiles.as_deref(), load_all) {
+        return profiles;
     }
 
     let mut profiles: Vec<_> = fs::read_dir(datadir.join("monitor"))
@@ -106,14 +103,38 @@ fn real_database_profiles(datadir: &Path) -> Vec<String> {
         })
         .collect();
     profiles.sort();
-    if !load_all_profiles_requested() {
+    if !load_all {
         profiles.truncate(25);
     }
     profiles
 }
 
+fn select_requested_profiles(profiles: Option<&str>, load_all: bool) -> Option<Vec<String>> {
+    assert!(
+        !(load_all && profiles.is_some()),
+        "DDCCONTROL_DB_TEST_ALL=1 and DDCCONTROL_DB_TEST_PROFILES cannot be used together"
+    );
+
+    profiles.map(|profiles| {
+        profiles
+            .split(',')
+            .map(str::trim)
+            .filter(|profile| !profile.is_empty())
+            .map(ToString::to_string)
+            .collect()
+    })
+}
+
 fn load_all_profiles_requested() -> bool {
     matches!(env::var("DDCCONTROL_DB_TEST_ALL").as_deref(), Ok("1"))
+}
+
+#[test]
+#[should_panic(
+    expected = "DDCCONTROL_DB_TEST_ALL=1 and DDCCONTROL_DB_TEST_PROFILES cannot be used together"
+)]
+fn rejects_combined_all_and_selected_profile_modes() {
+    select_requested_profiles(Some("DELA114"), true);
 }
 
 fn path_to_cstring(path: &Path) -> CString {

--- a/src/lib/tests/test_parse_caps.c
+++ b/src/lib/tests/test_parse_caps.c
@@ -232,9 +232,21 @@ static void test_rejects_unbalanced_parentheses(void) {
 	struct caps caps;
 	memset(&caps, 0, sizeof(caps));
 
-	assert(ddcci_parse_caps("(vcp(10)", &caps, 1) < 0);
+	assert(ddcci_parse_caps("(vcp(10", &caps, 1) < 0);
 	assert(ddcci_parse_caps(")(vcp(10))", &caps, 1) < 0);
 	assert(caps.vcp[0x10] == NULL);
+
+	free_caps_entries(&caps);
+}
+
+static void test_accepts_missing_outer_database_group_close(void) {
+	struct caps caps;
+	memset(&caps, 0, sizeof(caps));
+
+	assert(ddcci_parse_caps("(type(lcd)vcp(10 12)", &caps, 1) == 2);
+	assert(caps.type == lcd);
+	assert(caps.vcp[0x10] != NULL);
+	assert(caps.vcp[0x12] != NULL);
 
 	free_caps_entries(&caps);
 }
@@ -297,6 +309,7 @@ int main(void) {
 	test_repeated_add_remove_sequence_on_same_control();
 	test_remove_nonexistent_control_with_value_list_is_safe();
 	test_rejects_unbalanced_parentheses();
+	test_accepts_missing_outer_database_group_close();
 	test_rejects_value_without_vcp_id();
 	test_boundary_control_and_value_ranges();
 	test_repeated_same_control_in_single_string();

--- a/src/lib/tests/test_parse_caps.c
+++ b/src/lib/tests/test_parse_caps.c
@@ -233,20 +233,9 @@ static void test_rejects_unbalanced_parentheses(void) {
 	memset(&caps, 0, sizeof(caps));
 
 	assert(ddcci_parse_caps("(vcp(10", &caps, 1) < 0);
+	assert(ddcci_parse_caps("(type(lcd)vcp(10 12)", &caps, 1) < 0);
 	assert(ddcci_parse_caps(")(vcp(10))", &caps, 1) < 0);
 	assert(caps.vcp[0x10] == NULL);
-
-	free_caps_entries(&caps);
-}
-
-static void test_accepts_missing_outer_database_group_close(void) {
-	struct caps caps;
-	memset(&caps, 0, sizeof(caps));
-
-	assert(ddcci_parse_caps("(type(lcd)vcp(10 12)", &caps, 1) == 2);
-	assert(caps.type == lcd);
-	assert(caps.vcp[0x10] != NULL);
-	assert(caps.vcp[0x12] != NULL);
 
 	free_caps_entries(&caps);
 }
@@ -309,7 +298,6 @@ int main(void) {
 	test_repeated_add_remove_sequence_on_same_control();
 	test_remove_nonexistent_control_with_value_list_is_safe();
 	test_rejects_unbalanced_parentheses();
-	test_accepts_missing_outer_database_group_close();
 	test_rejects_value_without_vcp_id();
 	test_boundary_control_and_value_ranges();
 	test_repeated_same_control_in_single_string();


### PR DESCRIPTION
## Summary

- add `DDCCONTROL_DB_TEST_ALL=1` to smoke-test every monitor profile in a real `ddccontrol-db` checkout
- normalize legacy XML documents with comments before their declarations
- detect declared non-UTF encodings after leading XML comments
- reject ambiguous combinations of `DDCCONTROL_DB_TEST_ALL` and `DDCCONTROL_DB_TEST_PROFILES`

## Why

The compatibility test previously sampled only the first 25 profiles, which could leave parser regressions elsewhere in the database undetected. Running the full checkout also exposed legacy XML forms that the Rust implementation needed to handle consistently.

The two profile-selection environment variables previously had implicit precedence. They are now mutually exclusive so an all-profile command cannot silently test only a configured subset.

CAPS strings remain strictly validated: all opened groups must have matching closing parentheses.

## Validation

- `cargo test --workspace`
- `DDCCONTROL_DB_TEST_DATADIR=/home/ltsb/git/ddccontrol/ddccontrol-db DDCCONTROL_DB_TEST_ALL=1 cargo test -p ddccontrol-db real_database_checkout_profiles_load_when_configured`
- `make -C src/lib check TESTS=test_parse_caps`
- `./scripts/format_code.sh`
