### PR TITLE
feat: port EDID parser to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,10 +17,15 @@ name = "ddccontrol-db"
 version = "0.1.0"
 dependencies = [
  "ddccontrol-caps",
+ "ddccontrol-edid",
  "encoding_rs",
  "libc",
  "roxmltree",
 ]
+
+[[package]]
+name = "ddccontrol-edid"
+version = "0.1.0"
 
 [[package]]
 name = "encoding_rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "crates/ddccontrol-caps",
     "crates/ddccontrol-db",
+    "crates/ddccontrol-edid",
 ]
 resolver = "2"
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,10 @@ EXTRA_DIST = config.rpath intltool-extract.in intltool-merge.in intltool-update.
 	crates/ddccontrol-caps/fixtures/fallback_crt.caps \
 	crates/ddccontrol-caps/fixtures/nested_values.caps \
 	crates/ddccontrol-caps/src/lib.rs \
+	crates/ddccontrol-edid/Cargo.toml \
+	crates/ddccontrol-edid/README.md \
+	crates/ddccontrol-edid/src/lib.rs \
+	crates/ddccontrol-edid/tests/parser.rs \
 	crates/ddccontrol-db/Cargo.toml \
 	crates/ddccontrol-db/README.md \
 	crates/ddccontrol-db/fixtures/compat-db/options.xml \

--- a/crates/ddccontrol-db/Cargo.toml
+++ b/crates/ddccontrol-db/Cargo.toml
@@ -14,6 +14,7 @@ gettext = []
 
 [dependencies]
 ddccontrol-caps = { path = "../ddccontrol-caps" }
+ddccontrol-edid = { path = "../ddccontrol-edid" }
 encoding_rs = "0.8"
 libc = "0.2"
 roxmltree = "0.20"

--- a/crates/ddccontrol-db/README.md
+++ b/crates/ddccontrol-db/README.md
@@ -3,7 +3,9 @@
 `ddccontrol-db` parses the ddccontrol XML monitor database and exports the C ABI
 used by `libddccontrol`.
 
-CAPS string parsing lives in the sibling `ddccontrol-caps` crate.
+CAPS string parsing lives in the sibling `ddccontrol-caps` crate. EDID parsing
+lives in `ddccontrol-edid`; this crate includes both parsers in the existing
+Rust static library and exposes their C ABI entry points.
 
 ## C ABI Ownership
 
@@ -15,6 +17,8 @@ The C side must release that data with the matching ddccontrol free functions:
 
 - VCP entries created by `ddccontrol_caps_parse` are owned by the caller's
   `struct caps` and are released by the existing C caps cleanup paths.
+- `ddccontrol_edid_parse` writes into caller-owned fixed-size storage and does
+  not allocate or transfer ownership across the ABI.
 - Monitor databases returned by `ddcci_create_db` must be released with
   `ddcci_free_db`.
 
@@ -23,8 +27,8 @@ internal pointers to C. Do not release Rust-created database structs with
 anything other than the documented C cleanup function.
 
 The Rust mirror structs are `#[repr(C)]`. Keep the Rust layout tests and the C
-`test_abi_layout` test in sync with `src/lib/ddcci.h`, `src/lib/monitor_db.h`,
-and `src/lib/monitor_db_internal.h`.
+`test_abi_layout` test in sync with `src/lib/ddcci.h`, `src/lib/rust_ffi.h`,
+`src/lib/monitor_db.h`, and `src/lib/monitor_db_internal.h`.
 
 ## Compatibility Tests
 

--- a/crates/ddccontrol-db/src/lib.rs
+++ b/crates/ddccontrol-db/src/lib.rs
@@ -1,5 +1,6 @@
 use ddccontrol_caps::{Caps, MonitorType, VcpEntry};
-use libc::{c_char, c_int, c_ushort, c_void, free, malloc};
+use ddccontrol_edid::Edid;
+use libc::{c_char, c_int, c_uchar, c_uint, c_ushort, c_void, free, malloc, size_t};
 use std::ffi::CStr;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::ptr;
@@ -16,6 +17,105 @@ pub struct CCaps {
     vcp: [*mut CVcpEntry; 256],
     monitor_type: c_int,
     raw_caps: *mut c_char,
+}
+
+const EDID_BLOCK_LEN: usize = ddccontrol_edid::EDID_BLOCK_LEN;
+const EDID_TEXT_LEN: usize = 14;
+
+#[repr(C)]
+pub struct CEdidInfo {
+    serial_number: c_uint,
+    manufacture_week: c_int,
+    manufacture_year: c_int,
+    version: c_int,
+    revision: c_int,
+    max_width_cm: c_int,
+    max_height_cm: c_int,
+    monitor_name: [c_char; EDID_TEXT_LEN],
+    serial_ascii: [c_char; EDID_TEXT_LEN],
+}
+
+#[repr(C)]
+pub struct CEdidResult {
+    pnpid: [c_char; 8],
+    digital: c_uchar,
+    edid: [c_uchar; EDID_BLOCK_LEN],
+    edid_len: c_int,
+    info: CEdidInfo,
+}
+
+#[no_mangle]
+/// Parse EDID bytes into a C-compatible result without transferring ownership.
+///
+/// # Safety
+///
+/// `buf` must point to at least `min(len, 128)` readable bytes and `result` must
+/// point to writable storage for one `CEdidResult`. Both pointers must remain
+/// valid for the duration of the call.
+pub unsafe extern "C" fn ddccontrol_edid_parse(
+    buf: *const c_uchar,
+    len: size_t,
+    result: *mut CEdidResult,
+) -> c_int {
+    catch_unwind(AssertUnwindSafe(|| {
+        ddccontrol_edid_parse_inner(buf, len, result)
+    }))
+    .unwrap_or(-1)
+}
+
+unsafe fn ddccontrol_edid_parse_inner(
+    buf: *const c_uchar,
+    len: size_t,
+    result: *mut CEdidResult,
+) -> c_int {
+    if buf.is_null() || result.is_null() {
+        return -1;
+    }
+
+    let parse_len = len.min(EDID_BLOCK_LEN);
+    let parsed = match ddccontrol_edid::parse(slice::from_raw_parts(buf, parse_len)) {
+        Ok(parsed) => parsed,
+        Err(_) => return -1,
+    };
+    ptr::write(result, edid_to_c(&parsed));
+    0
+}
+
+fn edid_to_c(parsed: &Edid) -> CEdidResult {
+    let mut pnpid = [0; 8];
+    for (output, input) in pnpid.iter_mut().zip(parsed.pnp_id().bytes()) {
+        *output = input as c_char;
+    }
+
+    let mut edid = [0; EDID_BLOCK_LEN];
+    edid[..parsed.raw().len()].copy_from_slice(parsed.raw());
+    let info = parsed.info();
+
+    CEdidResult {
+        pnpid,
+        digital: if parsed.is_digital_input() { 0x80 } else { 0 },
+        edid,
+        edid_len: parsed.raw().len() as c_int,
+        info: CEdidInfo {
+            serial_number: info.serial_number,
+            manufacture_week: c_int::from(info.manufacture_week),
+            manufacture_year: c_int::from(info.manufacture_year),
+            version: c_int::from(info.version),
+            revision: c_int::from(info.revision),
+            max_width_cm: c_int::from(info.max_width_cm),
+            max_height_cm: c_int::from(info.max_height_cm),
+            monitor_name: text_to_c(&info.monitor_name),
+            serial_ascii: text_to_c(&info.serial_ascii),
+        },
+    }
+}
+
+fn text_to_c(text: &str) -> [c_char; EDID_TEXT_LEN] {
+    let mut output = [0; EDID_TEXT_LEN];
+    for (destination, source) in output.iter_mut().zip(text.bytes()) {
+        *destination = source as c_char;
+    }
+    output
 }
 
 #[cfg(test)]
@@ -191,6 +291,30 @@ mod abi_tests {
                 align_of::<*mut c_char>()
             )
         );
+    }
+
+    #[test]
+    fn edid_ffi_layout_matches_c_abi_contract() {
+        assert_eq!(size_of::<c_char>(), 1);
+        assert_eq!(size_of::<c_uchar>(), 1);
+        assert_eq!(size_of::<c_int>(), 4);
+        assert_eq!(size_of::<c_uint>(), 4);
+
+        assert_eq!(field_offset!(CEdidInfo, serial_number), 0);
+        assert_eq!(field_offset!(CEdidInfo, manufacture_week), 4);
+        assert_eq!(field_offset!(CEdidInfo, manufacture_year), 8);
+        assert_eq!(field_offset!(CEdidInfo, version), 12);
+        assert_eq!(field_offset!(CEdidInfo, revision), 16);
+        assert_eq!(field_offset!(CEdidInfo, max_width_cm), 20);
+        assert_eq!(field_offset!(CEdidInfo, max_height_cm), 24);
+        assert_eq!(field_offset!(CEdidInfo, monitor_name), 28);
+        assert_eq!(field_offset!(CEdidInfo, serial_ascii), 42);
+
+        assert_eq!(field_offset!(CEdidResult, pnpid), 0);
+        assert_eq!(field_offset!(CEdidResult, digital), 8);
+        assert_eq!(field_offset!(CEdidResult, edid), 9);
+        assert_eq!(field_offset!(CEdidResult, edid_len), 140);
+        assert_eq!(field_offset!(CEdidResult, info), 144);
     }
 }
 

--- a/crates/ddccontrol-edid/Cargo.toml
+++ b/crates/ddccontrol-edid/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "ddccontrol-edid"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "EDID base-block parser for ddccontrol"
+
+[lib]
+crate-type = ["rlib"]

--- a/crates/ddccontrol-edid/README.md
+++ b/crates/ddccontrol-edid/README.md
@@ -1,0 +1,18 @@
+# ddccontrol-edid
+
+`ddccontrol-edid` parses the EDID fields used by ddccontrol without performing
+hardware I/O. It preserves the behavior of the historical
+`ddcci_parse_edid_buf()` implementation, including support for a partial base
+block containing the first 23 bytes.
+
+The parser extracts:
+
+- the seven-character PNP ID;
+- the digital/analog input flag;
+- the numeric serial number and manufacture date;
+- the EDID version and physical dimensions;
+- monitor-name and ASCII-serial descriptors from complete base blocks; and
+- at most the first 128 bytes of the base block.
+
+For compatibility, the parser validates the EDID header but not the base-block
+checksum. I2C access and user-visible diagnostics remain in the C library.

--- a/crates/ddccontrol-edid/src/lib.rs
+++ b/crates/ddccontrol-edid/src/lib.rs
@@ -1,0 +1,160 @@
+// Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
+
+use std::fmt;
+
+pub const EDID_BLOCK_LEN: usize = 128;
+pub const EDID_MIN_PARSE_LEN: usize = 0x17;
+
+const EDID_HEADER: [u8; 8] = [0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00];
+const DESCRIPTOR_START: usize = 0x36;
+const DESCRIPTOR_LEN: usize = 18;
+const DESCRIPTOR_TEXT_LEN: usize = 13;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Edid {
+    pnp_id: String,
+    digital_input: bool,
+    raw: Vec<u8>,
+    info: EdidInfo,
+}
+
+impl Edid {
+    pub fn pnp_id(&self) -> &str {
+        &self.pnp_id
+    }
+
+    pub fn is_digital_input(&self) -> bool {
+        self.digital_input
+    }
+
+    pub fn raw(&self) -> &[u8] {
+        &self.raw
+    }
+
+    pub fn info(&self) -> &EdidInfo {
+        &self.info
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EdidInfo {
+    pub serial_number: u32,
+    pub manufacture_week: u8,
+    pub manufacture_year: u16,
+    pub version: u8,
+    pub revision: u8,
+    pub max_width_cm: u8,
+    pub max_height_cm: u8,
+    pub monitor_name: String,
+    pub serial_ascii: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ParseError {
+    TooShort { actual: usize },
+    InvalidHeader,
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TooShort { actual } => write!(
+                formatter,
+                "EDID buffer is {actual} bytes; at least {EDID_MIN_PARSE_LEN} are required"
+            ),
+            Self::InvalidHeader => formatter.write_str("invalid EDID header"),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+/// Parse the fields used by ddccontrol from an EDID base block.
+///
+/// The historical C API accepts a partial block once all fields through the
+/// maximum-image-size bytes are present. Descriptor text is therefore parsed
+/// only when a complete 128-byte base block is available. The checksum is not
+/// validated in order to retain compatibility with monitors accepted by the C
+/// implementation.
+pub fn parse(input: &[u8]) -> Result<Edid, ParseError> {
+    if input.len() < EDID_MIN_PARSE_LEN {
+        return Err(ParseError::TooShort {
+            actual: input.len(),
+        });
+    }
+    if input[..EDID_HEADER.len()] != EDID_HEADER {
+        return Err(ParseError::InvalidHeader);
+    }
+
+    let manufacturer = [
+        ((input[8] >> 2) & 0x1f) + b'A' - 1,
+        ((input[8] & 0x03) << 3) + (input[9] >> 5) + b'A' - 1,
+        (input[9] & 0x1f) + b'A' - 1,
+    ];
+    let product_code = u16::from_le_bytes([input[10], input[11]]);
+    let mut pnp_id = String::with_capacity(7);
+    pnp_id.extend(manufacturer.into_iter().map(char::from));
+    use std::fmt::Write;
+    write!(&mut pnp_id, "{product_code:04X}").expect("writing to a String cannot fail");
+
+    let mut info = EdidInfo {
+        serial_number: u32::from_le_bytes([input[0x0c], input[0x0d], input[0x0e], input[0x0f]]),
+        manufacture_week: input[0x10],
+        manufacture_year: u16::from(input[0x11]) + 1990,
+        version: input[0x12],
+        revision: input[0x13],
+        max_width_cm: input[0x15],
+        max_height_cm: input[0x16],
+        monitor_name: String::new(),
+        serial_ascii: String::new(),
+    };
+
+    if input.len() >= EDID_BLOCK_LEN {
+        parse_descriptors(input, &mut info);
+    }
+
+    Ok(Edid {
+        pnp_id,
+        digital_input: input[0x14] & 0x80 != 0,
+        raw: input[..input.len().min(EDID_BLOCK_LEN)].to_vec(),
+        info,
+    })
+}
+
+fn parse_descriptors(input: &[u8], info: &mut EdidInfo) {
+    for descriptor in 0..4 {
+        let start = DESCRIPTOR_START + descriptor * DESCRIPTOR_LEN;
+        let descriptor = &input[start..start + DESCRIPTOR_LEN];
+
+        if descriptor[0] != 0 || descriptor[1] != 0 || descriptor[2] != 0 || descriptor[4] != 0 {
+            continue;
+        }
+
+        match descriptor[3] {
+            0xfc => info.monitor_name = parse_descriptor_text(&descriptor[5..]),
+            0xff => info.serial_ascii = parse_descriptor_text(&descriptor[5..]),
+            _ => {}
+        }
+    }
+}
+
+fn parse_descriptor_text(input: &[u8]) -> String {
+    let mut text = Vec::with_capacity(DESCRIPTOR_TEXT_LEN);
+
+    for &byte in input.iter().take(DESCRIPTOR_TEXT_LEN) {
+        if byte == b'\n' || byte == b'\r' {
+            break;
+        }
+        text.push(if (b' '..=b'~').contains(&byte) {
+            byte
+        } else {
+            b' '
+        });
+    }
+
+    while text.last() == Some(&b' ') {
+        text.pop();
+    }
+
+    String::from_utf8(text).expect("descriptor normalization only emits ASCII")
+}

--- a/crates/ddccontrol-edid/tests/parser.rs
+++ b/crates/ddccontrol-edid/tests/parser.rs
@@ -1,0 +1,113 @@
+// Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
+
+use ddccontrol_edid::{parse, ParseError, EDID_BLOCK_LEN, EDID_MIN_PARSE_LEN};
+
+const EDID_HEADER: [u8; 8] = [0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00];
+const DESCRIPTOR_START: usize = 0x36;
+const DESCRIPTOR_LEN: usize = 18;
+const DESCRIPTOR_TEXT_LEN: usize = 13;
+
+fn make_edid() -> [u8; EDID_BLOCK_LEN] {
+    let mut edid = [0; EDID_BLOCK_LEN];
+    edid[..EDID_HEADER.len()].copy_from_slice(&EDID_HEADER);
+    edid[8] = 0x4c;
+    edid[9] = 0x2d;
+    edid
+}
+
+fn set_descriptor(edid: &mut [u8; EDID_BLOCK_LEN], index: usize, kind: u8, text: &[u8]) {
+    let start = DESCRIPTOR_START + index * DESCRIPTOR_LEN;
+    edid[start..start + DESCRIPTOR_LEN].fill(0);
+    edid[start + 3] = kind;
+    let text_len = text.len().min(DESCRIPTOR_TEXT_LEN);
+    edid[start + 5..start + 5 + text_len].copy_from_slice(&text[..text_len]);
+    if text_len < DESCRIPTOR_TEXT_LEN {
+        edid[start + 5 + text_len] = b'\n';
+    }
+}
+
+#[test]
+fn parses_legacy_fields_and_little_endian_numbers() {
+    let mut input = make_edid();
+    input[10] = 0x34;
+    input[11] = 0x12;
+    input[0x0c..=0x0f].copy_from_slice(&[0x78, 0x56, 0x34, 0x12]);
+    input[0x10] = 22;
+    input[0x11] = 30;
+    input[0x12] = 1;
+    input[0x13] = 4;
+    input[0x14] = 0xff;
+    input[0x15] = 60;
+    input[0x16] = 34;
+
+    let parsed = parse(&input).unwrap();
+    assert_eq!(parsed.pnp_id(), "SAM1234");
+    assert!(parsed.is_digital_input());
+    assert_eq!(parsed.raw(), input);
+    assert_eq!(parsed.info().serial_number, 0x1234_5678);
+    assert_eq!(parsed.info().manufacture_week, 22);
+    assert_eq!(parsed.info().manufacture_year, 2020);
+    assert_eq!(parsed.info().version, 1);
+    assert_eq!(parsed.info().revision, 4);
+    assert_eq!(parsed.info().max_width_cm, 60);
+    assert_eq!(parsed.info().max_height_cm, 34);
+}
+
+#[test]
+fn accepts_and_preserves_the_minimum_partial_block() {
+    let input = make_edid();
+    let parsed = parse(&input[..EDID_MIN_PARSE_LEN]).unwrap();
+
+    assert_eq!(parsed.raw(), &input[..EDID_MIN_PARSE_LEN]);
+    assert!(parsed.info().monitor_name.is_empty());
+    assert!(parsed.info().serial_ascii.is_empty());
+}
+
+#[test]
+fn rejects_short_buffers_and_invalid_headers() {
+    let mut input = make_edid();
+    assert_eq!(
+        parse(&input[..EDID_MIN_PARSE_LEN - 1]),
+        Err(ParseError::TooShort {
+            actual: EDID_MIN_PARSE_LEN - 1
+        })
+    );
+
+    input[4] = 0;
+    assert_eq!(parse(&input), Err(ParseError::InvalidHeader));
+}
+
+#[test]
+fn parses_and_normalizes_descriptor_text() {
+    let mut input = make_edid();
+    set_descriptor(&mut input, 0, 0xfc, b"Panel\x01 27   ");
+    set_descriptor(&mut input, 1, 0xff, b"ABC123\rignored");
+
+    let parsed = parse(&input).unwrap();
+    assert_eq!(parsed.info().monitor_name, "Panel  27");
+    assert_eq!(parsed.info().serial_ascii, "ABC123");
+}
+
+#[test]
+fn ignores_non_text_descriptors_and_uses_the_last_matching_one() {
+    let mut input = make_edid();
+    set_descriptor(&mut input, 0, 0xfc, b"First");
+    set_descriptor(&mut input, 1, 0xfd, b"Not a name");
+    set_descriptor(&mut input, 2, 0xfc, b"Last");
+    input[DESCRIPTOR_START + 3 * DESCRIPTOR_LEN] = 1;
+    input[DESCRIPTOR_START + 3 * DESCRIPTOR_LEN + 3] = 0xff;
+
+    let parsed = parse(&input).unwrap();
+    assert_eq!(parsed.info().monitor_name, "Last");
+    assert!(parsed.info().serial_ascii.is_empty());
+}
+
+#[test]
+fn limits_the_stored_base_block_to_128_bytes() {
+    let mut input = make_edid().to_vec();
+    input.extend_from_slice(&[1, 2, 3, 4]);
+
+    let parsed = parse(&input).unwrap();
+    assert_eq!(parsed.raw().len(), EDID_BLOCK_LEN);
+    assert_eq!(parsed.raw(), &input[..EDID_BLOCK_LEN]);
+}

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -26,6 +26,9 @@ RUST_DB_DEPS = \
 	$(top_srcdir)/crates/ddccontrol-caps/fixtures/db_patch_add_remove.caps \
 	$(top_srcdir)/crates/ddccontrol-caps/fixtures/fallback_crt.caps \
 	$(top_srcdir)/crates/ddccontrol-caps/fixtures/nested_values.caps \
+	$(top_srcdir)/crates/ddccontrol-edid/Cargo.toml \
+	$(top_srcdir)/crates/ddccontrol-edid/src/lib.rs \
+	$(top_srcdir)/crates/ddccontrol-edid/tests/parser.rs \
 	$(top_srcdir)/crates/ddccontrol-db/Cargo.toml \
 	$(top_srcdir)/crates/ddccontrol-db/src/lib.rs
 
@@ -37,7 +40,7 @@ $(RUST_DB_LIB): $(RUST_DB_DEPS)
 	}
 	cd $(top_srcdir) && DDCONTROL_DATADIR="$(datadir)/ddccontrol-db" CARGO_TARGET_DIR=$(abs_top_builddir)/target $(CARGO) build --release -p ddccontrol-db $(RUST_GETTEXT_FEATURE)
 
-libddccontrol_la_SOURCES = ddcci.c ddcci.h monitor_db.h \
+libddccontrol_la_SOURCES = ddcci.c ddcci.h monitor_db.h rust_ffi.h \
    i2c-dev.h conf.c conf.h internal.h \
    monitor_db_internal.h
 

--- a/src/lib/ddcci.c
+++ b/src/lib/ddcci.c
@@ -41,6 +41,7 @@
 
 #include "ddcci.h"
 #include "internal.h"
+#include "rust_ffi.h"
 
 #include "conf.h"
 
@@ -555,57 +556,13 @@ int ddcci_command(struct monitor* mon, unsigned char cmd)
 	return ddcci_write(mon, _buf, sizeof(_buf));
 }
 
-static void ddcci_copy_edid_text(char *dest, size_t dest_len, const unsigned char *src, size_t src_len)
-{
-	size_t len = 0;
-
-	if (!dest || dest_len == 0)
-		return;
-
-	while (len < src_len && len + 1 < dest_len && src[len] != '\n' && src[len] != '\r') {
-		dest[len] = (src[len] >= ' ' && src[len] < 127) ? (char)src[len] : ' ';
-		len++;
-	}
-
-	while (len > 0 && dest[len - 1] == ' ')
-		len--;
-
-	dest[len] = 0;
-}
-
-static void ddcci_parse_edid_descriptors(struct monitor* mon, const unsigned char* buf, int len)
-{
-	int descriptor;
-
-	if (len < DDCCI_EDID_BLOCK_LEN)
-		return;
-
-	for (descriptor = 0; descriptor < 4; descriptor++) {
-		const unsigned char *desc = buf + 0x36 + descriptor * 18;
-
-		if (desc[0] != 0 || desc[1] != 0 || desc[2] != 0 || desc[4] != 0)
-			continue;
-
-		switch (desc[3]) {
-		case 0xfc:
-			ddcci_copy_edid_text(mon->edid_info.monitor_name, sizeof(mon->edid_info.monitor_name),
-			                     desc + 5, 13);
-			break;
-		case 0xff:
-			ddcci_copy_edid_text(mon->edid_info.serial_ascii, sizeof(mon->edid_info.serial_ascii),
-			                     desc + 5, 13);
-			break;
-		default:
-			break;
-		}
-	}
-}
-
 /* Parse an EDID buffer and fill in mon->pnpid, mon->digital, mon->edid, and mon->edid_info.
  * Requires at least DDCCI_EDID_MIN_PARSE_LEN bytes and a valid EDID header.
  * Returns 0 on success, -1 on failure. */
 int ddcci_parse_edid_buf(struct monitor* mon, const unsigned char* buf, int len)
 {
+	struct ddccontrol_edid_result parsed;
+
 	if (!mon)
 		return -1;
 
@@ -614,33 +571,14 @@ int ddcci_parse_edid_buf(struct monitor* mon, const unsigned char* buf, int len)
 	memset(mon->edid, 0, sizeof(mon->edid));
 	memset(&mon->edid_info, 0, sizeof(mon->edid_info));
 
-	if (!buf || len < DDCCI_EDID_MIN_PARSE_LEN)
+	if (!buf || len < 0 || ddccontrol_edid_parse(buf, (size_t)len, &parsed) < 0)
 		return -1;
 
-	if (buf[0] != 0 || buf[1] != 0xff || buf[2] != 0xff || buf[3] != 0xff ||
-	    buf[4] != 0xff || buf[5] != 0xff || buf[6] != 0xff || buf[7] != 0)
-		return -1;
-
-	snprintf(mon->pnpid, 8, "%c%c%c%02X%02X",
-	         ((buf[8] >> 2) & 31) + 'A' - 1,
-	         ((buf[8] & 3) << 3) + (buf[9] >> 5) + 'A' - 1,
-	         (buf[9] & 31) + 'A' - 1, buf[11], buf[10]);
-
-	mon->digital = (buf[0x14] & 0x80);
-	mon->edid_info.serial_number = (unsigned int)buf[0xc] |
-	                               ((unsigned int)buf[0xd] << 8) |
-	                               ((unsigned int)buf[0xe] << 16) |
-	                               ((unsigned int)buf[0xf] << 24);
-	mon->edid_info.manufacture_week = buf[0x10];
-	mon->edid_info.manufacture_year = buf[0x11] + 1990;
-	mon->edid_info.version = buf[0x12];
-	mon->edid_info.revision = buf[0x13];
-	mon->edid_info.max_width_cm = buf[0x15];
-	mon->edid_info.max_height_cm = buf[0x16];
-	ddcci_parse_edid_descriptors(mon, buf, len);
-
-	mon->edid_len = len >= DDCCI_EDID_BLOCK_LEN ? DDCCI_EDID_BLOCK_LEN : len;
-	memcpy(mon->edid, buf, mon->edid_len);
+	memcpy(mon->pnpid, parsed.pnpid, sizeof(mon->pnpid));
+	mon->digital = parsed.digital;
+	memcpy(mon->edid, parsed.edid, sizeof(mon->edid));
+	mon->edid_len = parsed.edid_len;
+	mon->edid_info = parsed.info;
 
 	if (!mon->probing && verbosity) {
 		printf(_("Serial number: %u\n"), mon->edid_info.serial_number);

--- a/src/lib/rust_ffi.h
+++ b/src/lib/rust_ffi.h
@@ -1,0 +1,25 @@
+/*
+    C ABI declarations for ddccontrol's Rust components
+    Copyright(c) 2004-2026 DDCcontrol authors and contributors (see AUTHORS and CONTRIBUTORS)
+*/
+
+#ifndef DDCCONTROL_RUST_FFI_H
+#define DDCCONTROL_RUST_FFI_H
+
+#include "ddcci.h"
+
+#include <stddef.h>
+
+struct ddccontrol_edid_result {
+	char pnpid[8];
+	unsigned char digital;
+	unsigned char edid[DDCCI_EDID_BLOCK_LEN];
+	int edid_len;
+	struct edid_info info;
+};
+
+/* All output storage is owned by C. Rust writes result only on success. */
+int ddccontrol_edid_parse(const unsigned char *buf, size_t len,
+	struct ddccontrol_edid_result *result);
+
+#endif /* DDCCONTROL_RUST_FFI_H */

--- a/src/lib/tests/test_abi_layout.c
+++ b/src/lib/tests/test_abi_layout.c
@@ -4,6 +4,7 @@
 
 #include "../ddcci.h"
 #include "../monitor_db_internal.h"
+#include "../rust_ffi.h"
 
 #include <stddef.h>
 
@@ -21,6 +22,21 @@ ABI_ASSERT(offsetof(struct caps, vcp) == 0);
 ABI_ASSERT(offsetof(struct value_db, id) == 0);
 ABI_ASSERT(offsetof(struct monitor_db, name) == 0);
 ABI_ASSERT(offsetof(struct value_db_private, public_value) == 0);
+ABI_ASSERT(sizeof(unsigned int) == 4);
+ABI_ASSERT(offsetof(struct edid_info, serial_number) == 0);
+ABI_ASSERT(offsetof(struct edid_info, manufacture_week) == 4);
+ABI_ASSERT(offsetof(struct edid_info, manufacture_year) == 8);
+ABI_ASSERT(offsetof(struct edid_info, version) == 12);
+ABI_ASSERT(offsetof(struct edid_info, revision) == 16);
+ABI_ASSERT(offsetof(struct edid_info, max_width_cm) == 20);
+ABI_ASSERT(offsetof(struct edid_info, max_height_cm) == 24);
+ABI_ASSERT(offsetof(struct edid_info, monitor_name) == 28);
+ABI_ASSERT(offsetof(struct edid_info, serial_ascii) == 42);
+ABI_ASSERT(offsetof(struct ddccontrol_edid_result, pnpid) == 0);
+ABI_ASSERT(offsetof(struct ddccontrol_edid_result, digital) == 8);
+ABI_ASSERT(offsetof(struct ddccontrol_edid_result, edid) == 9);
+ABI_ASSERT(offsetof(struct ddccontrol_edid_result, edid_len) == 140);
+ABI_ASSERT(offsetof(struct ddccontrol_edid_result, info) == 144);
 
 int main(void)
 {


### PR DESCRIPTION
## Summary

- add a dependency-free `ddccontrol-edid` crate for the EDID fields used by ddccontrol
- preserve the existing `ddcci_parse_edid_buf()` C API and legacy parsing behavior through a fixed-size C ABI result
- keep I2C access and user-visible diagnostics in C
- add separate Rust integration tests and C/Rust ABI layout checks
- include the new crate and tests in autotools source distributions

## Why

EDID parsing is isolated, input-driven, and hardware-independent, making it a good next step in the incremental Rust port. Moving it into a small internal crate improves memory safety and testability without changing the hardware-facing I2C backend.

The parser intentionally retains compatibility with the C implementation, including the 23-byte minimum input, little-endian product and serial fields, descriptor text normalization, and header-only validation without enforcing an EDID checksum.

## Impact

Existing C callers continue to use `ddcci_parse_edid_buf()`. The Rust/C boundary uses only `#[repr(C)]` fixed-size data with caller-owned storage, so no allocator ownership crosses the ABI. Explicit little-endian decoding remains portable to Debian architectures including big-endian `s390x`.

## Validation

- `cargo test --locked --workspace`
- `cargo clippy -p ddccontrol-edid --all-targets -- -D warnings`
- `make check`
- `make distcheck`
- `./scripts/format_code.sh`
- `./scripts/check_git_clean_after_build.sh`
