### PR TITLE
ci: test full database on release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,9 @@ name: Release Please
 on:
   push:
     branches: [master]
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
 permissions:
@@ -16,6 +19,7 @@ concurrency:
 
 jobs:
   release-please:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -26,6 +30,30 @@ jobs:
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
+
+  full-database-check:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      startsWith(github.head_ref, 'release-please--') &&
+      contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check out monitor database
+        uses: actions/checkout@v6
+        with:
+          repository: ddccontrol/ddccontrol-db
+          path: ddccontrol-db-checkout
+
+      - name: Test all monitor profiles
+        env:
+          DDCCONTROL_DB_TEST_DATADIR: ${{ github.workspace }}/ddccontrol-db-checkout/db
+          DDCCONTROL_DB_TEST_ALL: "1"
+        run: cargo test --workspace
 
   release-artifacts:
     needs: release-please


### PR DESCRIPTION
## Summary

- trigger the Release Please workflow for pull request activity
- add a full monitor database compatibility job for Release Please PRs
- check out the latest `ddccontrol/ddccontrol-db` and test every monitor profile
- skip the Release Please action itself for pull request events

## Why

The real-database compatibility test is opt-in through environment variables, so normal CI does not continuously verify every monitor profile. Release Please PRs are the final integration point before publishing and provide a focused place to run the more expensive full-database check.

The job is restricted to PRs created by `github-actions[bot]` with an `autorelease: pending` label and a `release-please--` head branch. Normal pull requests therefore skip the job.

## Impact

A release PR will fail before merge if the current ddccontrol code cannot load every profile from the latest monitor database checkout. Normal builds and pull requests keep their existing test workload.

## Validation

- `actionlint .github/workflows/release-please.yml`
- `DDCCONTROL_DB_TEST_DATADIR=<ddccontrol-db-checkout>/db DDCCONTROL_DB_TEST_ALL=1 cargo test --workspace`
- `./scripts/format_code.sh`
- `./scripts/check_git_clean_after_build.sh`
